### PR TITLE
fix(lorebook): prevent substring matching for keywords, check for Asian characters also

### DIFF
--- a/src/lib/services/ai/retrieval/EntryRetrievalService.ts
+++ b/src/lib/services/ai/retrieval/EntryRetrievalService.ts
@@ -660,7 +660,10 @@ export class EntryRetrievalService extends BaseAIService {
     if (normalized.length < 2) return false
 
     // Check if the keyword contains characters from non-space-separated languages (CJK, Thai, Lao, Khmer, Burmese)
-    const isNonSpaceSeparated = /[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uac00-\ud7af\u0e00-\u0e7f\u0e80-\u0eff\u1780-\u17ff\u1000-\u109f]/.test(normalized)
+    const isNonSpaceSeparated =
+      /[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uac00-\ud7af\u0e00-\u0e7f\u0e80-\u0eff\u1780-\u17ff\u1000-\u109f]/.test(
+        normalized,
+      )
     if (isNonSpaceSeparated) {
       // Non-space-separated languages must use substring matching
       return searchContent.includes(normalized)

--- a/src/lib/services/ai/retrieval/EntryRetrievalService.ts
+++ b/src/lib/services/ai/retrieval/EntryRetrievalService.ts
@@ -659,18 +659,25 @@ export class EntryRetrievalService extends BaseAIService {
     const normalized = text.toLowerCase().trim()
     if (normalized.length < 2) return false
 
-    // Exact match
-    if (searchContent.includes(normalized)) {
-      return true
+    // Check if the keyword contains CJK (Chinese, Japanese, Korean) characters
+    const hasCJK = /[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uac00-\ud7af]/.test(normalized)
+
+    if (hasCJK) {
+      // Non-space-separated languages must use substring matching
+      return searchContent.includes(normalized)
     }
 
-    // Word boundary match
-    const wordPattern = new RegExp(`\\b${escapeRegex(normalized)}\\b`, 'i')
-    if (wordPattern.test(searchContent)) {
-      return true
+    // Dynamic word boundary match for space-separated languages
+    let patternStr = escapeRegex(normalized)
+    if (/^\w/.test(normalized)) {
+      patternStr = '\\b' + patternStr
+    }
+    if (/\w$/.test(normalized)) {
+      patternStr = patternStr + '\\b'
     }
 
-    return false
+    const wordPattern = new RegExp(patternStr, 'i')
+    return wordPattern.test(searchContent)
   }
 
   /**

--- a/src/lib/services/ai/retrieval/EntryRetrievalService.ts
+++ b/src/lib/services/ai/retrieval/EntryRetrievalService.ts
@@ -659,24 +659,21 @@ export class EntryRetrievalService extends BaseAIService {
     const normalized = text.toLowerCase().trim()
     if (normalized.length < 2) return false
 
-    // Check if the keyword contains CJK (Chinese, Japanese, Korean) characters
-    const hasCJK = /[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uac00-\ud7af]/.test(normalized)
-
-    if (hasCJK) {
+    // Check if the keyword contains characters from non-space-separated languages (CJK, Thai, Lao, Khmer, Burmese)
+    const isNonSpaceSeparated = /[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uac00-\ud7af\u0e00-\u0e7f\u0e80-\u0eff\u1780-\u17ff\u1000-\u109f]/.test(normalized)
+    if (isNonSpaceSeparated) {
       // Non-space-separated languages must use substring matching
       return searchContent.includes(normalized)
     }
-
-    // Dynamic word boundary match for space-separated languages
+    // Dynamic Unicode-aware word boundary match for space-separated languages
     let patternStr = escapeRegex(normalized)
-    if (/^\w/.test(normalized)) {
-      patternStr = '\\b' + patternStr
+    if (/^[\p{L}\p{N}]/u.test(normalized)) {
+      patternStr = '(?<![\\p{L}\\p{N}])' + patternStr
     }
-    if (/\w$/.test(normalized)) {
-      patternStr = patternStr + '\\b'
+    if (/[\p{L}\p{N}]$/u.test(normalized)) {
+      patternStr = patternStr + '(?![\\p{L}\\p{N}])'
     }
-
-    const wordPattern = new RegExp(patternStr, 'i')
+    const wordPattern = new RegExp(patternStr, 'iu')
     return wordPattern.test(searchContent)
   }
 


### PR DESCRIPTION
Removed the short-circuiting .includes() check that caused keywords (like 'hulk') to falsely trigger on substrings (like 'madhulkman').

Replaced it with a dynamic regex using \b word boundaries for space-separated languages. Added CJK character detection so that Asian language keywords (which don't use spaces) bypass \b and correctly use substring matching, since \b does not work between CJK characters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyword matching for CJK and other non-space-separated scripts (Chinese, Japanese, Korean, Thai, Lao, Khmer, Burmese) using reliable substring matching.
  * Enhanced boundary-aware matching for space-separated languages to reduce false positives.
  * Refined overall search result relevance across mixed-language queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->