### PR TITLE
Story scroll, UX, and settings fixes and improvements

### DIFF
--- a/src/lib/components/settings/tabs/interface.svelte
+++ b/src/lib/components/settings/tabs/interface.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { settings } from '$lib/stores/settings.svelte'
+  import { settings, STORY_WIDTH_OPTIONS } from '$lib/stores/settings.svelte'
   import { ui } from '$lib/stores/ui.svelte'
   import { database } from '$lib/services/database'
   import { grammarService } from '$lib/services/grammar'
   import { THEMES } from '../../../../themes/themes'
   import { Switch } from '$lib/components/ui/switch'
+  import { Slider } from '$lib/components/ui/slider'
   import { Label } from '$lib/components/ui/label'
   import * as Select from '$lib/components/ui/select'
   import { Button } from '$lib/components/ui/button'
@@ -16,6 +17,13 @@
   import { getSupportedLanguages } from '$lib/services/ai/utils/TranslationService'
   import { updaterService } from '$lib/services/updater'
   import { RefreshCw, Loader2, Languages, Plus, X, Trash2 } from 'lucide-svelte'
+
+  const storyWidthIndex = $derived(
+    Math.max(
+      0,
+      STORY_WIDTH_OPTIONS.findIndex((o) => o.key === settings.uiSettings.storyMaxWidth),
+    ),
+  )
 
   let isCheckingUpdates = $state(false)
   let updateMessage = $state<string | null>(null)
@@ -185,6 +193,31 @@
         {/each}
       </Select.Content>
     </Select.Root>
+  </div>
+
+  <!-- Story Content Width -->
+  <div class="space-y-2">
+    <div class="flex items-center justify-between">
+      <Label>Story Content Width</Label>
+      <span class="text-muted-foreground text-sm">
+        {STORY_WIDTH_OPTIONS[storyWidthIndex]?.label ?? 'Default'}
+      </span>
+    </div>
+    <p class="text-muted-foreground text-xs">
+      Max width of the story area — applies to text and inline images
+    </p>
+    <Slider
+      type="single"
+      min={0}
+      max={STORY_WIDTH_OPTIONS.length - 1}
+      step={1}
+      value={storyWidthIndex}
+      onValueChange={(idx) => settings.setStoryMaxWidth(STORY_WIDTH_OPTIONS[idx].key)}
+    />
+    <div class="text-muted-foreground flex justify-between text-xs">
+      <span>{STORY_WIDTH_OPTIONS[0].label}</span>
+      <span>{STORY_WIDTH_OPTIONS[STORY_WIDTH_OPTIONS.length - 1].label}</span>
+    </div>
   </div>
 
   <!-- Word Count Toggle -->

--- a/src/lib/components/story/ActionInput.svelte
+++ b/src/lib/components/story/ActionInput.svelte
@@ -616,7 +616,6 @@
         }
 
         if (event.type === 'phase_complete' && event.phase === 'narrative' && fullResponse.trim()) {
-          ui.endStreaming()
           narrationEntry = await story.addEntry(
             'narration',
             fullResponse,
@@ -624,6 +623,7 @@
             fullReasoning || undefined,
             narrationEntryId,
           )
+          ui.endStreaming()
           emitNarrativeResponse(narrationEntry.id, fullResponse)
           if (inlineImageTracker?.hasPendingImages) await inlineImageTracker.flushToDatabase()
         }

--- a/src/lib/components/story/StoryEntry.svelte
+++ b/src/lib/components/story/StoryEntry.svelte
@@ -1629,7 +1629,6 @@
 
   /* Inline image display styles */
   :global(.inline-image-display) {
-    margin: 0.75rem 0;
     border-radius: 0.5rem;
     overflow: hidden;
     border: 1px solid var(--surface-600);
@@ -1679,7 +1678,8 @@
   :global(.inline-image-content) {
     display: block;
     width: 100%;
-    max-width: 28rem;
+    max-height: 70vh;
+    object-fit: contain;
     margin: 0 auto;
   }
 
@@ -1888,6 +1888,8 @@
     display: block;
     width: 100%;
     height: auto;
+    max-height: 70vh;
+    object-fit: contain;
     transition:
       filter 0.2s ease,
       transform 0.2s ease;

--- a/src/lib/components/story/StoryView.svelte
+++ b/src/lib/components/story/StoryView.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import { story } from '$lib/stores/story.svelte'
   import { ui } from '$lib/stores/ui.svelte'
-  import { settings } from '$lib/stores/settings.svelte'
+  import { settings, STORY_WIDTH_OPTIONS } from '$lib/stores/settings.svelte'
   import { Loader2, BookOpen, ChevronDown, ChevronUp } from 'lucide-svelte'
-  import { tick } from 'svelte'
+  import { tick, untrack } from 'svelte'
   import { fade } from 'svelte/transition'
   import StoryEntry from './StoryEntry.svelte'
   import StreamingEntry from './StreamingEntry.svelte'
@@ -11,6 +11,13 @@
   import ActionChoices from './ActionChoices.svelte'
   import { Button } from '$lib/components/ui/button'
   import EmptyState from '$lib/components/ui/empty-state/empty-state.svelte'
+
+  const storyMaxWidthStyle = $derived.by(() => {
+    const maxWidth =
+      STORY_WIDTH_OPTIONS.find((o) => o.key === settings.uiSettings.storyMaxWidth)?.maxWidth ??
+      '48rem'
+    return `max-width: ${maxWidth}`
+  })
 
   let storyContainer: HTMLDivElement
   let containerHeight = $state(0)
@@ -30,6 +37,8 @@
 
   // Track if user has scrolled away from top (for showing scroll-to-top button)
   let userScrolledDown = $state(false)
+  // Track physical scroll position at bottom (updated on scroll AND on content resize)
+  let isAtPhysicalBottom = $state(true)
 
   // Track the current story ID to detect story switches
   let lastStoryId = $state<string | null>(null)
@@ -39,6 +48,13 @@
   let scrollRAF: number | null = null
   let prevEntryCount = 0
   let suppressScrollHandler = false
+
+  // No reactive reads — runs once on mount, cleanup cancels any in-flight RAF on unmount
+  $effect(() => {
+    return () => {
+      if (scrollRAF !== null) cancelAnimationFrame(scrollRAF)
+    }
+  })
 
   // Anchor the window to the end (latest entries) or start (oldest entries)
   function anchorToBottom(total: number) {
@@ -57,7 +73,9 @@
 
     if (currentStoryId !== lastStoryId) {
       lastStoryId = currentStoryId
+      prevEntryCount = story.entries.length
       anchorToBottom(story.entries.length)
+      tick().then(() => performScroll())
     }
   })
 
@@ -100,6 +118,7 @@
       const trimCount = Math.min(windowEnd - windowStart - MAX_VISIBLE_ENTRIES, LOAD_MORE_BATCH)
       windowEnd -= trimCount
       await tick()
+      if (!storyContainer) return
       // No scroll compensation: removed entries were below the viewport
     }
   }
@@ -124,13 +143,16 @@
       const trimCount = Math.min(windowEnd - windowStart - MAX_VISIBLE_ENTRIES, LOAD_MORE_BATCH)
       windowStart += trimCount
       await tick()
+      if (!storyContainer) return
       // Compensate: removed entries above shift all content up
       storyContainer.scrollTop = prevScrollTop - (prevScrollHeight - storyContainer.scrollHeight)
     }
   }
 
-  // Helper function to perform smooth scroll with RAF batching
-  function performScroll(scrollPosition: number) {
+  // Helper function to perform scroll with RAF batching.
+  // Pass scrollPosition for an exact position, or omit/pass undefined to scroll to the
+  // current bottom at RAF execution time (avoids stale scrollHeight from content changes).
+  function performScroll(scrollPosition?: number) {
     if (!storyContainer) return
 
     if (scrollRAF !== null) {
@@ -139,7 +161,7 @@
 
     scrollRAF = requestAnimationFrame(() => {
       if (storyContainer) {
-        storyContainer.scrollTop = scrollPosition
+        storyContainer.scrollTop = scrollPosition ?? storyContainer.scrollHeight
       }
       scrollRAF = null
     })
@@ -147,9 +169,7 @@
 
   function scrollToBottom() {
     anchorToBottom(story.entries.length)
-    requestAnimationFrame(() => {
-      performScroll(storyContainer?.scrollHeight ?? 0)
-    })
+    performScroll()
   }
 
   async function scrollToTop() {
@@ -158,6 +178,8 @@
     anchorToTop(story.entries.length)
     await tick()
     performScroll(0)
+    // Reset in the frame AFTER performScroll's RAF fires, so the scroll event
+    // triggered by scrollTop=0 is still ignored by handleScroll
     requestAnimationFrame(() => {
       suppressScrollHandler = false
     })
@@ -176,7 +198,7 @@
       SCROLL_THRESHOLD
     )
   }
-  // Handle scroll events during streaming
+  // Handle scroll events — update scroll break state, button visibility, and lazy-load triggers
   function handleScroll() {
     if (!storyContainer || suppressScrollHandler) return
 
@@ -192,11 +214,12 @@
 
     // Track if user has scrolled down from top (for scroll-to-top button)
     userScrolledDown = !nearTop
+    isAtPhysicalBottom = nearBottom
   }
 
   // Disabled when truly at the very start/end of the entire story
   const atVeryTop = $derived(displayedEntries.hiddenAtTop === 0 && !userScrolledDown)
-  const atVeryBottom = $derived(displayedEntries.hiddenAtBottom === 0 && !ui.userScrolledUp)
+  const atVeryBottom = $derived(displayedEntries.hiddenAtBottom === 0 && isAtPhysicalBottom)
 
   // Auto-scroll to bottom when new entries are added or streaming content changes
   $effect(() => {
@@ -205,33 +228,67 @@
     const _ = innerHeight
     const __ = containerHeight
 
-    // Detect if entries were added (vs deleted or unchanged)
-    const wasAdded = currentCount > prevEntryCount
+    // Update physical bottom state on content/viewport resize (scroll events handle it during scrolling)
+    if (storyContainer) isAtPhysicalBottom = isNearEdge('bottom')
+
+    // Detect if entries were added (vs deleted or unchanged).
+    // wasEmpty: entries just loaded for the first time for this story.
+    const prevCount = prevEntryCount
+    const wasAdded = currentCount > prevCount
+    const wasEmpty = prevCount === 0 && wasAdded
     prevEntryCount = currentCount
 
-    // Detect if we should scroll:
-    // 1. We are NOT user-scrolled-up (pinned mode)
-    // 2. OR on user action send message/retry
     const lastEntry = story.entries[story.entries.length - 1]
+    // Key entries (user action, narration, retry) must never be hidden behind
+    // the "N later entries hidden" collapse indicator.
+    const isKeyEntry =
+      wasAdded && lastEntry && ['user_action', 'retry', 'narration'].includes(lastEntry.type)
+
+    if (wasAdded) {
+      if (!ui.userScrolledUp) {
+        // Normal case: anchor window to the latest entries
+        anchorToBottom(currentCount)
+      } else if (isKeyEntry) {
+        // User is scrolled up but a key entry arrived: extend windowEnd so the
+        // entry is in the virtual window (no collapse), but do NOT call
+        // anchorToBottom (which trims windowStart and can re-trigger this effect
+        // via innerHeight changes, inadvertently causing a scroll to bottom).
+        windowEnd = currentCount
+      }
+    }
+
+    // Initial story load: entries just went from 0 → N (loaded asynchronously
+    // after the story switch). Always scroll to bottom here — autoScroll only
+    // applies during generation, not when positioning on story open.
+    // This fires AFTER the story-switch effect's early performScroll (which ran
+    // against an empty container) and its cancelAnimationFrame ensures it wins.
+    if (wasEmpty) {
+      performScroll()
+      return
+    }
+
+    // Physical scroll: autoScroll setting must be enabled. user_action/retry
+    // additionally override the userScrolledUp check (sending a message always
+    // re-engages auto-scroll). Narration does NOT — if the user scrolled up
+    // during streaming they stay where they are.
     const shouldScroll =
       settings.uiSettings.autoScroll &&
+      (ui.isStreaming || wasAdded) &&
       (!ui.userScrolledUp ||
         (wasAdded && lastEntry && ['user_action', 'retry'].includes(lastEntry.type)))
 
     if (!shouldScroll) return
 
-    // New entries: re-anchor window to the latest entries
-    if (wasAdded) {
-      anchorToBottom(currentCount)
-    }
-
-    performScroll(storyContainer?.scrollHeight ?? 0)
+    performScroll()
   })
 
-  // Scroll to bottom when returning from gallery or other panels
+  // Scroll to bottom when opening/returning to story panel — always, regardless of autoScroll
+  // (autoScroll only controls scrolling during generation, not initial panel positioning)
+  // untrack prevents story.entries.length (accessed inside scrollToBottom) from being
+  // tracked as a dependency — otherwise this effect would re-fire on every new entry.
   $effect(() => {
     if (ui.activePanel === 'story' && storyContainer) {
-      scrollToBottom()
+      untrack(() => scrollToBottom())
     }
   })
 
@@ -270,7 +327,11 @@
     class="relative z-10 flex-1 overflow-y-auto px-3 pt-3 pb-1 sm:px-6 sm:pt-4 sm:pb-2"
     onscroll={handleScroll}
   >
-    <div class="mx-auto max-w-3xl space-y-2.5 sm:space-y-3" bind:clientHeight={innerHeight}>
+    <div
+      class="mx-auto space-y-2.5 sm:space-y-3"
+      style={storyMaxWidthStyle}
+      bind:clientHeight={innerHeight}
+    >
       {#if story.entries.length === 0 && !ui.isStreaming}
         <EmptyState
           icon={BookOpen}
@@ -351,31 +412,33 @@
       <div class="pointer-events-none sticky right-0 bottom-0 left-0 z-20 flex justify-center py-2">
         <div class="pointer-events-auto flex gap-2">
           <!-- Scroll to top button -->
-          {#if settings.uiSettings.showScrollToTop}
-            <Button
-              variant="secondary"
-              size="sm"
-              class={buttonClasses}
-              onclick={scrollToTop}
-              disabled={atVeryTop}
-              aria-label="Scroll to first message"
-            >
-              <ChevronUp class={iconClasses} />
-            </Button>
+          {#if settings.uiSettings.showScrollToTop && !atVeryTop}
+            <div transition:fade={{ duration: 150 }}>
+              <Button
+                variant="secondary"
+                size="sm"
+                class={buttonClasses}
+                onclick={scrollToTop}
+                aria-label="Scroll to first message"
+              >
+                <ChevronUp class={iconClasses} />
+              </Button>
+            </div>
           {/if}
 
           <!-- Scroll to bottom button -->
-          {#if settings.uiSettings.showScrollToBottom}
-            <Button
-              variant="secondary"
-              size="sm"
-              class={buttonClasses}
-              onclick={scrollToBottom}
-              disabled={atVeryBottom}
-              aria-label="Scroll to bottom"
-            >
-              <ChevronDown class={iconClasses} />
-            </Button>
+          {#if settings.uiSettings.showScrollToBottom && !atVeryBottom}
+            <div transition:fade={{ duration: 150 }}>
+              <Button
+                variant="secondary"
+                size="sm"
+                class={buttonClasses}
+                onclick={scrollToBottom}
+                aria-label="Scroll to bottom"
+              >
+                <ChevronDown class={iconClasses} />
+              </Button>
+            </div>
           {/if}
         </div>
       </div>
@@ -388,7 +451,7 @@
       ? 'bg-background/60 backdrop-blur-md'
       : 'bg-card'}"
   >
-    <div class="mx-auto max-w-3xl">
+    <div class="mx-auto" style={storyMaxWidthStyle}>
       <ActionInput />
     </div>
   </div>

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -1096,6 +1096,15 @@ export function getPresetDefaults(provider: ProviderType, presetId: string): Gen
   return preset
 }
 
+export const STORY_WIDTH_OPTIONS = [
+  { key: '2xl' as const, label: 'Narrow', maxWidth: '42rem' },
+  { key: '3xl' as const, label: 'Default', maxWidth: '48rem' },
+  { key: '4xl' as const, label: 'Wide', maxWidth: '56rem' },
+  { key: '5xl' as const, label: 'Wider', maxWidth: '64rem' },
+  { key: '7xl' as const, label: 'Very wide', maxWidth: '80rem' },
+  { key: '9xl' as const, label: 'Extra wide', maxWidth: '96rem' },
+] as const
+
 export function getDefaultUISettings(): UISettings {
   return {
     theme: 'dark',
@@ -1113,6 +1122,7 @@ export function getDefaultUISettings(): UISettings {
     autoScroll: true,
     showScrollToTop: false,
     showScrollToBottom: true,
+    storyMaxWidth: '3xl',
   }
 }
 
@@ -1465,11 +1475,21 @@ class SettingsStore {
       if (showScrollToBottom !== null)
         this.uiSettings.showScrollToBottom = showScrollToBottom === 'true'
 
+      const storyMaxWidth = await database.getSetting('story_max_width')
+      if (
+        storyMaxWidth &&
+        (STORY_WIDTH_OPTIONS.map((o) => o.key) as string[]).includes(storyMaxWidth)
+      )
+        this.uiSettings.storyMaxWidth = storyMaxWidth as UISettings['storyMaxWidth']
+
       const debugMode = await database.getSetting('debug_mode')
       if (debugMode !== null) debug.isActive = this.uiSettings.debugMode = debugMode === 'true'
 
       const sidebarWidth = await database.getSetting('sidebar_width')
       if (sidebarWidth) this.uiSettings.sidebarWidth = parseInt(sidebarWidth, 10)
+
+      const sidebarOpen = await database.getSetting('sidebar_open')
+      if (sidebarOpen !== null) ui.sidebarOpen = sidebarOpen === 'true'
 
       const manualMode = await database.getSetting('advanced_manual_mode')
       if (manualMode !== null) {
@@ -2456,6 +2476,11 @@ class SettingsStore {
   async setShowScrollToBottom(enabled: boolean) {
     this.uiSettings.showScrollToBottom = enabled
     await database.setSetting('show_scroll_to_bottom', enabled.toString())
+  }
+
+  async setStoryMaxWidth(width: UISettings['storyMaxWidth']) {
+    this.uiSettings.storyMaxWidth = width
+    await database.setSetting('story_max_width', width)
   }
 
   async setSidebarWidth(width: number) {

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -1105,6 +1105,8 @@ export const STORY_WIDTH_OPTIONS = [
   { key: '9xl' as const, label: 'Extra wide', maxWidth: '96rem' },
 ] as const
 
+const VALID_STORY_WIDTH_KEYS: string[] = STORY_WIDTH_OPTIONS.map((o) => o.key)
+
 export function getDefaultUISettings(): UISettings {
   return {
     theme: 'dark',
@@ -1476,10 +1478,7 @@ class SettingsStore {
         this.uiSettings.showScrollToBottom = showScrollToBottom === 'true'
 
       const storyMaxWidth = await database.getSetting('story_max_width')
-      if (
-        storyMaxWidth &&
-        (STORY_WIDTH_OPTIONS.map((o) => o.key) as string[]).includes(storyMaxWidth)
-      )
+      if (storyMaxWidth && VALID_STORY_WIDTH_KEYS.includes(storyMaxWidth))
         this.uiSettings.storyMaxWidth = storyMaxWidth as UISettings['storyMaxWidth']
 
       const debugMode = await database.getSetting('debug_mode')

--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -308,6 +308,9 @@ class UIStore {
 
   toggleSidebar() {
     this.sidebarOpen = !this.sidebarOpen
+    database
+      .setSetting('sidebar_open', this.sidebarOpen.toString())
+      .catch((err) => console.warn('[UI] Failed to persist sidebar state:', err))
   }
 
   /**
@@ -317,6 +320,8 @@ class UIStore {
   setMobileDefaults() {
     if (typeof window !== 'undefined' && window.innerWidth < 640) {
       this.sidebarOpen = false
+      // No DB persist — this is a layout constraint, not a user preference.
+      // Persisting here would overwrite the desktop sidebar preference.
     }
   }
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -741,6 +741,7 @@ export interface UISettings {
   autoScroll: boolean
   showScrollToTop: boolean
   showScrollToBottom: boolean
+  storyMaxWidth: '2xl' | '3xl' | '4xl' | '5xl' | '7xl' | '9xl'
 }
 
 export interface UpdateSettings {


### PR DESCRIPTION
closes issue #296 

Scroll fixes (StoryView.svelte)
- Auto-scroll during post-generation phase ("Updating world…") no longer fires when Auto Scroll is disabled
- Scroll-to-bottom button now correctly appears/disappears based on physical scroll position, not just userScrolledUp state
- Scroll-to-bottom button now appears during streaming when Auto Scroll is off
- Story opens at bottom on load/restart — fixed timing issue where performScroll ran against an empty container before async entries arrived; the main scroll effect now handles the initial load unconditionally
- Streaming→saved entry flicker eliminated: ui.endStreaming() is now called after story.addEntry(), not before
- Key entries (user_action, narration, retry) are never hidden behind the "N later entries hidden for performance" collapse indicator, even when the user scrolled up during streaming — window is extended without triggering a scroll-to-bottom side effect
- Scroll buttons now fade in/out with a 150ms transition instead of instantly appearing
- untrack() on the active-panel scroll effect prevents it from re-firing on every new entry
- RAF cleanup on component unmount

Story content width setting (interface.svelte, settings.svelte.ts, StoryView.svelte)
- New Story Content Width slider in Settings → Interface, under Font Size
- 6 steps: Narrow (42rem) → Default (48rem) → Wide → Wider → Very wide → Extra wide (96rem)
- Persisted to DB; restored on app restart
- Single source of truth: STORY_WIDTH_OPTIONS in settings.svelte.ts holds key, label, and CSS value — no duplication across files

Sidebar persistence (ui.svelte.ts, settings.svelte.ts)
- Sidebar open/closed state persisted across restarts
- setMobileDefaults() no longer persists to DB (it's a layout constraint, not a user preference — previously it would overwrite the desktop sidebar state)

Image height (StoryEntry.svelte)
- Inline and agent-mode generated images capped at 70vh with object-fit: contain
- Removed hardcoded max-width: 28rem on agent-mode images (inconsistent with configurable story width)
- Removed vertical margin from .inline-image-display