### PR TITLE
Implemented OpenAI compatible API configuration.

### DIFF
--- a/src/lib/components/story/ActionInput.svelte
+++ b/src/lib/components/story/ActionInput.svelte
@@ -816,11 +816,11 @@
     await tick();
 
     // Generate AI response with streaming
-    if (settings.hasApiKey) {
+    if (!settings.needsApiKey) {
       await generateResponse(userActionEntry.id, content);
     } else {
       log('No API key configured');
-      await story.addEntry('system', 'Please configure your OpenRouter API key in settings to enable AI generation.');
+      await story.addEntry('system', 'Please configure your API key in settings to enable AI generation.');
     }
   }
 
@@ -851,7 +851,7 @@
     ui.clearGenerationError();
 
     // Retry generation with the same user action
-    if (settings.hasApiKey) {
+    if (!settings.needsApiKey) {
       await generateResponse(userActionEntry.id, userActionEntry.content);
     }
   }
@@ -932,7 +932,7 @@
       await tick();
 
       // Regenerate
-      if (settings.hasApiKey) {
+      if (!settings.needsApiKey) {
         await generateResponse(userActionEntry.id, backup.userActionContent);
       }
     } catch (error) {

--- a/src/lib/components/wizard/SetupWizard.svelte
+++ b/src/lib/components/wizard/SetupWizard.svelte
@@ -120,7 +120,7 @@
   let openingError = $state<string | null>(null);
 
   // Check if API key is configured
-  const hasApiKey = $derived(settings.hasApiKey);
+  const needsApiKey = $derived(settings.needsApiKey);
 
   // Genre options with icons
   const genres: { id: Genre; name: string; icon: typeof Wand2; description: string }[] = [
@@ -615,7 +615,7 @@
       importedLorebook = result;
 
       // Run LLM classification if we have entries and an API key
-      if (result.entries.length > 0 && settings.hasApiKey) {
+      if (result.entries.length > 0 && settings.needsApiKey) {
         isImporting = false;
         isClassifying = true;
         classificationProgress = { current: 0, total: result.entries.length };
@@ -715,7 +715,7 @@
 
     <!-- Content -->
     <div class="flex-1 overflow-y-auto py-4 min-h-0">
-      {#if !hasApiKey}
+      {#if needsApiKey}
         <!-- API Key Warning -->
         <div class="flex flex-col items-center justify-center py-8 text-center">
           <div class="rounded-full bg-amber-500/20 p-4 mb-4">

--- a/src/lib/services/ai/actionChoices.ts
+++ b/src/lib/services/ai/actionChoices.ts
@@ -1,4 +1,4 @@
-import type { OpenRouterProvider } from './openrouter';
+import type { OpenAIProvider as OpenAIProvider } from './openrouter';
 import type { StoryEntry, Character, Location, Item, StoryBeat, Entry } from '$lib/types';
 import { settings } from '$lib/stores/settings.svelte';
 
@@ -29,9 +29,9 @@ interface WorldStateContext {
 }
 
 export class ActionChoicesService {
-  private provider: OpenRouterProvider;
+  private provider: OpenAIProvider;
 
-  constructor(provider: OpenRouterProvider) {
+  constructor(provider: OpenAIProvider) {
     this.provider = provider;
   }
 

--- a/src/lib/services/ai/agenticRetrieval.ts
+++ b/src/lib/services/ai/agenticRetrieval.ts
@@ -1,4 +1,4 @@
-import type { OpenRouterProvider } from './openrouter';
+import type { OpenAIProvider as OpenAIProvider } from './openrouter';
 import type {
   Tool,
   ToolCall,
@@ -174,10 +174,10 @@ export interface AgenticRetrievalResult {
 }
 
 export class AgenticRetrievalService {
-  private provider: OpenRouterProvider;
+  private provider: OpenAIProvider;
   private settingsOverride?: Partial<AgenticRetrievalSettings>;
 
-  constructor(provider: OpenRouterProvider, settingsOverride?: Partial<AgenticRetrievalSettings>) {
+  constructor(provider: OpenAIProvider, settingsOverride?: Partial<AgenticRetrievalSettings>) {
     this.provider = provider;
     this.settingsOverride = settingsOverride;
   }

--- a/src/lib/services/ai/classifier.ts
+++ b/src/lib/services/ai/classifier.ts
@@ -1,4 +1,4 @@
-import type { OpenRouterProvider } from './openrouter';
+import type { OpenAIProvider as OpenAIProvider } from './openrouter';
 import type { Character, Location, Item, StoryBeat } from '$lib/types';
 import { settings, type ClassifierSettings } from '$lib/stores/settings.svelte';
 
@@ -111,10 +111,10 @@ export interface ClassificationContext {
 }
 
 export class ClassifierService {
-  private provider: OpenRouterProvider;
+  private provider: OpenAIProvider;
   private settingsOverride?: Partial<ClassifierSettings>;
 
-  constructor(provider: OpenRouterProvider, settingsOverride?: Partial<ClassifierSettings>) {
+  constructor(provider: OpenAIProvider, settingsOverride?: Partial<ClassifierSettings>) {
     this.provider = provider;
     this.settingsOverride = settingsOverride;
   }

--- a/src/lib/services/ai/context.ts
+++ b/src/lib/services/ai/context.ts
@@ -9,7 +9,7 @@
  */
 
 import type { Character, Location, Item, StoryBeat, StoryEntry, Chapter } from '$lib/types';
-import type { OpenRouterProvider } from './openrouter';
+import type { OpenAIProvider as OpenAIProvider } from './openrouter';
 
 const DEBUG = true;
 
@@ -65,10 +65,10 @@ export interface ContextResult {
 }
 
 export class ContextBuilder {
-  private provider: OpenRouterProvider | null;
+  private provider: OpenAIProvider | null;
   private config: ContextConfig;
 
-  constructor(provider: OpenRouterProvider | null, config: Partial<ContextConfig> = {}) {
+  constructor(provider: OpenAIProvider | null, config: Partial<ContextConfig> = {}) {
     this.provider = provider;
     this.config = { ...DEFAULT_CONTEXT_CONFIG, ...config };
   }

--- a/src/lib/services/ai/entryRetrieval.ts
+++ b/src/lib/services/ai/entryRetrieval.ts
@@ -9,7 +9,7 @@
  */
 
 import type { Entry, EntryType, StoryEntry, Character, Location, Item } from '$lib/types';
-import type { OpenRouterProvider } from './openrouter';
+import type { OpenAIProvider as OpenAIProvider } from './openrouter';
 import { settings } from '$lib/stores/settings.svelte';
 
 /**
@@ -91,10 +91,10 @@ export interface EntryRetrievalResult {
 }
 
 export class EntryRetrievalService {
-  private provider: OpenRouterProvider | null;
+  private provider: OpenAIProvider | null;
   private config: EntryRetrievalConfig;
 
-  constructor(provider: OpenRouterProvider | null, config: Partial<EntryRetrievalConfig> = {}) {
+  constructor(provider: OpenAIProvider | null, config: Partial<EntryRetrievalConfig> = {}) {
     this.provider = provider;
     this.config = { ...DEFAULT_ENTRY_RETRIEVAL_CONFIG, ...config };
   }
@@ -726,7 +726,7 @@ export async function getRelevantEntries(
   entries: Entry[],
   userInput: string,
   recentStoryEntries: StoryEntry[],
-  provider?: OpenRouterProvider,
+  provider?: OpenAIProvider,
   liveState?: LiveWorldState,
   activationTracker?: ActivationTracker
 ): Promise<EntryRetrievalResult> {

--- a/src/lib/services/ai/index.ts
+++ b/src/lib/services/ai/index.ts
@@ -1,5 +1,5 @@
 import { settings } from '$lib/stores/settings.svelte';
-import { OpenRouterProvider } from './openrouter';
+import { OpenAIProvider as OpenAIProvider } from './openrouter';
 import { BUILTIN_TEMPLATES } from '$lib/services/templates';
 import { ClassifierService, type ClassificationResult, type ClassificationContext } from './classifier';
 import { MemoryService, type ChapterAnalysis, type ChapterSummary, type RetrievalDecision, DEFAULT_MEMORY_CONFIG } from './memory';
@@ -35,12 +35,11 @@ interface WorldState {
 
 class AIService {
   private getProvider() {
-    const apiKey = settings.apiSettings.openrouterApiKey;
-    log('Getting provider, API key configured:', !!apiKey);
-    if (!apiKey) {
+    log('Getting provider, API key configured:', !!settings.apiSettings.openaiApiKey);
+    if (settings.needsApiKey) {
       throw new Error('No API key configured');
     }
-    return new OpenRouterProvider(apiKey);
+    return new OpenAIProvider(settings.apiSettings);
   }
 
   async generateResponse(
@@ -480,7 +479,7 @@ class AIService {
       hasRetrievedContext: !!retrievedChapterContext,
     });
 
-    let provider: OpenRouterProvider | null = null;
+    let provider: OpenAIProvider | null = null;
     try {
       provider = this.getProvider();
     } catch {
@@ -532,7 +531,7 @@ class AIService {
       hasActivationTracker: !!activationTracker,
     });
 
-    let provider: OpenRouterProvider | null = null;
+    let provider: OpenAIProvider | null = null;
     try {
       provider = this.getProvider();
     } catch {

--- a/src/lib/services/ai/loreManagement.ts
+++ b/src/lib/services/ai/loreManagement.ts
@@ -1,4 +1,4 @@
-import type { OpenRouterProvider } from './openrouter';
+import type { OpenAIProvider as OpenAIProvider } from './openrouter';
 import type {
   Tool,
   ToolCall,
@@ -388,11 +388,11 @@ interface ToolExecutionContext {
 }
 
 export class LoreManagementService {
-  private provider: OpenRouterProvider;
+  private provider: OpenAIProvider;
   private changes: LoreChange[] = [];
   private settingsOverride?: Partial<LoreManagementSettings>;
 
-  constructor(provider: OpenRouterProvider, settingsOverride?: Partial<LoreManagementSettings>) {
+  constructor(provider: OpenAIProvider, settingsOverride?: Partial<LoreManagementSettings>) {
     this.provider = provider;
     this.settingsOverride = settingsOverride;
   }

--- a/src/lib/services/ai/memory.ts
+++ b/src/lib/services/ai/memory.ts
@@ -1,4 +1,4 @@
-import type { OpenRouterProvider } from './openrouter';
+import type { OpenAIProvider } from './openrouter';
 import type { Chapter, StoryEntry, MemoryConfig } from '$lib/types';
 import { settings, type MemorySettings } from '$lib/stores/settings.svelte';
 
@@ -48,10 +48,10 @@ export interface RetrievedContext {
 }
 
 export class MemoryService {
-  private provider: OpenRouterProvider;
+  private provider: OpenAIProvider;
   private settingsOverride?: Partial<MemorySettings>;
 
-  constructor(provider: OpenRouterProvider, settingsOverride?: Partial<MemorySettings>) {
+  constructor(provider: OpenAIProvider, settingsOverride?: Partial<MemorySettings>) {
     this.provider = provider;
     this.settingsOverride = settingsOverride;
   }

--- a/src/lib/services/ai/openrouter.ts
+++ b/src/lib/services/ai/openrouter.ts
@@ -1,3 +1,4 @@
+import type { APISettings } from '$lib/types';
 import type {
   AIProvider,
   GenerationRequest,
@@ -12,7 +13,7 @@ import type {
   AgenticMessage,
 } from './types';
 
-const OPENROUTER_API_URL = 'https://openrouter.ai/api/v1/chat/completions';
+export const OPENROUTER_API_URL = 'https://openrouter.ai/api/v1/' //Used as the default.
 const DEBUG = true;
 
 function log(...args: any[]) {
@@ -21,14 +22,14 @@ function log(...args: any[]) {
   }
 }
 
-export class OpenRouterProvider implements AIProvider {
+export class OpenAIProvider implements AIProvider {
   id = 'openrouter';
   name = 'OpenRouter';
 
-  private apiKey: string;
+  private settings: APISettings
 
-  constructor(apiKey: string) {
-    this.apiKey = apiKey;
+  constructor(settings: APISettings ) {
+    this.settings = settings
   }
 
   async generateResponse(request: GenerationRequest): Promise<GenerationResponse> {
@@ -56,11 +57,11 @@ export class OpenRouterProvider implements AIProvider {
 
     log('Sending request to OpenRouter...');
 
-    const response = await fetch(OPENROUTER_API_URL, {
+    const response = await fetch(new URL('chat/completions', this.settings.openaiApiURL), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${this.apiKey}`,
+        'Authorization': `Bearer ${this.settings.openaiApiKey}`,
         'HTTP-Referer': 'https://aventura.camp',
         'X-Title': 'Aventura',
       },
@@ -118,11 +119,11 @@ export class OpenRouterProvider implements AIProvider {
 
     log('Sending tool-enabled request to OpenRouter...');
 
-    const response = await fetch(OPENROUTER_API_URL, {
+    const response = await fetch(new URL('chat/completions', this.settings.openaiApiURL), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${this.apiKey}`,
+        'Authorization': `Bearer ${this.settings.openaiApiKey}`,
         'HTTP-Referer': 'https://aventura.camp',
         'X-Title': 'Aventura',
       },
@@ -219,11 +220,11 @@ export class OpenRouterProvider implements AIProvider {
       requestBody.top_p = request.topP;
     }
 
-    const response = await fetch(OPENROUTER_API_URL, {
+    const response = await fetch(new URL('chat/completions', this.settings.openaiApiURL), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${this.apiKey}`,
+        'Authorization': `Bearer ${this.settings.openaiApiKey}`,
         'HTTP-Referer': 'https://aventura.camp',
         'X-Title': 'Aventura',
       },
@@ -304,10 +305,11 @@ export class OpenRouterProvider implements AIProvider {
     try {
       log('Fetching models from OpenRouter API...');
 
-      const response = await fetch('https://openrouter.ai/api/v1/models', {
+      const response = await fetch(new URL('models', this.settings.openaiApiURL), {
         method: 'GET',
         headers: {
           'Accept': 'application/json',
+          'Authorization': `Bearer ${this.settings.openaiApiKey}`,
         },
         signal: controller.signal,
       });

--- a/src/lib/services/ai/scenario.ts
+++ b/src/lib/services/ai/scenario.ts
@@ -1,5 +1,5 @@
 import { settings } from '$lib/stores/settings.svelte';
-import { OpenRouterProvider } from './openrouter';
+import { OpenAIProvider, OPENROUTER_API_URL } from './openrouter';
 import type { Message } from './types';
 import type { StoryMode, POV, Character, Location, Item } from '$lib/types';
 
@@ -234,14 +234,12 @@ export interface GeneratedOpening {
     description: string;
   };
 }
-
 class ScenarioService {
   private getProvider() {
-    const apiKey = settings.apiSettings.openrouterApiKey;
-    if (!apiKey) {
+    if (settings.needsApiKey) {
       throw new Error('No API key configured');
     }
-    return new OpenRouterProvider(apiKey);
+    return new OpenAIProvider(settings.apiSettings);
   }
 
   /**

--- a/src/lib/services/ai/styleReviewer.ts
+++ b/src/lib/services/ai/styleReviewer.ts
@@ -1,4 +1,4 @@
-import type { OpenRouterProvider } from './openrouter';
+import type { OpenAIProvider } from './openrouter';
 import type { StoryEntry } from '$lib/types';
 import { settings } from '$lib/stores/settings.svelte';
 
@@ -32,9 +32,9 @@ export interface StyleReviewResult {
  * Runs in the background every N messages to provide writing guidance.
  */
 export class StyleReviewerService {
-  private provider: OpenRouterProvider;
+  private provider: OpenAIProvider;
 
-  constructor(provider: OpenRouterProvider) {
+  constructor(provider: OpenAIProvider) {
     this.provider = provider;
   }
 

--- a/src/lib/services/ai/suggestions.ts
+++ b/src/lib/services/ai/suggestions.ts
@@ -1,4 +1,4 @@
-import type { OpenRouterProvider } from './openrouter';
+import type { OpenAIProvider as OpenAIProvider } from './openrouter';
 import type { StoryEntry, StoryBeat, Entry } from '$lib/types';
 import { settings, type SuggestionsSettings } from '$lib/stores/settings.svelte';
 
@@ -20,10 +20,10 @@ export interface SuggestionsResult {
 }
 
 export class SuggestionsService {
-  private provider: OpenRouterProvider;
+  private provider: OpenAIProvider;
   private settingsOverride?: Partial<SuggestionsSettings>;
 
-  constructor(provider: OpenRouterProvider, settingsOverride?: Partial<SuggestionsSettings>) {
+  constructor(provider: OpenAIProvider, settingsOverride?: Partial<SuggestionsSettings>) {
     this.provider = provider;
     this.settingsOverride = settingsOverride;
   }

--- a/src/lib/services/ai/timelineFill.ts
+++ b/src/lib/services/ai/timelineFill.ts
@@ -1,4 +1,4 @@
-import type { OpenRouterProvider } from './openrouter';
+import type { OpenAIProvider as OpenAIProvider } from './openrouter';
 import type { Chapter, StoryEntry } from '$lib/types';
 import { settings } from '$lib/stores/settings.svelte';
 
@@ -75,10 +75,10 @@ export const DEFAULT_QUERY_ANSWER_PROMPT = `You answer specific questions about 
 // ===== Service Class =====
 
 export class TimelineFillService {
-  private provider: OpenRouterProvider;
+  private provider: OpenAIProvider;
   private settingsOverride?: Partial<TimelineFillSettings>;
 
-  constructor(provider: OpenRouterProvider, settingsOverride?: Partial<TimelineFillSettings>) {
+  constructor(provider: OpenAIProvider, settingsOverride?: Partial<TimelineFillSettings>) {
     this.provider = provider;
     this.settingsOverride = settingsOverride;
   }

--- a/src/lib/services/lorebookImporter.ts
+++ b/src/lib/services/lorebookImporter.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Entry, EntryType, EntryInjectionMode, EntryCreator } from '$lib/types';
-import { OpenRouterProvider } from './ai/openrouter';
+import { OpenAIProvider as OpenAIProvider } from './ai/openrouter';
 import { settings } from '$lib/stores/settings.svelte';
 
 const DEBUG = true;
@@ -187,13 +187,14 @@ export async function classifyEntriesWithLLM(
 ): Promise<ImportedEntry[]> {
   if (entries.length === 0) return entries;
 
-  const apiKey = settings.apiSettings.openrouterApiKey;
+  const apiKey = settings.apiSettings.openaiApiKey;
+  const openaiApiURL = settings.apiSettings.openaiApiURL;
   if (!apiKey) {
     log('No API key available, skipping LLM classification');
     return entries;
   }
 
-  const provider = new OpenRouterProvider(apiKey);
+  const provider = new OpenAIProvider(settings.apiSettings);
   const BATCH_SIZE = 50;
   const MAX_CONCURRENT = 5;
   const classifiedEntries = [...entries];

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -362,7 +362,8 @@ export interface UIState {
 
 // API Settings
 export interface APISettings {
-  openrouterApiKey: string | null;
+  openaiApiURL: string;
+  openaiApiKey: string | null;
   defaultModel: string;
   temperature: number;
   maxTokens: number;


### PR DESCRIPTION
<img width="770" height="663" alt="image" src="https://github.com/user-attachments/assets/c9322de9-e94d-4d39-8f5e-c68e3bf36ba1" />

This will default to OpenRouter, and migrate settings.
```typescript
// Load API settings
const apiURL = await database.getSetting('openai_api_url') ?? OPENROUTER_API_URL; //Default to OpenRouter.
const apiKey = await database.getSetting('openai_api_key') ?? await database.getSetting('openrouter_api_key'); //Migrate API key location.
```
I didn't rename `src/lib/services/ai/openrouter.ts` so this commit is easier to review.

Should I move `debounce` to a new `utils.ts`, or `import lodash`?
```typescript
// Import lodash?
// import { debounce } from 'lodash';
// If not, Where should this go?
let timeout: number|null = 0;
const debounce = (to_run: Function, time: number = 100) => {
  timeout && clearTimeout(timeout);
  timeout = setTimeout(() => {
    timeout = null;
    to_run();
  }, time);
};
```

Would you like any changes made to this PR?