### PR TITLE
refactor: extract shared debounce utility, fix stale writes on unmount

### DIFF
--- a/src/lib/components/memory/MemorySettings.svelte
+++ b/src/lib/components/memory/MemorySettings.svelte
@@ -1,37 +1,34 @@
 <script lang="ts">
   import { story } from '$lib/stores/story.svelte'
   import { ui } from '$lib/stores/ui.svelte'
+  import { onDestroy } from 'svelte'
   import { slide } from 'svelte/transition'
+  import { createDebouncedSave } from '$lib/utils/debounce'
   import { Card, CardContent } from '$lib/components/ui/card'
   import { Slider } from '$lib/components/ui/slider'
   import { Label } from '$lib/components/ui/label'
   import { ToggleGroup, ToggleGroupItem } from '$lib/components/ui/toggle-group'
 
-  const threshold = $derived(story.memoryConfig.tokenThreshold)
-  const bufferMessages = $derived(story.memoryConfig.chapterBuffer)
+  // Local state for editing — seeded from store, written back on debounced save
+  let localThreshold = $state(story.memoryConfig.tokenThreshold)
+  let localBuffer = $state(story.memoryConfig.chapterBuffer)
 
-  // Local state for editing
-  let localThreshold = $derived(threshold)
-  let localBuffer = $derived(bufferMessages)
-
-  // Debounced save
-  let saveTimeout: ReturnType<typeof setTimeout> | null = null
+  // Single debounced save: flushes both values in one call
+  const { trigger, flush } = createDebouncedSave(() =>
+    story.updateMemoryConfig({ tokenThreshold: localThreshold, chapterBuffer: localBuffer }),
+  )
 
   function scheduleThresholdSave(value: number) {
     localThreshold = value
-    if (saveTimeout) clearTimeout(saveTimeout)
-    saveTimeout = setTimeout(() => {
-      story.updateMemoryConfig({ tokenThreshold: value })
-    }, 500)
+    trigger()
   }
 
   function scheduleBufferSave(value: number) {
     localBuffer = value
-    if (saveTimeout) clearTimeout(saveTimeout)
-    saveTimeout = setTimeout(() => {
-      story.updateMemoryConfig({ chapterBuffer: value })
-    }, 500)
+    trigger()
   }
+
+  onDestroy(() => flush())
 
   function formatNumber(num: number): string {
     return num.toLocaleString()

--- a/src/lib/components/settings/AgentProfiles.svelte
+++ b/src/lib/components/settings/AgentProfiles.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { SvelteMap } from 'svelte/reactivity'
   import { onDestroy } from 'svelte'
+  import { createDebouncedSave } from '$lib/utils/debounce'
   import { settings, DEFAULT_SERVICE_PRESET_ASSIGNMENTS } from '$lib/stores/settings.svelte'
   import type { GenerationPreset } from '$lib/types'
   import { ask } from '@tauri-apps/plugin-dialog'
@@ -229,20 +230,9 @@
   let isLoadingPresetModels = $state(false)
 
   // Auto-persist: debounced save to avoid a DB write on every slider tick
-  let saveTimer: ReturnType<typeof setTimeout> | null = null
-
-  function debouncedSave() {
-    if (saveTimer) clearTimeout(saveTimer)
-    saveTimer = setTimeout(() => settings.saveGenerationPresets(), 300)
-  }
-
-  function flushSave() {
-    if (saveTimer) {
-      clearTimeout(saveTimer)
-      saveTimer = null
-      settings.saveGenerationPresets()
-    }
-  }
+  const { trigger: debouncedSave, flush: flushSave } = createDebouncedSave(() =>
+    settings.saveGenerationPresets(),
+  )
 
   // Flush any pending save when the component is destroyed (e.g. Settings modal closed)
   onDestroy(() => flushSave())

--- a/src/lib/components/settings/MainNarrative.svelte
+++ b/src/lib/components/settings/MainNarrative.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onDestroy } from 'svelte'
+  import { createDebouncedSave } from '$lib/utils/debounce'
   import { settings } from '$lib/stores/settings.svelte'
   import { Cpu, AlertTriangle } from 'lucide-svelte'
   import { fetchModelsFromProvider } from '$lib/services/ai/sdk/providers'
@@ -21,22 +22,9 @@
   let modelError = $state<string | null>(null)
 
   // Debounced save for sliders
-  let saveTimer: ReturnType<typeof setTimeout> | null = null
-
-  function debouncedSave() {
-    if (saveTimer) clearTimeout(saveTimer)
-    saveTimer = setTimeout(() => {
-      settings.saveApiSettings()
-    }, 300)
-  }
-
-  function flushSave() {
-    if (saveTimer) {
-      clearTimeout(saveTimer)
-      saveTimer = null
-      settings.saveApiSettings()
-    }
-  }
+  const { trigger: debouncedSave, flush: flushSave } = createDebouncedSave(() =>
+    settings.saveApiSettings(),
+  )
 
   onDestroy(() => flushSave())
 

--- a/src/lib/components/settings/tabs/api-connection.svelte
+++ b/src/lib/components/settings/tabs/api-connection.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onDestroy } from 'svelte'
+  import { createDebouncedSave } from '$lib/utils/debounce'
   import { settings } from '$lib/stores/settings.svelte'
   import type { APIProfile, ProviderType, TextModel } from '$lib/types'
   import { fetchModelsFromProvider } from '$lib/services/ai/sdk/providers'
@@ -29,8 +30,9 @@
   let formFavoriteModels = $state<string[]>([])
 
   // Auto-save debounce state
-  let saveTimeout: ReturnType<typeof setTimeout> | null = null
+  let mounted = true
   let saveStatus = $state<'idle' | 'saving' | 'saved'>('idle')
+  const { trigger: triggerAutoSave, flush: flushAutoSave } = createDebouncedSave(autoSaveEdit)
 
   // UI state
   let isFetchingModels = $state(false)
@@ -39,8 +41,7 @@
 
   function startEdit(profile: APIProfile) {
     if (editingProfileId && editingProfileId !== profile.id && !isNewProfile) {
-      if (saveTimeout) clearTimeout(saveTimeout)
-      autoSaveEdit()
+      flushAutoSave()
     }
 
     editingProfileId = profile.id
@@ -177,8 +178,7 @@
       openCollapsibles = new SvelteSet(openCollapsibles)
 
       if (editingProfileId === profile.id) {
-        if (saveTimeout) clearTimeout(saveTimeout)
-        autoSaveEdit()
+        flushAutoSave()
         editingProfileId = null
       }
     }
@@ -210,18 +210,11 @@
 
     saveStatus = 'saving'
     await settings.updateProfile(profile.id, profile)
+    if (!mounted) return
     saveStatus = 'saved'
     setTimeout(() => {
-      saveStatus = 'idle'
+      if (mounted) saveStatus = 'idle'
     }, 2000)
-  }
-
-  function triggerAutoSave() {
-    if (saveTimeout) clearTimeout(saveTimeout)
-    saveTimeout = setTimeout(() => {
-      autoSaveEdit()
-      saveTimeout = null
-    }, 500)
   }
 
   $effect(() => {
@@ -241,10 +234,8 @@
   })
 
   onDestroy(() => {
-    if (saveTimeout) {
-      clearTimeout(saveTimeout)
-      saveTimeout = null
-    }
+    mounted = false
+    flushAutoSave()
   })
 
   // Fix #1: shared handler to avoid duplication between new-profile and edit forms

--- a/src/lib/components/settings/tabs/api-connection.svelte
+++ b/src/lib/components/settings/tabs/api-connection.svelte
@@ -31,7 +31,7 @@
 
   // Auto-save debounce state
   let mounted = true
-  let saveStatus = $state<'idle' | 'saving' | 'saved'>('idle')
+  let saveStatus = $state<'idle' | 'saving' | 'saved' | 'error'>('idle')
   const { trigger: triggerAutoSave, flush: flushAutoSave } = createDebouncedSave(autoSaveEdit)
 
   // UI state
@@ -209,12 +209,21 @@
     }
 
     saveStatus = 'saving'
-    await settings.updateProfile(profile.id, profile)
-    if (!mounted) return
-    saveStatus = 'saved'
-    setTimeout(() => {
-      if (mounted) saveStatus = 'idle'
-    }, 2000)
+    try {
+      await settings.updateProfile(profile.id, profile)
+      if (!mounted) return
+      saveStatus = 'saved'
+      setTimeout(() => {
+        if (mounted && saveStatus === 'saved') saveStatus = 'idle'
+      }, 2000)
+    } catch (err) {
+      console.error('Failed to save API profile', err)
+      if (!mounted) return
+      saveStatus = 'error'
+      setTimeout(() => {
+        if (mounted && saveStatus === 'error') saveStatus = 'idle'
+      }, 3000)
+    }
   }
 
   $effect(() => {
@@ -411,8 +420,10 @@
               <p class="text-muted-foreground mt-2 min-h-[1lh] text-right text-xs">
                 {#if saveStatus === 'saving'}
                   Saving...
-                {:else if saveStatus !== 'idle'}
+                {:else if saveStatus === 'saved'}
                   ✓ Saved
+                {:else if saveStatus === 'error'}
+                  <span class="text-destructive">⚠ Save failed</span>
                 {/if}
               </p>
             </div>

--- a/src/lib/components/settings/tabs/images.svelte
+++ b/src/lib/components/settings/tabs/images.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onDestroy, untrack } from 'svelte'
+  import { createDebouncedSave } from '$lib/utils/debounce'
   import { settings } from '$lib/stores/settings.svelte'
   import { Label } from '$lib/components/ui/label'
   import { Button } from '$lib/components/ui/button'
@@ -134,14 +135,9 @@
   let profileLoraStrengthModel = $state(1.0)
   let profileLoraStrengthClip = $state(1.0)
   let availableLoras = $state<string[]>([])
-  let saveTimeout: ReturnType<typeof setTimeout> | null = null
+  const { trigger: triggerAutoSave, flush: flushAutoSave } = createDebouncedSave(autoSaveProfile)
 
-  onDestroy(() => {
-    if (saveTimeout) {
-      clearTimeout(saveTimeout)
-      saveTimeout = null
-    }
-  })
+  onDestroy(() => flushAutoSave())
 
   // Model info cache for active profiles
   let activeProfilesModelInfo = $state<Record<string, ImageModelInfo[]>>({})
@@ -356,14 +352,6 @@
     })
   }
 
-  function triggerAutoSave() {
-    if (saveTimeout) clearTimeout(saveTimeout)
-    saveTimeout = setTimeout(() => {
-      autoSaveProfile()
-      saveTimeout = null
-    }, 500)
-  }
-
   $effect(() => {
     if (editingProfileId && !isNewProfile) {
       // Touch all form fields so Svelte tracks them as dependencies
@@ -395,11 +383,7 @@
 
   // Aliased for clarity in UI but uses the same logic
   function saveEditingProfile() {
-    if (saveTimeout) {
-      clearTimeout(saveTimeout)
-      saveTimeout = null
-    }
-    autoSaveProfile()
+    flushAutoSave()
   }
 
   function startNewProfile() {

--- a/src/lib/utils/debounce.ts
+++ b/src/lib/utils/debounce.ts
@@ -1,0 +1,36 @@
+/**
+ * Creates a debounced save pair — `trigger()` and `flush()` — backed by a
+ * single shared timer.
+ *
+ * - `trigger()` resets the timer on every call and fires `saveFn` once the
+ *   delay has elapsed with no further calls.
+ * - `flush()` cancels any pending timer and runs `saveFn` immediately (useful
+ *   in `onDestroy` or before navigating away).
+ *
+ * @param saveFn  The function to call (may be async; errors are not caught).
+ * @param delay   Debounce window in milliseconds (default: 500).
+ */
+export function createDebouncedSave(
+  saveFn: () => void,
+  delay = 500,
+): { trigger: () => void; flush: () => void } {
+  let timer: ReturnType<typeof setTimeout> | null = null
+
+  function trigger() {
+    if (timer) clearTimeout(timer)
+    timer = setTimeout(() => {
+      timer = null
+      saveFn()
+    }, delay)
+  }
+
+  function flush() {
+    if (timer) {
+      clearTimeout(timer)
+      timer = null
+      saveFn()
+    }
+  }
+
+  return { trigger, flush }
+}

--- a/src/lib/utils/debounce.ts
+++ b/src/lib/utils/debounce.ts
@@ -7,20 +7,36 @@
  * - `flush()` cancels any pending timer and runs `saveFn` immediately (useful
  *   in `onDestroy` or before navigating away).
  *
- * @param saveFn  The function to call (may be async; errors are not caught).
+ * Errors thrown synchronously or via a rejected Promise from `saveFn` are
+ * logged to `console.error` so fire-and-forget callers (e.g. `onDestroy`)
+ * don't produce unhandled rejections. Callers that need UI-level error
+ * handling should do it inside their own `saveFn`.
+ *
+ * @param saveFn  The function to call on debounce fire or flush.
  * @param delay   Debounce window in milliseconds (default: 500).
  */
 export function createDebouncedSave(
-  saveFn: () => void,
+  saveFn: () => void | Promise<void>,
   delay = 500,
 ): { trigger: () => void; flush: () => void } {
   let timer: ReturnType<typeof setTimeout> | null = null
+
+  function safeSave() {
+    try {
+      const result = saveFn()
+      if (result instanceof Promise) {
+        result.catch((err) => console.error('Debounced save failed:', err))
+      }
+    } catch (err) {
+      console.error('Debounced save failed:', err)
+    }
+  }
 
   function trigger() {
     if (timer) clearTimeout(timer)
     timer = setTimeout(() => {
       timer = null
-      saveFn()
+      safeSave()
     }, delay)
   }
 
@@ -28,7 +44,7 @@ export function createDebouncedSave(
     if (timer) {
       clearTimeout(timer)
       timer = null
-      saveFn()
+      safeSave()
     }
   }
 


### PR DESCRIPTION
**Summary**
- Add createDebouncedSave(fn, delay?) in src/lib/utils/debounce.ts — returns { trigger, flush } backed by a single shared timer
- Refactor 5 components (MemorySettings, AgentProfiles, MainNarrative, api-connection, images) to use it, removing ~60 lines of identical timer boilerplate

**Bug fixes included**
- MemorySettings: local slider state was declared with $derived, making it read-only in Svelte 5 — replaced with $state seeded from the store at mount
- api-connection: after await settings.updateProfile() resolves, the component may already be unmounted; added a mounted guard to prevent stale writes to saveStatus and a dangling setTimeout
- api-connection / images: onDestroy previously discarded any pending debounced save; it now flushes it, so changes are not lost when the settings modal is closed mid-debounce window