### PR TITLE
Fix/inline image error feedback

### DIFF
--- a/src/lib/components/story/StoryEntry.svelte
+++ b/src/lib/components/story/StoryEntry.svelte
@@ -812,6 +812,7 @@
       retryBtn.addEventListener('click', async () => {
         const imageId = retryBtn.getAttribute('data-image-id')
         if (imageId && expandedImage) {
+          ;(retryBtn as HTMLButtonElement).disabled = true
           await regenerateInlineImage(imageId, expandedImage.prompt)
           expandedImageId = null
           clickedElement = null
@@ -1704,6 +1705,7 @@
   :global(.inline-image-placeholder) {
     position: relative;
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
     margin: 1rem 0;
@@ -1724,6 +1726,31 @@
   :global(.inline-image-placeholder.failed) {
     border-color: var(--color-red-500, #ef4444);
     background: linear-gradient(135deg, var(--surface-800) 0%, rgba(239, 68, 68, 0.1) 100%);
+    gap: 0.5rem;
+    padding: 1rem;
+  }
+
+  :global(.placeholder-text) {
+    font-size: 0.75rem;
+    color: var(--muted-foreground);
+    text-align: center;
+    max-width: 100%;
+    word-break: break-word;
+  }
+
+  :global(.inline-image-retry) {
+    margin-top: 0.5rem;
+    padding: 0.375rem 0.75rem;
+    border-radius: 0.375rem;
+    font-size: 0.75rem;
+    background-color: var(--surface-600);
+    color: var(--foreground);
+    border: 1px solid var(--surface-500);
+    cursor: pointer;
+  }
+
+  :global(.inline-image-retry:hover) {
+    background-color: var(--surface-500);
   }
 
   /* Shimmer effect */

--- a/src/lib/components/story/StoryEntry.svelte
+++ b/src/lib/components/story/StoryEntry.svelte
@@ -1598,6 +1598,12 @@
     text-decoration-style: dashed;
   }
 
+  :global(.embedded-image-link.failed) {
+    color: var(--destructive);
+    text-decoration-style: wavy;
+    cursor: pointer;
+  }
+
   :global(.embedded-image-link.regenerating) {
     color: var(--accent-400);
     animation: pulse-glow 1s ease-in-out infinite;

--- a/src/lib/services/ai/image/InlineImageService.ts
+++ b/src/lib/services/ai/image/InlineImageService.ts
@@ -18,7 +18,7 @@ import {
 } from './providers/registry'
 import { database } from '$lib/services/database'
 import { settings } from '$lib/stores/settings.svelte'
-import { emitImageQueued, emitImageReady } from '$lib/services/events'
+import { emitImageQueued, emitImageReady, emitImageAnalysisFailed } from '$lib/services/events'
 import { normalizeImageDataUrl, parseImageSize } from '$lib/utils/image'
 import { extractPicTags, type ParsedPicTag } from '$lib/utils/inlineImageParser'
 import { DEFAULT_FALLBACK_STYLE_PROMPT } from './constants'
@@ -283,8 +283,9 @@ export class InlineImageGenerationService {
         errorMessage,
       })
 
-      // Emit ready event (with failure)
+      // Emit ready event (with failure) and notify UI
       emitImageReady(imageId, entryId, false)
+      emitImageAnalysisFailed(entryId, errorMessage)
     }
   }
 }

--- a/src/lib/services/ai/image/providers/fetchAdapter.ts
+++ b/src/lib/services/ai/image/providers/fetchAdapter.ts
@@ -103,8 +103,13 @@ export async function imageFetch(options: {
         startTime,
         errorText,
       )
+      const err = errorPayload as any
+      const humanMessage =
+        typeof errorPayload === 'string'
+          ? errorPayload
+          : (err?.error?.message ?? err?.message ?? err?.error)
       throw new Error(
-        `Image API error ${response.status}: ${typeof errorPayload === 'string' ? errorPayload : JSON.stringify(errorPayload)}`,
+        `Image API error ${response.status}: ${humanMessage ?? JSON.stringify(errorPayload)}`,
       )
     }
 

--- a/src/lib/services/image/ImageEmbeddingService.ts
+++ b/src/lib/services/image/ImageEmbeddingService.ts
@@ -30,7 +30,7 @@ function getDisplayableAgenticImages(images: EmbeddedImage[]): EmbeddedImage[] {
   return images.filter(
     (img) =>
       img.generationMode !== 'inline' &&
-      (img.status === 'complete' || img.status === 'generating' || img.status === 'pending') &&
+      (img.status === 'complete' || img.status === 'generating' || img.status === 'pending' || img.status === 'failed') &&
       img.sourceText.length >= 20,
   )
 }
@@ -131,7 +131,9 @@ function processUnified(
         ? 'complete'
         : marker.status === 'generating'
           ? 'generating'
-          : 'pending'
+          : marker.status === 'failed'
+            ? 'failed'
+            : 'pending'
 
     placeholderMap.set(
       placeholder,

--- a/src/lib/services/image/ImageEmbeddingService.ts
+++ b/src/lib/services/image/ImageEmbeddingService.ts
@@ -30,7 +30,10 @@ function getDisplayableAgenticImages(images: EmbeddedImage[]): EmbeddedImage[] {
   return images.filter(
     (img) =>
       img.generationMode !== 'inline' &&
-      (img.status === 'complete' || img.status === 'generating' || img.status === 'pending' || img.status === 'failed') &&
+      (img.status === 'complete' ||
+        img.status === 'generating' ||
+        img.status === 'pending' ||
+        img.status === 'failed') &&
       img.sourceText.length >= 20,
   )
 }


### PR DESCRIPTION
Problem
When image generation fails, there was no visual feedback:
- Agentic images silently disappeared from the narrative text
- Inline images showed no error placeholder in the rendered content
- The error message stored was the raw JSON API response
- The retry button had no disabled state, allowing multiple concurrent requests
- 
Changes
- ImageEmbeddingService: include failed status in agentic image markers so they remain visible in the text as a red wavy-underlined link
- StoryEntry.svelte: add failed CSS class for the link, add flex-direction: column to the placeholder so the retry button is always visible, add styles for .placeholder-text and .inline-image-retry, disable the retry button immediately on click
- fetchAdapter.ts: extract the human-readable message from the API error JSON instead of serializing the whole payload
- InlineImageService: emit ImageAnalysisFailed on generation error so the UI shows an error toast