### PR TITLE
fix: appimage not launching

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,7 +2,8 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    // Fix for "Failed to create GBM buffer" error on some Linux environments
+    // Workaround for "Failed to create GBM buffer" on Linux (e.g. Wayland/NVIDIA).
+    // This disables the DMA-BUF renderer, forcing a more compatible fallback.
     #[cfg(target_os = "linux")]
     std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
 


### PR DESCRIPTION
Fixes app not launching on some linux configurations, especially with wayland and potentially nvidia drivers.

This env var forces webkit to fall back to an older and more compatible renderer, technically less performant, but should not matter for aventura.