### PR TITLE
feat: add scroll-to-top button and auto-scroll toggle (#137)

### DIFF
--- a/src/lib/components/settings/tabs/interface.svelte
+++ b/src/lib/components/settings/tabs/interface.svelte
@@ -152,6 +152,32 @@
     />
   </div>
 
+  <!-- Auto Scroll Toggle -->
+  <div class="flex items-center justify-between">
+    <div>
+      <Label>Auto Scroll</Label>
+      <p class="text-muted-foreground text-xs">
+        Automatically scroll to the latest message during generation
+      </p>
+    </div>
+    <Switch
+      checked={settings.uiSettings.autoScroll}
+      onCheckedChange={(v) => settings.setAutoScroll(v)}
+    />
+  </div>
+
+  <!-- Scroll to Top Toggle -->
+  <div class="flex items-center justify-between">
+    <div>
+      <Label>Scroll to Top Button</Label>
+      <p class="text-muted-foreground text-xs">Show a button to jump to the first story entry</p>
+    </div>
+    <Switch
+      checked={settings.uiSettings.showScrollToTop}
+      onCheckedChange={(v) => settings.setShowScrollToTop(v)}
+    />
+  </div>
+
   <!-- Translation Section -->
   <div class="space-y-3">
     <div class="flex items-center gap-2">

--- a/src/lib/components/story/StoryView.svelte
+++ b/src/lib/components/story/StoryView.svelte
@@ -2,7 +2,7 @@
   import { story } from '$lib/stores/story.svelte'
   import { ui } from '$lib/stores/ui.svelte'
   import { settings } from '$lib/stores/settings.svelte'
-  import { Loader2, BookOpen, ChevronDown } from 'lucide-svelte'
+  import { Loader2, BookOpen, ChevronDown, ChevronUp } from 'lucide-svelte'
   import { fade } from 'svelte/transition'
   import StoryEntry from './StoryEntry.svelte'
   import StreamingEntry from './StreamingEntry.svelte'
@@ -79,6 +79,9 @@
     })
   }
 
+  // Track whether the user has scrolled away from the top
+  let isScrolledFromTop = $state(false)
+
   // Check if container is scrolled near bottom
   function isNearBottom(): boolean {
     if (!storyContainer) return true
@@ -88,6 +91,12 @@
       threshold
     )
   }
+
+  function isNearTop(): boolean {
+    if (!storyContainer) return true
+    return storyContainer.scrollTop < 100
+  }
+
   // Handle scroll events during streaming
   function handleScroll() {
     if (!storyContainer) return
@@ -104,6 +113,22 @@
     } else {
       if (!ui.userScrolledUp) ui.setScrollBreak(true)
     }
+
+    // Track scroll-from-top for the scroll-to-top button
+    isScrolledFromTop = !isNearTop()
+  }
+
+  function scrollToTop() {
+    // Load all entries first so the user can see the full history
+    if (displayedEntries.hiddenCount > 0) {
+      showAllEntries()
+    }
+
+    requestAnimationFrame(() => {
+      if (storyContainer) {
+        storyContainer.scrollTo({ top: 0, behavior: 'smooth' })
+      }
+    })
   }
 
   // Auto-scroll to bottom when new entries are added or streaming content changes
@@ -122,12 +147,11 @@
     prevEntryCount = currentCount
 
     // Detect if we should scroll:
-    // 1. We are NOT user-scrolled-up (pinned mode)
-    // 2. OR on user action send message/retry
+    // 1. Auto-scroll is enabled AND we are NOT user-scrolled-up (pinned mode)
+    // 2. OR on user action send message/retry (always scroll for user's own actions)
     const lastEntry = story.entries[story.entries.length - 1]
-    const shouldScroll =
-      !ui.userScrolledUp ||
-      (wasAdded && lastEntry && ['user_action', 'retry'].includes(lastEntry.type))
+    const isUserAction = wasAdded && lastEntry && ['user_action', 'retry'].includes(lastEntry.type)
+    const shouldScroll = (settings.uiSettings.autoScroll && !ui.userScrolledUp) || isUserAction
 
     if (!shouldScroll) return
 
@@ -136,7 +160,7 @@
 
   // Scroll to bottom when returning from gallery or other panels
   $effect(() => {
-    if (ui.activePanel === 'story' && storyContainer) {
+    if (settings.uiSettings.autoScroll && ui.activePanel === 'story' && storyContainer) {
       scrollToBottom()
     }
   })
@@ -228,18 +252,33 @@
       {/if}
     </div>
 
-    <!-- Scroll to bottom button -->
-    {#if ui.userScrolledUp}
+    <!-- Scroll navigation buttons -->
+    {#if ui.userScrolledUp || (settings.uiSettings.showScrollToTop && isScrolledFromTop)}
       <div class="pointer-events-none sticky bottom-2 flex w-full justify-center pb-2">
-        <Button
-          variant="secondary"
-          size="sm"
-          class="border-border bg-background/80 hover:bg-accent animate-in fade-in slide-in-from-bottom-2 pointer-events-auto h-9 w-9 rounded-full border shadow-lg backdrop-blur-sm"
-          onclick={scrollToBottom}
-          aria-label="Scroll to bottom"
-        >
-          <ChevronDown class="h-5 w-5" />
-        </Button>
+        <div class="animate-in fade-in slide-in-from-bottom-2 pointer-events-auto flex gap-2">
+          {#if settings.uiSettings.showScrollToTop && isScrolledFromTop}
+            <Button
+              variant="secondary"
+              size="sm"
+              class="border-border bg-background/80 hover:bg-accent h-9 w-9 rounded-full border shadow-lg backdrop-blur-sm"
+              onclick={scrollToTop}
+              aria-label="Scroll to top"
+            >
+              <ChevronUp class="h-5 w-5" />
+            </Button>
+          {/if}
+          {#if ui.userScrolledUp}
+            <Button
+              variant="secondary"
+              size="sm"
+              class="border-border bg-background/80 hover:bg-accent h-9 w-9 rounded-full border shadow-lg backdrop-blur-sm"
+              onclick={scrollToBottom}
+              aria-label="Scroll to bottom"
+            >
+              <ChevronDown class="h-5 w-5" />
+            </Button>
+          {/if}
+        </div>
       </div>
     {/if}
   </div>

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -1042,6 +1042,8 @@ class SettingsStore {
     disableSuggestions: false,
     disableActionPrefixes: false,
     showReasoning: true,
+    autoScroll: true,
+    showScrollToTop: false,
     sidebarWidth: 288,
   })
 
@@ -1342,6 +1344,12 @@ class SettingsStore {
 
       const showReasoning = await database.getSetting('show_reasoning')
       if (showReasoning !== null) this.uiSettings.showReasoning = showReasoning === 'true'
+
+      const autoScroll = await database.getSetting('auto_scroll')
+      if (autoScroll !== null) this.uiSettings.autoScroll = autoScroll === 'true'
+
+      const showScrollToTop = await database.getSetting('show_scroll_to_top')
+      if (showScrollToTop !== null) this.uiSettings.showScrollToTop = showScrollToTop === 'true'
 
       const debugMode = await database.getSetting('debug_mode')
       if (debugMode !== null) this.uiSettings.debugMode = debugMode === 'true'
@@ -2325,6 +2333,16 @@ class SettingsStore {
     await database.setSetting('show_reasoning', show.toString())
   }
 
+  async setAutoScroll(enabled: boolean) {
+    this.uiSettings.autoScroll = enabled
+    await database.setSetting('auto_scroll', enabled.toString())
+  }
+
+  async setShowScrollToTop(enabled: boolean) {
+    this.uiSettings.showScrollToTop = enabled
+    await database.setSetting('show_scroll_to_top', enabled.toString())
+  }
+
   async setSidebarWidth(width: number) {
     this.uiSettings.sidebarWidth = width
     await database.setSetting('sidebar_width', width.toString())
@@ -2715,6 +2733,8 @@ class SettingsStore {
       disableSuggestions: false,
       disableActionPrefixes: false,
       showReasoning: false,
+      autoScroll: true,
+      showScrollToTop: false,
       sidebarWidth: 288,
     }
 
@@ -2750,6 +2770,8 @@ class SettingsStore {
       'disable_action_prefixes',
       this.uiSettings.disableActionPrefixes.toString(),
     )
+    await database.setSetting('auto_scroll', this.uiSettings.autoScroll.toString())
+    await database.setSetting('show_scroll_to_top', this.uiSettings.showScrollToTop.toString())
     await database.setSetting(
       'advanced_manual_mode',
       this.advancedRequestSettings.manualMode.toString(),

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -730,6 +730,8 @@ export interface UISettings {
   disableSuggestions: boolean
   disableActionPrefixes: boolean
   showReasoning: boolean
+  autoScroll: boolean
+  showScrollToTop: boolean
   sidebarWidth: number
 }
 


### PR DESCRIPTION
Add two new configurable options under Settings > Interface:
- Auto Scroll (default: on) - controls auto-scroll during generation
- Scroll to Top Button (default: off) - shows button to jump to first entry

Closes #137