### PR TITLE
Add A1111/Forge/KoboldCPP image provider + image gen model fetch fixes

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,9 +8,7 @@
     "devUrl": "http://localhost:1420",
     "beforeBuildCommand": "npm run build",
     "frontendDist": "../build",
-    "features": [
-      "devtools"
-    ]
+    "features": ["devtools"]
   },
   "app": {
     "windows": [

--- a/src/lib/components/settings/tabs/images.svelte
+++ b/src/lib/components/settings/tabs/images.svelte
@@ -12,7 +12,7 @@
   import {
     listImageModels,
     listImageModelsByProvider,
-    getComfySamplerInfo,
+    getProviderSamplerInfo,
     listLoras,
     generateImage,
     ComfyMode,
@@ -382,13 +382,16 @@
           loadLoras(baseUrl || undefined)
         } else if (providerType === 'a1111') {
           loadSamplerInfo(baseUrl || undefined, 'a1111')
+        } else {
+          profileSamplers = []
+          profileSchedulers = []
         }
       })
     }
   })
 
   async function loadSamplerInfo(baseUrl?: string, providerType: 'comfyui' | 'a1111' = 'comfyui') {
-    const info = await getComfySamplerInfo(baseUrl, providerType)
+    const info = await getProviderSamplerInfo(baseUrl, providerType)
     if ((profileBaseUrl || undefined) !== baseUrl) return
     profileSamplers = info.samplers.map((s) => ({ value: s, label: s }))
     profileSchedulers = info.schedulers.map((s) => ({ value: s, label: s }))

--- a/src/lib/components/settings/tabs/images.svelte
+++ b/src/lib/components/settings/tabs/images.svelte
@@ -70,6 +70,7 @@
     { value: 'google', label: 'Google AI Studio' },
     { value: 'zhipu', label: 'Zhipu CogView' },
     { value: 'comfyui', label: 'ComfyUI' },
+    { value: 'a1111', label: 'A1111 / SD.cpp / Kobold' },
   ]
   const profileModes = [
     { value: ComfyMode.CustomWorkflow, label: 'Custom Workflow' },
@@ -333,20 +334,26 @@
   // Derived LoRA items — avoids re-mapping on every render
   const loraItems = $derived(availableLoras.map((l) => ({ value: l, label: l })))
 
-  // Load models for the profile form when provider/apiKey change
+  // Load models for the profile form when provider/apiKey/baseUrl change
   let profileModelsReqId = 0
 
   async function loadProfileFormModels(
     providerType: ImageProviderType,
     apiKey: string,
+    baseUrl: string,
     forceReload: boolean,
   ) {
-    const baseUrl = profileBaseUrl || undefined
+    const effectiveBaseUrl = baseUrl || undefined
     const reqId = ++profileModelsReqId
     isLoadingProfileModels = true
     profileModelsError = null
     try {
-      const models = await listImageModelsByProvider(providerType, apiKey, forceReload, baseUrl)
+      const models = await listImageModelsByProvider(
+        providerType,
+        apiKey,
+        forceReload,
+        effectiveBaseUrl,
+      )
       // Discard stale results if a newer request has already started.
       if (reqId !== profileModelsReqId) return
       profileModels = models
@@ -359,22 +366,29 @@
   }
 
   // Reactively load models when provider, apiKey, or (for ComfyUI) baseUrl changes in profile form.
-  // No loadingInEffect guard — stale-result checks inside each loader discard superseded results;
-  // the registry cache deduplicates concurrent requests for the same endpoint.
+  // Reactive deps are captured explicitly before untrack() so that reads inside the loader
+  // functions (e.g. settings.apiSettings.llmTimeoutMs) are NOT accidentally tracked as
+  // dependencies — which would cause the effect to re-run on unrelated settings changes.
   $effect(() => {
     if (editingProfileId && profileProviderType) {
-      // Touch profileBaseUrl so Svelte tracks it; ComfyUI models depend on the endpoint.
-      void profileBaseUrl
-      loadProfileFormModels(profileProviderType, profileApiKey, false)
-      if (profileProviderType === 'comfyui') {
-        loadSamplerInfo(profileBaseUrl || undefined)
-        loadLoras(profileBaseUrl || undefined)
-      }
+      const providerType = profileProviderType
+      const apiKey = profileApiKey
+      const baseUrl = profileBaseUrl
+
+      untrack(() => {
+        loadProfileFormModels(providerType, apiKey, baseUrl, false)
+        if (providerType === 'comfyui') {
+          loadSamplerInfo(baseUrl || undefined, 'comfyui')
+          loadLoras(baseUrl || undefined)
+        } else if (providerType === 'a1111') {
+          loadSamplerInfo(baseUrl || undefined, 'a1111')
+        }
+      })
     }
   })
 
-  async function loadSamplerInfo(baseUrl?: string) {
-    const info = await getComfySamplerInfo(baseUrl)
+  async function loadSamplerInfo(baseUrl?: string, providerType: 'comfyui' | 'a1111' = 'comfyui') {
+    const info = await getComfySamplerInfo(baseUrl, providerType)
     if ((profileBaseUrl || undefined) !== baseUrl) return
     profileSamplers = info.samplers.map((s) => ({ value: s, label: s }))
     profileSchedulers = info.schedulers.map((s) => ({ value: s, label: s }))
@@ -425,6 +439,15 @@
 
   // Builds the provider-specific options object from current form state
   function buildProviderOptions(): Record<string, any> {
+    if (profileProviderType === 'a1111') {
+      return {
+        steps: profileSteps,
+        cfg: profileCfg,
+        negativePrompt: profileNegativePrompt,
+        sampler: profileSampler,
+        scheduler: profileScheduler,
+      }
+    }
     if (profileProviderType !== 'comfyui') return {}
     const opts: Record<string, any> = {
       sampler: profileSampler,
@@ -492,6 +515,7 @@
         profileVaeName,
         profileClipType,
         profileWeightDtype,
+        // a1111 fields reuse profileSteps, profileCfg, profileNegativePrompt, profileSampler
       ]
       // Skip the first run after startEditProfile populates the form
       if (suppressAutoSave) {
@@ -522,8 +546,8 @@
     profileSampler = 'dpmpp_2m_sde_gpu'
     profileScheduler = 'sgm_uniform'
     profileMode = ComfyMode.BasicTxt2Img
-    profileCfg = 1
-    profileSteps = 6
+    profileCfg = 7
+    profileSteps = 20
     profilePositivePrompt = ''
     profileNegativePrompt = ''
     prevComfyBaseUrl = null
@@ -558,6 +582,15 @@
     profileBaseUrl = profile.baseUrl || ''
     profileModel = profile.model || ''
     profileModels = []
+
+    if (profile.providerType === 'a1111') {
+      const opts = profile.providerOptions || {}
+      profileSteps = Number(opts.steps) || 20
+      profileCfg = Number(opts.cfg) || 7
+      profileNegativePrompt = (opts.negativePrompt as string) || ''
+      profileSampler = (opts.sampler as string) || 'Euler a'
+      profileScheduler = (opts.scheduler as string) || 'karras'
+    }
 
     if (profile.providerType === 'comfyui') {
       const opts = profile.providerOptions || {}
@@ -768,7 +801,7 @@
   // Auto-load when switching to UNet mode
   $effect(() => {
     if (profileMode === ComfyMode.UnetTxt2Img && availableClips.length === 0) {
-      void loadUnetModels()
+      untrack(() => void loadUnetModels())
     }
   })
 
@@ -1313,8 +1346,8 @@
       />
     </div>
 
-    <!-- comfy doesnt use API keys -->
-    {#if profileProviderType !== 'comfyui'}
+    <!-- comfy and a1111 don't require API keys -->
+    {#if profileProviderType !== 'comfyui' && profileProviderType !== 'a1111'}
       <div class="space-y-2">
         <Label>API Key</Label>
         <div class="flex gap-2">
@@ -1367,7 +1400,7 @@
       </div>
     {/if}
 
-    {#if profileProviderType === 'comfyui' || profileProviderType === 'openai' || profileProviderType === 'zhipu'}
+    {#if profileProviderType === 'comfyui' || profileProviderType === 'openai' || profileProviderType === 'zhipu' || profileProviderType === 'a1111'}
       <div class="space-y-2">
         <Label>Base URL (optional)</Label>
         <Input bind:value={profileBaseUrl} placeholder="Custom base URL" />
@@ -1389,7 +1422,8 @@
         isLoading={isLoadingProfileModels}
         errorMessage={profileModelsError}
         showRefreshButton={true}
-        onRefresh={() => loadProfileFormModels(profileProviderType, profileApiKey, true)}
+        onRefresh={() =>
+          loadProfileFormModels(profileProviderType, profileApiKey, profileBaseUrl, true)}
       />
       {#if referenceProfileImg2ImgWarning}
         <p class="text-warning mt-1 text-xs">
@@ -1403,9 +1437,54 @@
       {/if}
     {/snippet}
 
-    {#if profileProviderType !== 'comfyui'}
+    {#if profileProviderType !== 'comfyui' && profileProviderType !== 'a1111'}
       <div class="space-y-2">
         {@render modelSelectContent()}
+      </div>
+    {/if}
+    {#if profileProviderType === 'a1111'}
+      <div class="space-y-2">
+        {@render modelSelectContent()}
+      </div>
+      <div class="grid grid-cols-2 gap-4 pt-2">
+        <div class="space-y-2">
+          <Label>Steps</Label>
+          <Input type="number" bind:value={profileSteps} placeholder="20" min="1" />
+        </div>
+        <div class="space-y-2">
+          <Label>CFG Scale</Label>
+          <Input type="number" bind:value={profileCfg} placeholder="7" step="0.5" />
+        </div>
+        <div class="space-y-2">
+          <Label>Sampler</Label>
+          <Autocomplete
+            items={profileSamplers}
+            selected={profileSamplers.find((s) => s.value === profileSampler)}
+            onSelect={(v) => {
+              profileSampler = (v as { value: string }).value
+            }}
+            itemLabel={(s: { label: string }) => s.label}
+            itemValue={(s: { value: string }) => s.value}
+            placeholder="Euler a"
+          />
+        </div>
+        <div class="space-y-2">
+          <Label>Scheduler</Label>
+          <Autocomplete
+            items={profileSchedulers}
+            selected={profileSchedulers.find((s) => s.value === profileScheduler)}
+            onSelect={(v) => {
+              profileScheduler = (v as { value: string }).value
+            }}
+            itemLabel={(s: { label: string }) => s.label}
+            itemValue={(s: { value: string }) => s.value}
+            placeholder="karras"
+          />
+        </div>
+        <div class="col-span-2 space-y-2">
+          <Label>Negative Prompt</Label>
+          <Textarea bind:value={profileNegativePrompt} placeholder="Negative prompt..." />
+        </div>
       </div>
     {/if}
     {#if profileProviderType === 'comfyui'}

--- a/src/lib/services/ai/image/index.ts
+++ b/src/lib/services/ai/image/index.ts
@@ -25,7 +25,7 @@ export {
   generateImage,
   listImageModels,
   listImageModelsByProvider,
-  getComfySamplerInfo,
+  getProviderSamplerInfo,
   listLoras,
   clearModelsCache,
   supportsImageGeneration,

--- a/src/lib/services/ai/image/providers/a1111.ts
+++ b/src/lib/services/ai/image/providers/a1111.ts
@@ -109,18 +109,25 @@ export function createA1111Provider(config: ImageProviderConfig): ImageProvider 
         }),
       ])
 
+      const toNames = (data: unknown): string[] =>
+        Array.isArray(data)
+          ? (data as { name?: string }[]).map((s) => s.name ?? '').filter(Boolean)
+          : []
+
       const samplers: string[] =
         samplersRes.status === 'fulfilled'
-          ? ((await samplersRes.value.json()) as { name?: string }[])
-              .map((s) => s.name ?? '')
-              .filter(Boolean)
+          ? await samplersRes.value
+              .json()
+              .then(toNames)
+              .catch(() => [])
           : []
 
       const schedulers: string[] =
         schedulersRes.status === 'fulfilled'
-          ? ((await schedulersRes.value.json()) as { name?: string }[])
-              .map((s) => s.name ?? '')
-              .filter(Boolean)
+          ? await schedulersRes.value
+              .json()
+              .then(toNames)
+              .catch(() => [])
           : []
 
       return { samplers, schedulers }

--- a/src/lib/services/ai/image/providers/a1111.ts
+++ b/src/lib/services/ai/image/providers/a1111.ts
@@ -1,0 +1,129 @@
+/**
+ * A1111 / Stable Diffusion WebUI Image Provider
+ *
+ * Compatible with AUTOMATIC1111, Forge, and KoboldCPP's SD image generation API.
+ * - txt2img: POST /sdapi/v1/txt2img
+ * - Models:  GET  /sdapi/v1/sd-models
+ */
+
+import type {
+  ImageProvider,
+  ImageProviderConfig,
+  ImageGenerateOptions,
+  ImageGenerateResult,
+  ImageModelInfo,
+  ComfySamplerInfo,
+} from './types'
+import { imageFetch, imageGetFetch } from './fetchAdapter'
+
+const DEFAULT_BASE_URL = 'http://localhost:7860'
+
+export function createA1111Provider(config: ImageProviderConfig): ImageProvider {
+  const baseUrl = config.baseUrl?.trim().replace(/\/$/, '') || DEFAULT_BASE_URL
+
+  return {
+    id: 'a1111',
+    name: 'A1111 / SD WebUI',
+
+    async generate(options: ImageGenerateOptions): Promise<ImageGenerateResult> {
+      const { model, prompt, size, signal, providerOptions } = options
+      const [width, height] = (size || '512x512').split('x').map(Number)
+
+      const opts = providerOptions ?? config.providerOptions ?? {}
+      const steps = Number(opts.steps) || 20
+      const cfgScale = Number(opts.cfg) || 7
+      const sampler = (opts.sampler as string) || 'Euler a'
+      const scheduler = (opts.scheduler as string) || undefined
+      const negativePrompt = (opts.negativePrompt as string) || ''
+
+      const body: Record<string, unknown> = {
+        prompt,
+        negative_prompt: negativePrompt,
+        width: width || 512,
+        height: height || 512,
+        steps,
+        cfg_scale: cfgScale,
+        sampler_name: sampler,
+        batch_size: 1,
+        n_iter: 1,
+        seed: -1,
+      }
+
+      if (scheduler) body.scheduler = scheduler
+
+      if (model) {
+        body.override_settings = { sd_model_checkpoint: model }
+        body.override_settings_restore_afterwards = true
+      }
+
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+      if (config.apiKey) headers.Authorization = `Bearer ${config.apiKey}`
+
+      const response = await imageFetch({
+        url: `${baseUrl}/sdapi/v1/txt2img`,
+        headers,
+        body: JSON.stringify(body),
+        signal,
+        serviceId: 'a1111-image',
+      })
+
+      const data = await response.json()
+      const base64 = data?.images?.[0]
+      if (!base64) throw new Error('No image data in A1111 response')
+
+      return { base64 }
+    },
+
+    async listModels(apiKey: string): Promise<ImageModelInfo[]> {
+      const headers: Record<string, string> = {}
+      if (apiKey) headers.Authorization = `Bearer ${apiKey}`
+
+      try {
+        const response = await imageGetFetch(`${baseUrl}/sdapi/v1/sd-models`, headers, {
+          serviceId: 'a1111-models',
+        })
+        const data: { title?: string; model_name?: string; name?: string }[] = await response.json()
+
+        return (Array.isArray(data) ? data : []).map((m) => ({
+          id: m.title || m.model_name || m.name || '',
+          name: m.title || m.model_name || m.name || '',
+          supportsSizes: [],
+          supportsImg2Img: false,
+        }))
+      } catch {
+        return []
+      }
+    },
+
+    async getSamplerInfo(): Promise<ComfySamplerInfo> {
+      const authHeaders: Record<string, string> | undefined = config.apiKey
+        ? { Authorization: `Bearer ${config.apiKey}` }
+        : undefined
+
+      const [samplersRes, schedulersRes] = await Promise.allSettled([
+        imageGetFetch(`${baseUrl}/sdapi/v1/samplers`, authHeaders, {
+          serviceId: 'a1111-samplers',
+        }),
+        imageGetFetch(`${baseUrl}/sdapi/v1/schedulers`, authHeaders, {
+          serviceId: 'a1111-schedulers',
+        }),
+      ])
+
+      const samplers: string[] =
+        samplersRes.status === 'fulfilled'
+          ? ((await samplersRes.value.json()) as { name?: string }[])
+              .map((s) => s.name ?? '')
+              .filter(Boolean)
+          : []
+
+      const schedulers: string[] =
+        schedulersRes.status === 'fulfilled'
+          ? ((await schedulersRes.value.json()) as { name?: string }[])
+              .map((s) => s.name ?? '')
+              .filter(Boolean)
+          : []
+
+      return { samplers, schedulers }
+    },
+  }
+}

--- a/src/lib/services/ai/image/providers/openai.ts
+++ b/src/lib/services/ai/image/providers/openai.ts
@@ -21,30 +21,6 @@ import { imageFetch, imageGetFetch } from './fetchAdapter'
 
 const DEFAULT_BASE_URL = 'https://api.openai.com/v1'
 
-// Metadata for known OpenAI image models — used to enrich API-fetched results
-const KNOWN_IMAGE_MODELS: Record<string, Omit<ImageModelInfo, 'id' | 'name'>> = {
-  'dall-e-3': {
-    description: 'High quality image generation',
-    supportsSizes: ['1024x1024', '1024x1792', '1792x1024'],
-    supportsImg2Img: false,
-  },
-  'dall-e-2': {
-    description: 'Image generation with editing support',
-    supportsSizes: ['256x256', '512x512', '1024x1024'],
-    supportsImg2Img: true,
-  },
-  'gpt-image-1': {
-    description: 'GPT-powered image generation',
-    supportsSizes: ['1024x1024', '1024x1792', '1792x1024'],
-    supportsImg2Img: true,
-  },
-  'gpt-image-2': {
-    description: 'GPT-powered image generation (latest)',
-    supportsSizes: ['1024x1024', '1024x1792', '1792x1024'],
-    supportsImg2Img: true,
-  },
-}
-
 // Prefixes used to identify image-capable models in the /v1/models response
 const IMAGE_MODEL_PREFIXES = ['dall-e-', 'gpt-image-']
 
@@ -107,25 +83,29 @@ export function createOpenAIProvider(config: ImageProviderConfig): ImageProvider
 }
 
 async function fetchOpenAIImageModels(baseUrl: string, apiKey: string): Promise<ImageModelInfo[]> {
-  const response = await imageGetFetch(
-    `${baseUrl}/models`,
-    apiKey ? { Authorization: `Bearer ${apiKey}` } : undefined,
-    { serviceId: 'openai-image-models' },
-  )
-  const data = await response.json()
-  const entries: { id?: string }[] = Array.isArray(data?.data) ? data.data : []
+  try {
+    const response = await imageGetFetch(
+      `${baseUrl}/models`,
+      apiKey ? { Authorization: `Bearer ${apiKey}` } : undefined,
+      { serviceId: 'openai-image-models' },
+    )
+    const data = await response.json()
+    const entries: { id?: string }[] = Array.isArray(data?.data) ? data.data : []
 
-  return entries
-    .filter((m) => m.id && IMAGE_MODEL_PREFIXES.some((prefix) => m.id!.startsWith(prefix)))
-    .map((m) => {
-      const id = m.id!
-      const known = KNOWN_IMAGE_MODELS[id]
-      return {
-        id,
-        name: id,
-        ...(known ?? { supportsSizes: [], supportsImg2Img: false }),
-      }
-    })
+    return entries
+      .filter((m) => m.id && IMAGE_MODEL_PREFIXES.some((prefix) => m.id!.startsWith(prefix)))
+      .map((m) => {
+        const id = m.id!
+        return {
+          id,
+          name: id,
+          supportsSizes: ['512x512', '1024x1024'],
+          supportsImg2Img: true,
+        }
+      })
+  } catch {
+    return []
+  }
 }
 
 async function fetchCustomModels(baseUrl: string, apiKey: string): Promise<ImageModelInfo[]> {

--- a/src/lib/services/ai/image/providers/openai.ts
+++ b/src/lib/services/ai/image/providers/openai.ts
@@ -4,6 +4,10 @@
  * Direct HTTP calls to OpenAI-compatible image APIs.
  * - txt2img: POST /images/generations (JSON)
  * - img2img: POST /images/edits (FormData)
+ *
+ * Models are fetched live from {baseUrl}/models and filtered by image-capable prefixes.
+ * Known models are enriched with size/img2img metadata; unknown future models get defaults.
+ * Falls back to a hardcoded list if the API call fails.
  */
 
 import type {
@@ -13,12 +17,40 @@ import type {
   ImageGenerateResult,
   ImageModelInfo,
 } from './types'
-import { imageFetch } from './fetchAdapter'
+import { imageFetch, imageGetFetch } from './fetchAdapter'
 
 const DEFAULT_BASE_URL = 'https://api.openai.com/v1'
 
+// Metadata for known OpenAI image models — used to enrich API-fetched results
+const KNOWN_IMAGE_MODELS: Record<string, Omit<ImageModelInfo, 'id' | 'name'>> = {
+  'dall-e-3': {
+    description: 'High quality image generation',
+    supportsSizes: ['1024x1024', '1024x1792', '1792x1024'],
+    supportsImg2Img: false,
+  },
+  'dall-e-2': {
+    description: 'Image generation with editing support',
+    supportsSizes: ['256x256', '512x512', '1024x1024'],
+    supportsImg2Img: true,
+  },
+  'gpt-image-1': {
+    description: 'GPT-powered image generation',
+    supportsSizes: ['1024x1024', '1024x1792', '1792x1024'],
+    supportsImg2Img: true,
+  },
+  'gpt-image-2': {
+    description: 'GPT-powered image generation (latest)',
+    supportsSizes: ['1024x1024', '1024x1792', '1792x1024'],
+    supportsImg2Img: true,
+  },
+}
+
+// Prefixes used to identify image-capable models in the /v1/models response
+const IMAGE_MODEL_PREFIXES = ['dall-e-', 'gpt-image-']
+
 export function createOpenAIProvider(config: ImageProviderConfig): ImageProvider {
-  const baseUrl = config.baseUrl || DEFAULT_BASE_URL
+  const baseUrl = config.baseUrl?.trim().replace(/\/$/, '') || DEFAULT_BASE_URL
+  const isCustomEndpoint = !!config.baseUrl?.trim()
 
   return {
     id: 'openai',
@@ -51,7 +83,7 @@ export function createOpenAIProvider(config: ImageProviderConfig): ImageProvider
         url: `${baseUrl}/images/generations`,
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${config.apiKey}`,
+          ...(config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : {}),
         },
         body: JSON.stringify(body),
         signal,
@@ -65,9 +97,61 @@ export function createOpenAIProvider(config: ImageProviderConfig): ImageProvider
       return { base64: imageData.b64_json, revisedPrompt: imageData.revised_prompt }
     },
 
-    async listModels(): Promise<ImageModelInfo[]> {
-      return getOpenAIModels()
+    async listModels(apiKey: string): Promise<ImageModelInfo[]> {
+      if (isCustomEndpoint) {
+        return fetchCustomModels(baseUrl, apiKey)
+      }
+      return fetchOpenAIImageModels(baseUrl, apiKey)
     },
+  }
+}
+
+async function fetchOpenAIImageModels(baseUrl: string, apiKey: string): Promise<ImageModelInfo[]> {
+  const response = await imageGetFetch(
+    `${baseUrl}/models`,
+    apiKey ? { Authorization: `Bearer ${apiKey}` } : undefined,
+    { serviceId: 'openai-image-models' },
+  )
+  const data = await response.json()
+  const entries: { id?: string }[] = Array.isArray(data?.data) ? data.data : []
+
+  return entries
+    .filter((m) => m.id && IMAGE_MODEL_PREFIXES.some((prefix) => m.id!.startsWith(prefix)))
+    .map((m) => {
+      const id = m.id!
+      const known = KNOWN_IMAGE_MODELS[id]
+      return {
+        id,
+        name: id,
+        ...(known ?? { supportsSizes: [], supportsImg2Img: false }),
+      }
+    })
+}
+
+async function fetchCustomModels(baseUrl: string, apiKey: string): Promise<ImageModelInfo[]> {
+  try {
+    const response = await imageGetFetch(
+      `${baseUrl}/models`,
+      apiKey ? { Authorization: `Bearer ${apiKey}` } : undefined,
+      { serviceId: 'openai-image-models' },
+    )
+    const data = await response.json()
+    const entries: { id?: string; name?: string }[] = Array.isArray(data)
+      ? data
+      : Array.isArray(data?.data)
+        ? data.data
+        : []
+
+    return entries
+      .filter((m) => m.id || m.name)
+      .map((m) => ({
+        id: m.id || m.name || '',
+        name: m.name || m.id || '',
+        supportsSizes: [],
+        supportsImg2Img: false,
+      }))
+  } catch {
+    return []
   }
 }
 
@@ -95,7 +179,7 @@ async function generateWithEdits(
   const response = await imageFetch({
     url: `${baseUrl}/images/edits`,
     headers: {
-      Authorization: `Bearer ${apiKey}`,
+      ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
       // Don't set Content-Type - let FormData set the boundary
     },
     body: formData,
@@ -108,30 +192,4 @@ async function generateWithEdits(
   if (!imageData?.b64_json) throw new Error('No image data in OpenAI edits response')
 
   return { base64: imageData.b64_json, revisedPrompt: imageData.revised_prompt }
-}
-
-function getOpenAIModels(): ImageModelInfo[] {
-  return [
-    {
-      id: 'dall-e-3',
-      name: 'DALL-E 3',
-      description: 'High quality image generation',
-      supportsSizes: ['1024x1024', '1024x1792', '1792x1024'],
-      supportsImg2Img: false,
-    },
-    {
-      id: 'dall-e-2',
-      name: 'DALL-E 2',
-      description: 'Image generation with editing support',
-      supportsSizes: ['256x256', '512x512', '1024x1024'],
-      supportsImg2Img: true,
-    },
-    {
-      id: 'gpt-image-1',
-      name: 'GPT Image 1',
-      description: 'GPT-powered image generation',
-      supportsSizes: ['1024x1024', '1024x1792', '1792x1024'],
-      supportsImg2Img: true,
-    },
-  ]
 }

--- a/src/lib/services/ai/image/providers/registry.ts
+++ b/src/lib/services/ai/image/providers/registry.ts
@@ -155,7 +155,7 @@ export async function listImageModels(profileId: string): Promise<ImageModelInfo
     }
     const provider = PROVIDER_FACTORIES[profile.providerType](config)
     const models = await provider.listModels(profile.apiKey)
-    if (models.length > 0) modelCaches.set(cacheKey, { models, timestamp: Date.now() })
+    modelCaches.set(cacheKey, { models, timestamp: Date.now() })
     return models
   } catch (error) {
     log('Error listing models', { providerType: profile.providerType, error })
@@ -189,7 +189,7 @@ export async function listImageModelsByProvider(
     }
     const provider = PROVIDER_FACTORIES[providerType](config)
     const models = await provider.listModels(apiKey)
-    if (models.length > 0) modelCaches.set(cacheKey, { models, timestamp: Date.now() })
+    modelCaches.set(cacheKey, { models, timestamp: Date.now() })
     return models
   } catch (error) {
     log('Error listing models by provider', { providerType, error })
@@ -200,7 +200,7 @@ export async function listImageModelsByProvider(
 /**
  * Get sampler/scheduler info for a ComfyUI or A1111 provider.
  */
-export async function getComfySamplerInfo(
+export async function getProviderSamplerInfo(
   baseUrl?: string,
   providerType: 'comfyui' | 'a1111' = 'comfyui',
 ): Promise<{ samplers: string[]; schedulers: string[] }> {

--- a/src/lib/services/ai/image/providers/registry.ts
+++ b/src/lib/services/ai/image/providers/registry.ts
@@ -25,6 +25,7 @@ import { createGoogleProvider } from './google'
 import { createZhipuProvider } from './zhipu'
 import { createComfyProvider } from './comfy'
 import { createOpenRouterProvider } from './openrouter'
+import { createA1111Provider } from './a1111'
 
 const log = createLogger('ImageRegistry')
 
@@ -43,6 +44,7 @@ const PROVIDER_FACTORIES: Record<ImageProviderType, ProviderFactory> = {
   google: createGoogleProvider,
   zhipu: createZhipuProvider,
   comfyui: createComfyProvider,
+  a1111: createA1111Provider,
 }
 
 // ============================================================================
@@ -196,10 +198,11 @@ export async function listImageModelsByProvider(
 }
 
 /**
- * Get sampler info for a ComfyUI provider.
+ * Get sampler/scheduler info for a ComfyUI or A1111 provider.
  */
 export async function getComfySamplerInfo(
   baseUrl?: string,
+  providerType: 'comfyui' | 'a1111' = 'comfyui',
 ): Promise<{ samplers: string[]; schedulers: string[] }> {
   try {
     const config: ImageProviderConfig = {
@@ -207,7 +210,8 @@ export async function getComfySamplerInfo(
       baseUrl,
       timeoutMs: settings.apiSettings.llmTimeoutMs,
     }
-    const provider = createComfyProvider(config)
+    const provider =
+      providerType === 'a1111' ? createA1111Provider(config) : createComfyProvider(config)
     if (provider.getSamplerInfo) {
       return await provider.getSamplerInfo()
     }

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -764,6 +764,7 @@ export type ImageProviderType =
   | 'google'
   | 'zhipu'
   | 'comfyui'
+  | 'a1111'
 
 export interface ImageProfile {
   id: string


### PR DESCRIPTION
- Adds a new a1111 image provider compatible with AUTOMATIC1111, Forge, SD.cpp and Koboldcpp.
- Sampler and scheduler lists are fetched live from the running server (same pattern as ComfyUI), so the dropdowns always reflect what the instance actually supports
- Fixes several issues in the OpenAI provider introduced alongside it: model list is now fetched from /v1/models (filtered by dall-e- / gpt-image- prefix), custom endpoints get a permissive fallback
- fixes image gen model fetch bug (infinite loop)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added A1111/Stable Diffusion WebUI as a selectable image provider with provider-specific options (base URL, steps, CFG scale, sampler, scheduler, negative prompt) and updated profile defaults.

* **Enhancements**
  * OpenAI image provider now fetches available models live and handles custom endpoints; API key usage is applied only when provided.
  * Improved model-listing responsiveness and sampler/scheduler discovery across providers.

* **Chores**
  * Minor build configuration formatting update.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AventurasTeam/Aventuras/pull/324)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->