### PR TITLE
improve classification result handling regarding location, character, item and story beat updates

### DIFF
--- a/src/lib/stores/story.svelte.ts
+++ b/src/lib/stores/story.svelte.ts
@@ -1924,9 +1924,6 @@ class StoryStore {
       }
     }
 
-    // Track which newCharacters were already created by characterUpdates
-    const createdNewCharacterNames = new SvelteSet<string>()
-
     // Apply character updates
     for (const update of result.entryUpdates.characterUpdates) {
       await this.wrapUpdate('Update character', update.name, async () => {
@@ -1966,7 +1963,6 @@ class StoryStore {
           await database.addCharacter(character)
           this.characters = [...this.characters, character]
           if (trackingEnabled) createdCharacterIds.push(character.id)
-          createdNewCharacterNames.add(update.name.toLowerCase())
           existing = character
         }
 
@@ -2025,9 +2021,6 @@ class StoryStore {
       })
     }
 
-    // Track which newLocations were already created by locationUpdates
-    const createdNewLocationNames = new SvelteSet<string>()
-
     // Apply location updates
     for (const update of result.entryUpdates.locationUpdates) {
       await this.wrapUpdate('Update location', update.name, async () => {
@@ -2066,7 +2059,6 @@ class StoryStore {
           await database.addLocation(location)
           this.locations = [...this.locations, location]
           if (trackingEnabled) createdLocationIds.push(location.id)
-          createdNewLocationNames.add(update.name.toLowerCase())
           existing = location
         }
 
@@ -2163,9 +2155,6 @@ class StoryStore {
       })
     }
 
-    // Track which newItems were already created by itemUpdates
-    const createdNewItemNames = new SvelteSet<string>()
-
     // Apply item updates
     for (const update of result.entryUpdates.itemUpdates) {
       await this.wrapUpdate('Update item', update.name, async () => {
@@ -2201,7 +2190,6 @@ class StoryStore {
           await database.addItem(item)
           this.items = [...this.items, item]
           if (trackingEnabled) createdItemIds.push(item.id)
-          createdNewItemNames.add(update.name.toLowerCase())
           existing = item
         }
 
@@ -2231,9 +2219,6 @@ class StoryStore {
         }
       })
     }
-
-    // Track which newStoryBeats were already created by storyBeatUpdates
-    const createdNewStoryBeatTitles = new SvelteSet<string>()
 
     // Apply story beat updates (mark as completed/failed)
     for (const update of result.entryUpdates.storyBeatUpdates) {
@@ -2272,7 +2257,6 @@ class StoryStore {
           await database.addStoryBeat(beat)
           this.storyBeats = [...this.storyBeats, beat]
           if (trackingEnabled) createdStoryBeatIds.push(beat.id)
-          createdNewStoryBeatTitles.add(update.title.toLowerCase())
           existing = beat
         }
 
@@ -2313,12 +2297,6 @@ class StoryStore {
     // Add new characters (check for duplicates)
     for (const newChar of result.entryUpdates.newCharacters) {
       await this.wrapUpdate('Add character', newChar.name, async () => {
-        // Skip if already created by characterUpdates handler above
-        if (createdNewCharacterNames.has(newChar.name.toLowerCase())) {
-          log('Skipping new character (already created by update):', newChar.name)
-          return
-        }
-
         const exists = this.characters.some(
           (c) => c.name.toLowerCase() === newChar.name.toLowerCase(),
         )
@@ -2426,12 +2404,6 @@ class StoryStore {
     // Add new locations (check for duplicates, merge into recently created)
     for (const newLoc of result.entryUpdates.newLocations) {
       await this.wrapUpdate('Add location', newLoc.name, async () => {
-        // Skip if already created by locationUpdates handler above
-        if (createdNewLocationNames.has(newLoc.name.toLowerCase())) {
-          log('Skipping new location (already created by update):', newLoc.name)
-          return
-        }
-
         const existing = this.locations.find(
           (l) => l.name.toLowerCase() === newLoc.name.toLowerCase(),
         )
@@ -2514,12 +2486,6 @@ class StoryStore {
     // Add new items (check for duplicates)
     for (const newItem of result.entryUpdates.newItems) {
       await this.wrapUpdate('Add item', newItem.name, async () => {
-        // Skip if already created by itemUpdates handler above
-        if (createdNewItemNames.has(newItem.name.toLowerCase())) {
-          log('Skipping new item (already created by update):', newItem.name)
-          return
-        }
-
         const exists = this.items.some((i) => i.name.toLowerCase() === newItem.name.toLowerCase())
         if (!exists) {
           log('Adding new item:', newItem.name)
@@ -2552,12 +2518,6 @@ class StoryStore {
     // Add new story beats (check for duplicates)
     for (const newBeat of result.entryUpdates.newStoryBeats) {
       await this.wrapUpdate('Add story beat', newBeat.title, async () => {
-        // Skip if already created by storyBeatUpdates handler above
-        if (createdNewStoryBeatTitles.has(newBeat.title.toLowerCase())) {
-          log('Skipping new story beat (already created by update):', newBeat.title)
-          return
-        }
-
         const exists = this.storyBeats.some(
           (b) => b.title.toLowerCase() === newBeat.title.toLowerCase(),
         )


### PR DESCRIPTION
In my testing, I noticed several issues with the Classification Engine, see #211.
LLMs seem to be creative on what they return, so I noticed:

- Setting the current scene location without creating the new location
  - => was ignored
- Updating non-existing location without having the location created first
  - => was ignored
- Updating non-existing locations with metadata and creating them in the same response
  - => a basic shell was created, the rich description in the update ignored
- I met a new character who introduced himself, classification returned character update with all details.
  - => was ignored.

I tried several cases and the current behavior **resulted in ignored updates the majority of times**.
Sometimes new locations where at least created a turn later, but this depends on luck.


## Changes Made

### Fix 1: `locationUpdates` — create location if not found + apply `description`
- When a `locationUpdate` targets a non-existent location, it now checks `newLocations` for matching data and creates the location first, then applies the update
- If not in `newLocations` either, creates a minimal location from the update name
- Tracks created names in `createdNewLocationNames` set so `newLocations` doesn't duplicate
- Now reads `update.changes.description` (replacement) in addition to `descriptionAddition` (append)

### Fix 2: `newLocations` — merge into existing instead of skipping
- Skips if already created by `locationUpdates` handler (via `createdNewLocationNames`)
- If location already exists (e.g. stub from `currentLocationName`), merges description/visited/current into it instead of silently dropping
- Original creation path unchanged for truly new locations

### Fix 3: `scene.currentLocationName` — create stub if not found
- If the location doesn't exist, creates a stub with `{ name, visited: true, current: false, description: null }`
- The existing logic then marks it as current
- `newLocations` (Fix 2) will later merge description/details into this stub if the model also outputs a `newLocation` entry

### Fix 4: `description` field in location updates
- Part of Fix 1 — `update.changes.description` is now applied as a replacement, and `descriptionAddition` appends to it

## Apply same update-before-create fix to characters, items, and story beats

Extends the location fix pattern to all entity types in [applyClassificationResult](cci:1://file:///var/home/fred/Entwicklung/Aventuras-dev/src/lib/stores/story.svelte.ts:1789:2-2756:3). The same ordering bug existed for all four entity types: update handlers run before new entity creation, so if a model outputs only an update or both an update and a new entry for the same name, the update was silently dropped.

### Changes (all in [story.svelte.ts](cci:7://file:///var/home/fred/Entwicklung/Aventuras-dev/src/lib/stores/story.svelte.ts:0:0-0:0))

**For each entity type (characters, items, story beats):**

1. **Update handlers** — if the entity doesn't exist, check the corresponding `new*` array for data and create it first, then apply the update. Track created names to avoid duplicates.

2. **New entity handlers** — skip if already created by the update handler. If the entity exists from another source, merge data into it (description, traits, visual descriptors, etc.) instead of silently skipping.

### Entity-specific details

| Entity | Update creates if missing | New merges into existing |
|--------|--------------------------|------------------------|
| **Characters** | Creates from `newCharacters` data, then applies `characterUpdate` (status, relationship, traits, visual descriptors) | Merges description, relationship, traits, visual descriptors |
| **Items** | Creates from `newItems` data, then applies `itemUpdate` (quantity, equipped, location) | Merges description, quantity, location, equipped |
| **Story Beats** | Creates from `newStoryBeats` data, then applies `storyBeatUpdate` (status, description) | Merges description, type |

## Examples

### Before: `scene.currentLocationName` for unknown location silently ignored

**Classifier output:**
```json
{
  "entryUpdates": {
    "locationUpdates": [
      {
        "name": "Starting Location",
        "changes": {
          "description": "Clara's home in Steinenbronn..."
        }
      }
    ]
  },
  "scene": {
    "currentLocationName": "Steinenbronn Village Streets",
    "timeProgression": "minutes"
  }
}
```

**Before:** "Steinenbronn Village Streets" doesn't exist in the locations list, so the `scene.currentLocationName` handler finds nothing and skips. The location switch is lost — the narrative context for the next generation still shows "Starting Location" as current.

**After:** A stub location is created (`{ name: "Steinenbronn Village Streets", visited: true, current: true, description: null }`), the previous location is unset, and the story correctly tracks the protagonist's movement. If a later classifier response adds a `newLocation` with the same name and a description, it gets merged into the stub.

---

### Before: `locationUpdate` + `newLocation` for same name — description lost

**Classifier output:**
```json
{
  "entryUpdates": {
    "locationUpdates": [
      {
        "name": "Schönbuch forest",
        "changes": {
          "description": "The path transitions from a road to a dirt track...",
          "descriptionAddition": "The forest is accessed via a narrow dirt track..."
        }
      }
    ],
    "newLocations": [
      {
        "name": "Schönbuch forest"
      }
    ]
  }
}
```

**Before:** `locationUpdates` runs first, tries to find "Schönbuch forest" — doesn't exist yet, silently skips. Then `newLocations` creates it with just `{ name: "Schönbuch forest" }` — no description. Both the `description` and `descriptionAddition` from the update are lost.

**After:** The `locationUpdates` handler sees the location doesn't exist, finds it in `newLocations`, creates it using that data, then applies the update (description + descriptionAddition) on top. The location is created with full details in a single pass.

---

### Before: `update.changes.description` (replacement) field ignored

**Classifier output:**
```json
{
  "locationUpdates": [
    {
      "name": "Starting Location",
      "changes": {
        "description": "Clara's home in Steinenbronn, equipped with silent alarm strings."
      }
    }
  ]
}
```

**Before:** The update handler only checked for `descriptionAddition` (append) and `visited`/`current`. The `description` field — defined in the schema as "Complete replacement description" — was never read. The description replacement was silently dropped.

**After:** `update.changes.description` is applied as a replacement. If both `description` and `descriptionAddition` are present, the addition is appended to the replacement.

---

👆 These examples above are all from real classifier outputs observed during my testing.

## Additional Thoughts

1. This file needs heavy refactoring and code-deduplication. But that's something for another day.

2. The schema asks the model to distinguish between "update an existing entity" and "create a new entity." But this turns out to be pretty random and models still regularly:
- Put new entities in updates
- Put the same entity in both arrays
- Set `scene.currentLocationName` to a location that doesn't exist yet

I'm not sure how useful the distinction is or if we should drop the "create a new entity" logic to make things easier for LLMs and reduce code complexity. But for now, I was focused on fixing the most pressing issues.

----

**🙏 Please review carefully and let me know if you have any concerns or if I messed up a logic which was supposed to be that way. But honestly the way it was, was pretty messed up and just didn't work as users and the classification engine expected.**