### PR TITLE
Feature: Google ai studio improvements

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,9 +8,7 @@
     "devUrl": "http://localhost:1420",
     "beforeBuildCommand": "npm run build",
     "frontendDist": "../build",
-    "features": [
-      "devtools"
-    ]
+    "features": ["devtools"]
   },
   "app": {
     "windows": [

--- a/src/lib/components/settings/tabs/images.svelte
+++ b/src/lib/components/settings/tabs/images.svelte
@@ -60,7 +60,7 @@
     { value: 'openrouter', label: 'OpenRouter' },
     { value: 'chutes', label: 'Chutes' },
     { value: 'pollinations', label: 'Pollinations' },
-    { value: 'google', label: 'Google Imagen' },
+    { value: 'google', label: 'Google AI Studio' },
     { value: 'zhipu', label: 'Zhipu CogView' },
     { value: 'comfyui', label: 'ComfyUI' },
   ]
@@ -118,6 +118,11 @@
   // Profile form model state
   let profileModel = $state('')
   let profileModels = $state<ImageModelInfo[]>([])
+  const referenceProfileImg2ImgWarning = $derived(
+    isEditingReferenceProfile &&
+      !!profileModel &&
+      profileModels.find((m) => m.id === profileModel)?.supportsImg2Img === false,
+  )
   let isLoadingProfileModels = $state(false)
   let profileModelsError = $state<string | null>(null)
 
@@ -1085,7 +1090,7 @@
         onModelChange={(id) => {
           profileModel = id
         }}
-        filterFunc={isEditingReferenceProfile ? (m) => m.supportsImg2Img : undefined}
+        filterFunc={undefined}
         showCost={true}
         showImg2ImgIndicator={true}
         showDescription={false}
@@ -1094,9 +1099,16 @@
         showRefreshButton={true}
         onRefresh={() => loadProfileFormModels(profileProviderType, profileApiKey, true)}
       />
-      <p class="text-muted-foreground mt-1 text-xs">
-        The image model this profile will use for generation.
-      </p>
+      {#if referenceProfileImg2ImgWarning}
+        <p class="text-warning mt-1 text-xs">
+          This profile is used for reference image generation (img2img), but the selected model
+          does not support img2img.
+        </p>
+      {:else}
+        <p class="text-muted-foreground mt-1 text-xs">
+          The image model this profile will use for generation.
+        </p>
+      {/if}
     </div>
     {#if profileProviderType === 'comfyui'}
       <div class="grid grid-cols-2 gap-4 pt-2">

--- a/src/lib/components/settings/tabs/images.svelte
+++ b/src/lib/components/settings/tabs/images.svelte
@@ -1101,8 +1101,8 @@
       />
       {#if referenceProfileImg2ImgWarning}
         <p class="text-warning mt-1 text-xs">
-          This profile is used for reference image generation (img2img), but the selected model
-          does not support img2img.
+          This profile is used for reference image generation (img2img), but the selected model does
+          not support img2img.
         </p>
       {:else}
         <p class="text-muted-foreground mt-1 text-xs">

--- a/src/lib/services/ai/image/providers/google.ts
+++ b/src/lib/services/ai/image/providers/google.ts
@@ -16,6 +16,7 @@ import type {
 import { createGoogleGenerativeAI } from '@ai-sdk/google'
 import { generateImage } from 'ai'
 import { isGoogleImageModel } from '../../sdk/providers/modelFetcher'
+import { createTimeoutFetch } from '../../sdk/providers/fetch'
 
 const DEFAULT_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta'
 
@@ -61,10 +62,11 @@ function sizeToAspectRatio(size: string): string {
 async function fetchGoogleImageModels(baseUrl: string, apiKey?: string): Promise<ImageModelInfo[]> {
   if (!apiKey) return getFallbackImageModels()
 
-  const url = baseUrl.replace(/\/$/, '') + '/models?key=' + apiKey + '&pageSize=200'
+  const url = baseUrl.replace(/\/$/, '') + '/models?key=' + encodeURIComponent(apiKey) + '&pageSize=200'
 
   try {
-    const response = await fetch(url)
+    const fetchFn = createTimeoutFetch(30000, 'google-image-models')
+    const response = await fetchFn(url)
     if (!response.ok) return getFallbackImageModels()
 
     const data = await response.json()

--- a/src/lib/services/ai/image/providers/google.ts
+++ b/src/lib/services/ai/image/providers/google.ts
@@ -1,9 +1,9 @@
 /**
- * Google Imagen Provider
+ * Google Image Provider
  *
- * Direct HTTP calls to Google's Generative AI API for image generation.
- * - txt2img: POST to generativelanguage.googleapis.com
- * - img2img: Not supported
+ * Uses the Vercel AI SDK (@ai-sdk/google) for all image generation.
+ * Supports both Imagen models (:predict) and Gemini image models
+ * (gemini-*-image, nano-banana-*) transparently via google.image().
  */
 
 import type {
@@ -13,65 +13,118 @@ import type {
   ImageGenerateResult,
   ImageModelInfo,
 } from './types'
-import { imageFetch } from './fetchAdapter'
+import { createGoogleGenerativeAI } from '@ai-sdk/google'
+import { generateImage } from 'ai'
+import { isGoogleImageModel } from '../../sdk/providers/modelFetcher'
 
 const DEFAULT_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta'
 
 export function createGoogleProvider(config: ImageProviderConfig): ImageProvider {
   const baseUrl = config.baseUrl || DEFAULT_BASE_URL
+  const googleSDK = createGoogleGenerativeAI({ apiKey: config.apiKey, baseURL: baseUrl })
 
   return {
     id: 'google',
-    name: 'Google Imagen',
+    name: 'Google AI Studio',
 
     async generate(options: ImageGenerateOptions): Promise<ImageGenerateResult> {
-      const { model, prompt, signal } = options
+      const { model, prompt, size, signal } = options
 
-      const body = {
-        instances: [{ prompt }],
-        parameters: {
-          sampleCount: 1,
-        },
-      }
-
-      const response = await imageFetch({
-        url: `${baseUrl}/models/${model}:predict?key=${config.apiKey}`,
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-        signal,
-        serviceId: 'google-image',
+      const result = await generateImage({
+        model: googleSDK.image(model),
+        prompt,
+        aspectRatio: sizeToAspectRatio(size) as `${number}:${number}`,
+        abortSignal: signal,
       })
 
-      const data = await response.json()
-      const predictions = data?.predictions
-      if (!predictions?.[0]?.bytesBase64Encoded) {
+      if (!result.images[0]?.base64) {
         throw new Error('No image data in Google response')
       }
 
-      return { base64: predictions[0].bytesBase64Encoded }
+      return { base64: result.images[0].base64 }
     },
 
     async listModels(): Promise<ImageModelInfo[]> {
-      return getGoogleModels()
+      return fetchGoogleImageModels(baseUrl, config.apiKey)
     },
   }
 }
 
-function getGoogleModels(): ImageModelInfo[] {
+function sizeToAspectRatio(size: string): string {
+  const [w, h] = size.split('x').map(Number)
+  if (!w || !h || w === h) return '1:1'
+  const gcd = (a: number, b: number): number => (b === 0 ? a : gcd(b, a % b))
+  const d = gcd(w, h)
+  return `${w / d}:${h / d}`
+}
+
+async function fetchGoogleImageModels(baseUrl: string, apiKey?: string): Promise<ImageModelInfo[]> {
+  if (!apiKey) return getFallbackImageModels()
+
+  const url = baseUrl.replace(/\/$/, '') + '/models?key=' + apiKey + '&pageSize=200'
+
+  try {
+    const response = await fetch(url)
+    if (!response.ok) return getFallbackImageModels()
+
+    const data = await response.json()
+    if (!data.models || !Array.isArray(data.models)) return getFallbackImageModels()
+
+    const models: ImageModelInfo[] = data.models
+      .filter((m: { name: string; supportedGenerationMethods?: string[] }) => {
+        const id = m.name.replace(/^models\//, '')
+        return m.supportedGenerationMethods?.includes('predict') || isGoogleImageModel(id)
+      })
+      .map((m: { name: string; displayName?: string; description?: string }) => {
+        const id = m.name.replace(/^models\//, '')
+        return {
+          id,
+          name: m.displayName || id,
+          description: m.description,
+          supportsSizes: getImagenSizes(id),
+          supportsImg2Img: supportsImg2Img(id),
+        }
+      })
+
+    return models.length > 0 ? models : getFallbackImageModels()
+  } catch (error) {
+    console.error('[Google Image] Failed to fetch models:', error)
+    return getFallbackImageModels()
+  }
+}
+
+function supportsImg2Img(id: string): boolean {
+  // Gemini image models (nano banana) and Imagen 4 support img2img
+  return isGoogleImageModel(id) || id === 'imagen-4.0-generate-001'
+}
+
+function getImagenSizes(id: string): string[] {
+  if (id.includes('fast')) return ['512x512', '1024x1024']
+  return ['512x512', '1024x1024', '2048x2048']
+}
+
+function getFallbackImageModels(): ImageModelInfo[] {
   return [
-    {
-      id: 'imagen-3.0-generate-002',
-      name: 'Imagen 3',
-      description: "Google's latest image generation model",
-      supportsSizes: ['512x512', '1024x1024'],
-      supportsImg2Img: false,
-    },
     {
       id: 'imagen-4.0-generate-001',
       name: 'Imagen 4',
-      description: 'Next-gen image generation',
-      supportsSizes: ['512x512', '1024x1024'],
-      supportsImg2Img: false,
+      description: 'Vertex served Imagen 4.0 model',
+      supportsSizes: getImagenSizes('imagen-4.0-generate-001'),
+      supportsImg2Img: supportsImg2Img('imagen-4.0-generate-001'),
+    },
+    {
+      id: 'imagen-4.0-ultra-generate-001',
+      name: 'Imagen 4 Ultra',
+      description: 'Vertex served Imagen 4.0 ultra model',
+      supportsSizes: getImagenSizes('imagen-4.0-ultra-generate-001'),
+      supportsImg2Img: supportsImg2Img('imagen-4.0-ultra-generate-001'),
+    },
+    {
+      id: 'imagen-4.0-fast-generate-001',
+      name: 'Imagen 4 Fast',
+      description: 'Vertex served Imagen 4.0 Fast model',
+      supportsSizes: getImagenSizes('imagen-4.0-fast-generate-001'),
+      supportsImg2Img: supportsImg2Img('imagen-4.0-fast-generate-001'),
     },
   ]
 }

--- a/src/lib/services/ai/image/providers/google.ts
+++ b/src/lib/services/ai/image/providers/google.ts
@@ -62,7 +62,8 @@ function sizeToAspectRatio(size: string): string {
 async function fetchGoogleImageModels(baseUrl: string, apiKey?: string): Promise<ImageModelInfo[]> {
   if (!apiKey) return getFallbackImageModels()
 
-  const url = baseUrl.replace(/\/$/, '') + '/models?key=' + encodeURIComponent(apiKey) + '&pageSize=200'
+  const url =
+    baseUrl.replace(/\/$/, '') + '/models?key=' + encodeURIComponent(apiKey) + '&pageSize=200'
 
   try {
     const fetchFn = createTimeoutFetch(30000, 'google-image-models')

--- a/src/lib/services/ai/sdk/generate.ts
+++ b/src/lib/services/ai/sdk/generate.ts
@@ -157,7 +157,12 @@ export function buildProviderOptions(
         const usesBudget = modelInfo?.isBudgetReasoning ?? preset.model.includes('gemini-2.5')
         if (usesBudget) {
           // Always send thinkingConfig for Gemini 2.5: 0=disabled, -1=unlimited, otherwise token count
-          const gemini25Budgets: Record<ReasoningEffort, number> = { off: 0, low: 2048, medium: -1, high: 8196 }
+          const gemini25Budgets: Record<ReasoningEffort, number> = {
+            off: 0,
+            low: 2048,
+            medium: -1,
+            high: 8196,
+          }
           options = {
             ...options,
             thinkingConfig: {
@@ -168,7 +173,9 @@ export function buildProviderOptions(
         } else if (reasoningEffort) {
           const isGemma = preset.model.toLowerCase().includes('gemma')
           const thinkingLevel = isGemma
-            ? reasoningEffort === 'high' ? 'high' : 'minimal'
+            ? reasoningEffort === 'high'
+              ? 'high'
+              : 'minimal'
             : reasoningEffort
           options = {
             ...options,

--- a/src/lib/services/ai/sdk/generate.ts
+++ b/src/lib/services/ai/sdk/generate.ts
@@ -148,21 +148,33 @@ export function buildProviderOptions(
           options = { thinking: { type: 'enabled' } } satisfies DeepSeekChatOptions
         }
         break
-      case 'google':
+      case 'google': {
         // Reinject safety settings here for complete model-request coverage
         options = {
           safetySettings: GOOGLE_SAFETY_SETTINGS,
         } satisfies GoogleGenerativeAIProviderOptions
-        if (reasoningEffort) {
-          // Gemini 2.5 uses thinkingBudget (token count), Gemini 3.x uses thinkingLevel
-          const usesBudget = modelInfo?.isBudgetReasoning ?? preset.model.includes('gemini-2.5')
+        // Gemini 2.5 uses thinkingBudget; Gemma 4 uses minimal/high; Gemini 3.x uses low/medium/high
+        const usesBudget = modelInfo?.isBudgetReasoning ?? preset.model.includes('gemini-2.5')
+        if (usesBudget) {
+          // Always send thinkingConfig for Gemini 2.5: 0=disabled, -1=unlimited, otherwise token count
+          const gemini25Budgets: Record<ReasoningEffort, number> = { off: 0, low: 2048, medium: -1, high: 8196 }
           options = {
             ...options,
             thinkingConfig: {
               includeThoughts: true,
-              ...(usesBudget
-                ? { thinkingBudget: budgetTokens }
-                : { thinkingLevel: reasoningEffort }),
+              thinkingBudget: gemini25Budgets[preset.reasoningEffort],
+            },
+          } satisfies GoogleGenerativeAIProviderOptions
+        } else if (reasoningEffort) {
+          const isGemma = preset.model.toLowerCase().includes('gemma')
+          const thinkingLevel = isGemma
+            ? reasoningEffort === 'high' ? 'high' : 'minimal'
+            : reasoningEffort
+          options = {
+            ...options,
+            thinkingConfig: {
+              includeThoughts: true,
+              thinkingLevel,
             },
           } satisfies GoogleGenerativeAIProviderOptions
         }
@@ -170,6 +182,7 @@ export function buildProviderOptions(
           options = { ...options, structuredOutputs } satisfies GoogleGenerativeAIProviderOptions
         }
         break
+      }
       case 'pollinations':
         options = {
           reasoning_effort: reasoningEffort,

--- a/src/lib/services/ai/sdk/providers/modelFetcher.ts
+++ b/src/lib/services/ai/sdk/providers/modelFetcher.ts
@@ -175,6 +175,11 @@ async function fetchAnthropicModels(baseUrl?: string, apiKey?: string): Promise<
   }
 }
 
+/** Models with -image in the ID or nano-banana in the ID are image generation models, not text */
+export function isGoogleImageModel(id: string): boolean {
+  return id.includes('-image') || id.includes('nano-banana')
+}
+
 interface GoogleModelEntry {
   name: string
   supportedGenerationMethods?: string[]
@@ -201,7 +206,7 @@ async function fetchGoogleModels(baseUrl?: string, apiKey?: string): Promise<Tex
     return getGoogleFallback()
   }
 
-  const modelsUrl = effectiveBaseUrl.replace(/\/$/, '') + '/models?key=' + apiKey
+  const modelsUrl = effectiveBaseUrl.replace(/\/$/, '') + '/models?key=' + apiKey + '&pageSize=200'
 
   try {
     const fetchFn = createTimeoutFetch(30000, 'model-fetch')
@@ -216,6 +221,7 @@ async function fetchGoogleModels(baseUrl?: string, apiKey?: string): Promise<Tex
     if (data.models && Array.isArray(data.models)) {
       const models = (data.models as GoogleModelEntry[])
         .filter((m) => m.supportedGenerationMethods?.includes('generateContent'))
+        .filter((m) => !isGoogleImageModel(m.name.replace(/^models\//, '')))
         .map((m) => {
           const id = m.name.replace(/^models\//, '')
           // Gemini 2.5 uses thinkingBudget (token count), Gemini 3.x uses thinkingLevel

--- a/src/lib/services/ai/sdk/providers/modelFetcher.ts
+++ b/src/lib/services/ai/sdk/providers/modelFetcher.ts
@@ -206,7 +206,7 @@ async function fetchGoogleModels(baseUrl?: string, apiKey?: string): Promise<Tex
     return getGoogleFallback()
   }
 
-  const modelsUrl = effectiveBaseUrl.replace(/\/$/, '') + '/models?key=' + apiKey + '&pageSize=200'
+  const modelsUrl = effectiveBaseUrl.replace(/\/$/, '') + '/models?key=' + encodeURIComponent(apiKey) + '&pageSize=200'
 
   try {
     const fetchFn = createTimeoutFetch(30000, 'model-fetch')

--- a/src/lib/services/ai/sdk/providers/modelFetcher.ts
+++ b/src/lib/services/ai/sdk/providers/modelFetcher.ts
@@ -206,7 +206,11 @@ async function fetchGoogleModels(baseUrl?: string, apiKey?: string): Promise<Tex
     return getGoogleFallback()
   }
 
-  const modelsUrl = effectiveBaseUrl.replace(/\/$/, '') + '/models?key=' + encodeURIComponent(apiKey) + '&pageSize=200'
+  const modelsUrl =
+    effectiveBaseUrl.replace(/\/$/, '') +
+    '/models?key=' +
+    encodeURIComponent(apiKey) +
+    '&pageSize=200'
 
   try {
     const fetchFn = createTimeoutFetch(30000, 'model-fetch')


### PR DESCRIPTION
- Fix thinkingConfig for Google models: correct level mapping per model family — Gemini 2.5 uses thinkingBudget (0 = disabled, -1 = unlimited, with per-effort budgets), Gemini 3.x uses thinkingLevel (low/medium/high), Gemma 4 uses thinkingLevel (minimal/high only).
- Dynamic image model fetching: Google image models are now fetched from the same /models?pageSize=200 endpoint used for text, filtered by predict method or -image/nano-banana in the model ID. Hardcoded list replaced with live data + fallback.
- Rewrite Google image provider: replaces direct HTTP :predict calls with the Vercel AI SDK's generateImage() + google.image(). Supports Imagen 4/Ultra/Fast and all Gemini image models (gemini-*-image, nano-banana-*) transparently through the same code path.
- isGoogleImageModel() helper: Gemini image models are excluded from the text model list and included in the image model list instead.
- Imagen 4 img2img support: imagen-4.0-generate-001 now correctly reports supportsImg2Img: true.
- Reference profile UX: removed the model filter on the reference profile selector (all models now visible); replaced with an inline warning when the selected model doesn't support img2img.
- Rename provider label from Google Imagen to Google AI Studio.