### PR TITLE
fix: only disable DMABUF renderer on NVIDIA GPUs with Wayland

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -20,7 +20,7 @@ fn is_nvidia_wayland() -> bool {
             .unwrap_or(false);
     let is_nvidia = std::path::Path::new("/proc/driver/nvidia").exists()
         || std::fs::read_to_string("/proc/modules")
-            .map(|m| m.contains("nvidia"))
+            .map(|m| m.lines().any(|line| line.starts_with("nvidia")))
             .unwrap_or(false);
     is_wayland && is_nvidia
 }


### PR DESCRIPTION
The previous workaround unconditionally disabled WebKit's DMA-BUF renderer on all Linux systems (`WEBKIT_DISABLE_DMABUF_RENDERER=1`), which forces software compositing and causes severe performance degradation for all Linux users.

The GBM buffer issue afaik only occurs with the **NVIDIA proprietary driver under Wayland**. X11 sessions and non-NVIDIA hardware are not affected.

This PR detects both conditions at runtime before applying the workaround:
- NVIDIA driver presence via `/proc/driver/nvidia` or `/proc/modules`
- Wayland session via `WAYLAND_DISPLAY` or `XDG_SESSION_TYPE`

The env var is now only set when both are true, restoring full GPU acceleration for everyone else.

**Tested on**: AMD GPU + Wayland (Bluefin/Fedora) - previously super laggy, now smooth.
**Not tested on**: On an actual Nvidia/Wayland device.