### PR TITLE
fix: use single-page web output, not static SSR

### DIFF
--- a/app.json
+++ b/app.json
@@ -24,7 +24,7 @@
       "package": "com.aventuras.app"
     },
     "web": {
-      "output": "static",
+      "output": "single",
       "favicon": "./assets/images/favicon.png"
     },
     "plugins": [


### PR DESCRIPTION
## Summary
- `expo start --web` was getting stuck in a bundling loop against `@expo/router-server/node/render.js` and OOM-crashing Metro. `"static"` output makes expo-router SSR-render every route on each dev request, which is a known Expo/Metro bundling-loop bug.
- The app is a single-page shell wrapped by Electron (not a multi-page indexed site), so switching `app.json`'s `web.output` from `"static"` to `"single"` avoids the per-request SSR path entirely.

## Test plan
- [x] `pnpm desktop`: web bundle now completes in a single pass (`Web Bundled ... entry.js (5342 modules)`), no repeated 0% re-bundling of `render.js`
- [ ] Confirm Electron window loads and app is usable end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the web build configuration to improve single-page application behavior and deployment compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->