### PR TITLE
 user message edit without auto-regeneration

### DIFF
--- a/src/lib/components/story/StoryEntry.svelte
+++ b/src/lib/components/story/StoryEntry.svelte
@@ -1224,8 +1224,9 @@
           Ctrl+Enter to save, Esc to cancel
         </p>
         {#if canSaveAndRegenerate}
-          <p class="text-muted-foreground/50 hidden text-xs sm:block">
+          <p class="hidden items-center gap-1 text-xs text-amber-500/80 sm:flex">
             Regenerate narration after significant changes
+            <RotateCcw class="h-3 w-3" />
           </p>
         {/if}
       </div>

--- a/src/lib/components/story/StoryEntry.svelte
+++ b/src/lib/components/story/StoryEntry.svelte
@@ -249,6 +249,19 @@
   // Can create checkpoint: latest entry, not a system entry, and no checkpoint exists yet
   const canCreateCheckpoint = $derived(isLatestEntry && entry.type !== 'system' && !entryCheckpoint)
 
+  // Is this the last user_action in the story? (used for the regeneration hint)
+  const isLastUserAction = $derived(
+    entry.type === 'user_action' && story.lastUserActionId === entry.id,
+  )
+
+  // Show regeneration hint when editing the last user_action and retry is available
+  const canSaveAndRegenerate = $derived(
+    isLastUserAction &&
+      !!ui.retryBackup &&
+      !!story.currentStory &&
+      ui.retryBackup.storyId === story.currentStory.id,
+  )
+
   async function handleCreateCheckpoint() {
     if (!checkpointName.trim()) return
     try {
@@ -924,42 +937,16 @@
     }
 
     try {
-      // Check if this is the last user_action entry
-      const isLastUserAction = entry.type === 'user_action' && isLastUserActionEntry()
-
-      if (
-        isLastUserAction &&
-        ui.retryBackup &&
-        story.currentStory &&
-        ui.retryBackup.storyId === story.currentStory.id
-      ) {
-        // Update the backup with the new content and trigger retry
-        console.log('[StoryEntry] Editing last user action, triggering retry with new content')
+      await story.updateEntry(entry.id, newContent)
+      // Keep retry backup in sync so a subsequent Retry uses the updated text
+      if (canSaveAndRegenerate) {
         ui.updateRetryBackupContent(newContent)
-        isEditing = false
-        await ui.triggerRetryLastMessage()
-      } else {
-        // Normal edit - just update the entry
-        await story.updateEntry(entry.id, newContent)
-        isEditing = false
       }
+      isEditing = false
     } catch (error) {
       console.error('[StoryEntry] Failed to save edit:', error)
       alert(error instanceof Error ? error.message : 'Failed to save edit')
     }
-  }
-
-  /**
-   * Check if this entry is the last user_action in the story.
-   */
-  function isLastUserActionEntry(): boolean {
-    // Find all user_action entries
-    const userActions = story.entries.filter((e) => e.type === 'user_action')
-    if (userActions.length === 0) return false
-
-    // Check if this entry is the last one
-    const lastUserAction = userActions[userActions.length - 1]
-    return lastUserAction.id === entry.id
   }
 
   /**
@@ -1236,6 +1223,11 @@
         <p class="text-muted-foreground hidden text-xs sm:block">
           Ctrl+Enter to save, Esc to cancel
         </p>
+        {#if canSaveAndRegenerate}
+          <p class="text-muted-foreground/50 hidden text-xs sm:block">
+            Regenerate narration after significant changes
+          </p>
+        {/if}
       </div>
     {:else if isDeleting}
       <div class="space-y-2">

--- a/src/lib/stores/story.svelte.ts
+++ b/src/lib/stores/story.svelte.ts
@@ -175,6 +175,16 @@ class StoryStore {
     return this.storyBeats.filter((b) => b.status === 'pending' || b.status === 'active')
   }
 
+  get lastUserActionId(): string | null {
+    // Search from the end for efficiency
+    for (let i = this.entries.length - 1; i >= 0; i--) {
+      if (this.entries[i].type === 'user_action') {
+        return this.entries[i].id
+      }
+    }
+    return null
+  }
+
   get wordCount(): number {
     // Use cached value if available, recalculate only when dirty
     if (this._wordCountDirty) {


### PR DESCRIPTION
Fixes: https://github.com/AventurasTeam/Aventuras/issues/302

Problem:
Editing the last user message previously triggered an automatic story regeneration (undoing subsequent AI turns). This caused a disruptive user experience when fixing minor typos or making small adjustments.

Solution:
- Modified StoryEntry.svelte to update the entry content and the retry backup silently when editing the last user action.
- Decoupled message saving from the triggerRetryLastMessage() call.
- Synchronized the retry backup content to ensure that if the user manually clicks "Retry" later, the AI uses the updated text.
- Added a UI hint to suggest manual regeneration after significant message changes.
- Refactored isLastUserAction check into a Svelte 5 derived rune for improved performance.

Impact:
Users can now fix typos in their last message without losing the current AI response, while still having the option to manually regenerate the answer if needed.