### PR TITLE
fix: set selectedGenre to 'custom' when user types in genre input (#127)

### DIFF
--- a/src/lib/components/wizard/SetupWizard.svelte
+++ b/src/lib/components/wizard/SetupWizard.svelte
@@ -166,10 +166,7 @@
           customGenre={wizard.narrative.customGenre}
           onSettingSeedChange={(v) => (wizard.setting.settingSeed = v)}
           onGuidanceChange={(v) => (wizard.setting.settingElaborationGuidance = v)}
-          onCustomGenreChange={(v) => {
-            wizard.narrative.customGenre = v
-            wizard.narrative.selectedGenre = 'custom'
-          }}
+          onCustomGenreChange={(v) => wizard.narrative.setCustomGenre(v)}
           onUseAsIs={() => wizard.setting.useSettingAsIs()}
           onExpandSetting={() =>
             wizard.setting.expandSetting(

--- a/src/lib/stores/wizard/narrativeStore.svelte.ts
+++ b/src/lib/stores/wizard/narrativeStore.svelte.ts
@@ -71,6 +71,12 @@ export class NarrativeStore {
     // });
   }
 
+  // Genre Actions
+  setCustomGenre(genre: string) {
+    this.customGenre = genre
+    this.selectedGenre = 'custom'
+  }
+
   // Lorebook Actions
   addLorebookFromVault(vaultLorebook: VaultLorebook) {
     const entries = vaultLorebook.entries.map((e) => ({


### PR DESCRIPTION
The genre input only updated customGenre but left selectedGenre at its default ('fantasy'), causing the custom genre to be silently ignored unless a Quick Start template was selected first.