### PR TITLE
plan: M3 — Memory floor (milestone + slices)

### DIFF
--- a/docs/implementation/milestones/03-memory-floor/milestone.md
+++ b/docs/implementation/milestones/03-memory-floor/milestone.md
@@ -1,0 +1,392 @@
+# Milestone 3: Memory floor
+
+## Goal
+
+The memory pipeline is online. Piggyback writes scene metadata and
+per-turn state mutations inline with main generation; the periodic
+classifier reconciles entities, happenings, awareness, and
+relationships in the background; retrieval embeds, ranks, and
+injects relevant context into each turn's prompt under per-type
+budgets. The embedder becomes a hard requirement for story
+creation, the wizard gains its full World and Cast steps, and the
+reader gains suggestions, regenerate, per-entry world-time editing,
+and action-batched undo. Stories made in M3 are coherent across a
+session.
+
+## Why now
+
+Real story data exists from M2; this milestone is where classifier
+prompt engineering and retrieval ranking get their first contact
+with real inputs — validation of the specs in
+[`docs/memory/`](../../../memory/README.md) against live traffic,
+not tuning (tuning waits for the M7.5 probe surface). It lands
+before the rich read surfaces (M4) because those need **populated**
+entity / awareness / happening data to render against: the tables
+and stores exist since M1.5; M3 fills them. It also front-loads the
+one schema-landing job M1.5 deliberately excluded (the per-type
+vec0 `embeddings` virtual tables), after which no v1 milestone
+carries schema work.
+
+## Narrative / overview
+
+Three build tracks run in parallel after day one, converging on the
+classifier as the hub. The **embedding track** lands the substrate
+retrieval stands on: [Slice 3.1a](./slices/01a-embedder-core.md)
+ships the vec0 tables, the local-ONNX and provider embedder
+runtimes behind one service surface, the curated-catalog download
+flow, and the story-creation hard gate (the wizard's Finish now
+embeds cast and lore in its commit transaction);
+[Slice 3.1b](./slices/01b-embedder-lifecycle.md) layers the
+lifecycle machinery on top — stale-row drain worker, the
+crash-safe model-swap flow, staleness UI, and the Matryoshka
+effective-dim machinery. [Slice 3.4](./slices/04-retrieval.md)
+then builds query construction, the pure ranker module, per-type
+budgets, and the memory pack templates — developed against seeded
+rows so it parallelizes with the classifier — and
+[Slice 3.5](./slices/05-dev-probe.md) writes the first
+`probe_captures` and pins the simulator-vs-prod parity test.
+
+The **classifier track** owns the write side.
+[Slice 3.2](./slices/02-piggyback.md) is the per-turn fast path:
+trailing-block parse, scene metadata (including each entry's
+`worldTime` — the roadmap attributed that write to the periodic
+classifier, another stale phrase dropped at promotion; the
+write-set table gives entry metadata to the per-turn layer),
+computed bookkeeping, the
+staged→active fast path, and the per-turn classifier fallback mode
+— **no row creation**; per the canonical write-set split
+([`cadence.md → Concurrency`](../../../memory/cadence.md#concurrency)),
+creation belongs exclusively to
+[Slice 3.3](./slices/03-classifier.md), the background periodic
+classifier: happenings extraction, awareness with severity-judged
+`decay_resistance`, relationship UPSERT-merge, disambiguation with
+the collision flag, provenance stamping into the survival anchor,
+the retry policy with per-branch `classifier_status`, and the
+in-flight classifier barrier for prose reversals. The roadmap
+entry's "stub creation" phrasing for 3.2 was stale against canon
+and is dropped (resolved at promotion). Slice 3.3 also keeps the
+`processedThrough` clamp — the roadmap's authoring note suggested
+moving it to the undo slice, but M2.2 already landed the
+survival-anchor predicate, and the clamp is correctness-critical
+from the moment `processedThrough` is first written, so it ships
+with its owner.
+
+The **reader / wizard track** ships what users touch:
+[Slice 3.6](./slices/06-wizard-world-cast.md) completes the wizard
+(World and Cast steps, refine / regenerate on the opening);
+[Slice 3.7](./slices/07-suggestions.md) adds next-turn suggestion
+chips over both emission folds plus the `suggestion-refresh`
+pipeline; [Slice 3.8](./slices/08-worldtime-edit.md) adds the
+per-entry world-time click-to-edit overlay and monotonicity flag;
+[Slice 3.9](./slices/09-undo-batched.md) extends CTRL-Z so undoing
+a prose turn reverses the positional suffix through the survival
+anchor; and [Slice 3.10](./slices/10-regenerate.md) (added at
+promotion — the roadmap's cross-cutting table named reader
+regenerate but no slice owned it) wires regenerate over the shared
+reversal sweep. The same table's "refine on entries" phrase is
+dropped: canon defines no reader-entry refine (refine is a
+wizard-opening affordance, 3.6).
+[Slice 3.11](./slices/11-story-settings-shell.md) (also added at
+promotion, from an audit finding) ships the minimal Story Settings
+host that 3.1b's embedding-status panel and 3.7's Composer section
+register into — the real basic surface remains M4.4.
+
+What changes from "before" to "after": the app goes from "one loop
+that forgets everything past the recent buffer" to "prose and
+structured world state stay consistent turn by turn, and older
+relevant content resurfaces on its own." M4 then makes that graph
+browsable.
+
+## Slices
+
+- [Slice 3.1a](./slices/01a-embedder-core.md) — embedder core:
+  vec0 tables, local + provider runtimes, catalog download flow,
+  story-creation hard gate, wizard Finish embeds
+- [Slice 3.1b](./slices/01b-embedder-lifecycle.md) — embedder
+  lifecycle: drain worker, crash-safe model swap, staleness UI,
+  Matryoshka effective dim
+- [Slice 3.2](./slices/02-piggyback.md) — piggyback layer:
+  trailing-block parse, scene metadata, computed bookkeeping,
+  staged fast path, classifier-fallback mode
+- [Slice 3.3](./slices/03-classifier.md) — periodic classifier:
+  background pipeline, extraction + reconciliation + provenance,
+  retry policy, classifier barrier
+- [Slice 3.4](./slices/04-retrieval.md) — retrieval: sync stage,
+  three-query stack, pure ranker, budgets, memory pack templates,
+  `js-tiktoken`
+- [Slice 3.5](./slices/05-dev-probe.md) — developer-only retrieval
+  probe: first `probe_captures` writes, parity test
+- [Slice 3.6](./slices/06-wizard-world-cast.md) — wizard steps 3
+  (World) and 4 (Cast), refine / regenerate on the opening
+- [Slice 3.7](./slices/07-suggestions.md) — next-turn suggestions:
+  emission folds, chip strip, `suggestion-refresh` pipeline,
+  categories editor
+- [Slice 3.8](./slices/08-worldtime-edit.md) — per-entry worldTime
+  click-to-edit overlay, monotonicity-break flag
+- [Slice 3.9](./slices/09-undo-batched.md) — CTRL-Z action-batched
+  extension over the survival anchor
+- [Slice 3.10](./slices/10-regenerate.md) — reader regenerate over
+  the shared reversal sweep
+- [Slice 3.11](./slices/11-story-settings-shell.md) — minimal
+  Story Settings host + section-registration seam
+
+## Dependency graph
+
+```
+day-one: 3.1a   3.2   3.6   3.8   3.11
+
+3.1a ─┬→ 3.1b
+      ├→ 3.3 ─┬→ 3.9
+      │       └→ 3.10
+      └→ 3.4 ──→ 3.5
+3.2 ───→ 3.7
+3.11 ┄┬→ 3.1b   (partial: settings-section portions only)
+     └→ 3.7
+```
+
+- **3.1a** gates 3.1b (lifecycle extends the service), 3.3 (the
+  disambiguation flow embeds extracted descriptions at decision
+  time), and 3.4 (vec0 + query embeds).
+- **3.2** gates 3.7 — both emission folds ride the per-turn paths
+  3.2 owns, and `<suggestions>` parses through 3.2's trailing-block
+  utility (C2). The roadmap sketch also gated 3.7 on 3.3; that gate
+  is dropped — the classifier fold is 3.2's per-turn fallback pass,
+  not the periodic classifier.
+- **3.3** gates 3.9 and 3.10 — both consume the shared reversal
+  sweep with the classifier-cancel drain and `processedThrough`
+  clamp (C3).
+- **3.4** develops against `pnpm db:seed` rows (frozen shapes;
+  the same look-ahead pattern M4 uses) and therefore does **not**
+  gate on 3.3; its definition of done still requires ranking real
+  classifier output. 3.4 gates 3.5 (the capture writer serializes
+  the ranker trace, and the parity test needs the pure module).
+  3.4 also pairs with 3.1b via C8 (its sync-failure surface's
+  `Switch embedder` action opens 3.1b's swap dialog) — a
+  doc-as-contract seam, not a gate.
+- **3.6** is day-one: the M1.5 lore / entity layer plus M2.3's
+  wizard shell are merged prerequisites. Its Finish-commit rows
+  flow through 3.1a's embed step via C5 — a doc-as-contract pair,
+  not a gate. 3.1b and 3.6 also co-edit wizard step 5 (memory-cost
+  disclosure vs opening refine / regenerate) in non-overlapping
+  regions — parallel-safe, noted for completeness.
+- **3.8** is build-independent day-one (entry metadata + the M2
+  calendar substrate); it only becomes _useful_ once 3.2's
+  piggyback layer writes non-zero `worldTime` values, so its
+  milestone-level validation follows 3.2 without blocking its
+  build.
+- **3.11** is a thin day-one shell; its edges to 3.1b and 3.7 are
+  **partial** — only their settings-section portions wait on it
+  (M2's partial-gate precedent); swap flow, drain worker, emission,
+  and the chip strip proceed regardless.
+
+## Slice contracts
+
+### C1 — Embedder service surface
+
+[Slice 3.1a](./slices/01a-embedder-core.md) owns one embedding
+service module. Pinned boundary: lazy init (never at boot — see
+[`model-management.md → Embedder failures`](../../../memory/model-management.md#embedder-failures));
+a batched embed entry point resolving the story's configured
+backend and model (`stories.settings` → app default); typed
+failures distinguishing init-failure from call-failure; the vec0
+write helper (metadata row + vector + `source_hash`) and the
+`embedding_stale` recompute-and-revalidate helper per
+[`retrieval.md → Compute lifecycle`](../../../memory/retrieval.md#compute-lifecycle).
+Consumers: 3.1b (drain worker, swap re-index), 3.3 (transient
+disambiguation embed), 3.4 (pre-retrieval sync stage + query
+embeds), and 3.1a's own wizard-Finish step. Matryoshka truncation +
+renorm (3.1b) lands **inside** the service — consumers never
+truncate, so rows written by 3.3 / 3.4 code built before 3.1b
+merges pick up effective-dim handling transparently. Exact names
+fixed in 3.1a's first commit.
+
+### C2 — Trailing-block parse utility
+
+[Slice 3.2](./slices/02-piggyback.md) owns the tagged
+trailing-block parser: segment isolation (each top-level block —
+`<state>`, later `<suggestions>` — parses independently; one
+failing never blocks another), jsonrepair-equivalent repair,
+per-field best-effort fallback, and placeholder substitution
+integration per
+[`generation-pipeline.md → ID placeholder substitution`](../../../generation-pipeline.md#id-placeholder-substitution).
+[Slice 3.7](./slices/07-suggestions.md) consumes it for
+`<suggestions>` (including category-id placeholder swap) rather
+than writing a second parser.
+
+### C3 — Shared prose-reversal sweep
+
+[Slice 3.3](./slices/03-classifier.md) extends M2.2's sweep
+primitive (`reverseAndPruneDeltaRows` bracketed by
+`reversalInProgress`) with the two classifier-era obligations, in
+one place: the in-flight drain
+(`await awaitRunTerminal('periodic-classifier', 'cancel')` before
+the sweep, per
+[`generation-pipeline.md → Prose reversals and the classifier barrier`](../../../generation-pipeline.md#prose-reversals-and-the-classifier-barrier))
+and the watermark clamp
+(`processedThrough ← min(processedThrough, position(B) − 1)` inside
+the sweep transaction, per
+[`classifier.md → Persistence`](../../../memory/classifier.md#persistence)).
+3.3 also relocates `awaitRunTerminal` from `lib/pipeline` into the
+generation store (mirroring M2.2's gate move) so `lib/actions`
+stays cycle-free. [Slice 3.9](./slices/09-undo-batched.md) and
+[Slice 3.10](./slices/10-regenerate.md) invoke this primitive for
+their reversals and implement **no** barrier or clamp logic of
+their own. Entry-point signature fixed in 3.3's first commit.
+
+### C4 — Pure ranker module + trace
+
+[Slice 3.4](./slices/04-retrieval.md) ships the ranker
+(`rank_per_type` / `rank_all` per
+[`retrieval.md → Pseudocode`](../../../memory/retrieval.md#pseudocode))
+as a pure-function module with no store or DB imports, and its
+output includes a per-candidate **trace** carrying the fields the
+probe capture model needs (`sim_q1..q3`, `sim_blend`,
+`recency_factor`, `pin_signal`, `kw_boost_value`,
+`chapter_boost_applied`, `bypass_triggered`, `final_score`,
+`mmr_rank`, `selected`, `drop_reason`, `tokens_estimated`, and the
+row's `embedding_stale` flag at capture time — per
+[`probe.md → What gets captured`](../../../memory/probe.md#what-gets-captured--light-mode-default)).
+This contract pins the **per-candidate** trace only; the
+query-level metadata (incl. Q3 sentence scores), per-type funnel
+summary, structural-floor list, and stale-row counts that the
+capture model also needs come from 3.4's retrieval-phase output,
+which 3.5 consumes sequenced (3.4 gates 3.5).
+[Slice 3.5](./slices/05-dev-probe.md) serializes that trace into
+`probe_captures` and pins the simulator-vs-prod parity test against
+the same module. Any ranker change that bypasses the pure module is
+a contract violation.
+
+### C5 — Wizard-commit embed seam
+
+The wizard's Finish transaction is touched by three slices: 3.1a
+adds the embed handling (each `entities` / `lore` row embeds at its
+insert step inside the one atomic transaction, per
+[`wizard.md → What Finish does`](../../../ui/screens/wizard/wizard.md#what-finish-does--atomic-commit);
+any embed failure rolls the whole commit back), 3.6 adds the rows
+themselves (full cast + initial lore), and 3.1b writes
+`stories.settings.effectiveDim` from the step-5 memory-cost
+disclosure — resolved by the embed helper from the story settings
+assembled earlier in the same transaction. Pinned: all Finish
+embeds flow through 3.1a's single embed helper; 3.1a implements it
+against the M2 commit shape (lead entity only); 3.6's rows and
+3.1b's dim flow through it without any slice knowing another's
+internals.
+
+### C6 — Per-turn phase-list extension seam
+
+Two parallel slices insert phases into the M2.7 per-turn pipeline
+declaration: 3.4 inserts the retrieval phase (with its
+head-of-phase sync stage) before the narrative phase, and 3.2
+inserts the conditional fallback-classifier phase after it, per
+the canonical phase order the pre-flight walk assumes
+([`generation-pipeline.md → Config pre-flight validation`](../../../generation-pipeline.md#config-pre-flight-validation)).
+Pinned: the per-turn definition exposes named insertion points (a
+structured phase list, not positional splicing), each slice adds
+its own phase entry plus its resolver-input declaration, and
+neither edits the other's entries. Exact shape fixed by whichever
+slice lands first; the insertion order above is binding either way.
+
+### C7 — Story Settings section registration
+
+[Slice 3.11](./slices/11-story-settings-shell.md) owns the minimal
+Story Settings shell and a section-registration seam: a section is
+a self-registered module declaring its tab and rendering its own
+body — consumers touch no shared file (same spirit as the M1.5
+delta-dispatch registration API). Consumers: 3.1b registers the
+Memory tab's embedding-status panel; 3.7 registers the Composer
+section (categories editor, master toggle, count stepper).
+Registration names fixed in 3.11's first commit.
+
+### C8 — Swap-dialog open action
+
+[Slice 3.1b](./slices/01b-embedder-lifecycle.md) exports a single
+named action that opens the model-swap dialog for a story (the
+[`Model swap UX`](../../../memory/retrieval.md#model-swap-ux)
+entry point). [Slice 3.4](./slices/04-retrieval.md)'s sync-failure
+surface imports it for its `Switch embedder` action rather than
+re-implementing any routing. Name fixed in 3.1b's first commit;
+3.4's own acceptance criteria test only the Retry path, so the
+cross-slice routing verifies at integration once both are merged
+(the two slices stay parallel).
+
+## Definition of done
+
+- **Coherence loop, both platforms.** On Electron desktop and an
+  Android device / emulator: play a story past one classifier
+  cadence; the classifier populates happenings, awareness rows,
+  and a canonically-ordered relationship row (verified via the dev
+  probe / DB); a later turn's prompt injects a retrieval bundle
+  containing at least one non-buffer candidate (verified via a
+  probe capture); suggestions chips render after replies and
+  tap-fills the composer in `Free` mode.
+- **Embedder hard gate.** On a fresh install with no embedder:
+  story creation is blocked with a route to settings; after a
+  curated download (license shown and attested, SHA256 verified),
+  creation proceeds and Finish embeds cast + lore in the commit
+  transaction — committed rows are never `embedding_stale`
+  (asserted by test); an embed failure at Finish rolls back the
+  entire commit and surfaces the retry surface.
+- **Sync-before-read holds.** A turn following classifier writes
+  runs the pre-retrieval sync stage and KNN sees the fresh rows;
+  a forced embed failure at the sync stage blocks the turn with
+  `Retry / Switch embedder / Roll back this turn` and the next-turn
+  affordance disabled; rows still stale at retrieval are excluded
+  from candidates (vitest each).
+- **Swap crash-safety.** Kill the app mid-re-index; on next story
+  open the resume / cancel prompt appears; resume completes the
+  stage-then-flip, cancel deletes staged NEW-model vectors and
+  clears `embedding_swap_target` (manual smoke + vitest on the
+  marker transitions).
+- **Matryoshka.** A provider-mode story created at
+  `effectiveDim = N` stores N-dim unit-norm vectors and queries at
+  N dims; truncation + renorm covered by unit test.
+- **Piggyback resilience.** A malformed trailing block skips
+  LLM-emitted fields for the turn without failing it; computed
+  bookkeeping still applies; `<state>` and `<suggestions>` parse
+  independently in all four outcome combinations (vitest).
+- **Classifier lifecycle.** Injected failures walk the
+  30 s → 2 m → 5 m backoff into failed-persistent, cadence
+  suspends, manual retry re-arms it (vitest, fake timers);
+  `classifier_status.processedThrough` advances on success and
+  clamps on reversal.
+- **Survival anchor exercised.** Regenerating a reply after a
+  catch-up classifier pass spares committed facts anchored to
+  surviving turns and re-processing does not re-derive them; CTRL-Z
+  of a prose turn carries its piggyback deltas and any classifier
+  deltas anchored to it (vitest over fixture logs + manual smoke).
+- **Parity.** The simulator-vs-prod ranker parity test passes:
+  identical selections and scores for the same captured state and
+  params.
+- **Wizard complete.** A story is creatable with genre / tone /
+  setting, initial lore, and a mixed cast including staged
+  entities; staged entities are excluded from opening
+  `sceneEntities`; refine / regenerate work on the opening
+  preview.
+- **Pre-flight coverage.** `periodic-classifier` and
+  `suggestion-refresh` declare resolver inputs; unassigned agents
+  halt before phase 0 with the M2 failure vocabulary.
+- **Hygiene.** Storybook stories exist for every compound M3
+  introduces; every new chrome string routes through `t()`;
+  `pnpm lint`, `pnpm typecheck`, `pnpm lint:docs`, and the full
+  vitest suite pass on every slice's PR.
+
+## Open questions
+
+- **Classifier output wire format.** Strict structured-output mode
+  (capability-gated) versus tagged trailing block for the periodic
+  classifier's emission — canon pins the content and placeholder
+  rules but not the wire shape. Resolve in
+  [Slice 3.3](./slices/03-classifier.md) planning.
+- **Curated catalog v1 contents.** Which embedding models ship in
+  the bundled catalog JSON beyond `Xenova/all-MiniLM-L6-v2-q8`.
+  Resolve in [Slice 3.1a](./slices/01a-embedder-core.md) planning.
+- **Scheduler placement.** Where the cadence tick lives (store
+  subscription on entry writes vs an orchestrator-adjacent
+  module) — the framework deliberately excludes it
+  ([`generation-pipeline.md → Background scheduler`](../../../generation-pipeline.md#background-scheduler--out-of-framework-scope)).
+  Resolve in [Slice 3.3](./slices/03-classifier.md) planning.
+- **Token-progress strip fill.** `js-tiktoken` lands in 3.4; the
+  reader's zero-filled token-progress strip (M2.5 interim) could
+  gain real open-region counts there or wait for chapter work in
+  M5. Default assumption: wire it in 3.4 if cheap, else record in
+  the slice's Implementation notes.

--- a/docs/implementation/milestones/03-memory-floor/slices/01a-embedder-core.md
+++ b/docs/implementation/milestones/03-memory-floor/slices/01a-embedder-core.md
@@ -1,0 +1,169 @@
+# Slice 3.1a — Embedder core: vec0 tables, runtimes, catalog, creation gate
+
+## Metadata
+
+- **Milestone:** [Milestone 3 — Memory floor](../milestone.md)
+- **Depends on:** none (day-one; M1.5 substrate + M2 wizard are
+  merged prerequisites)
+- **Blocks:** [Slice 3.1b](./01b-embedder-lifecycle.md),
+  [Slice 3.3](./03-classifier.md) (disambiguation embeds),
+  [Slice 3.4](./04-retrieval.md) (vec0 + query embeds).
+  [Slice 3.6](./06-wizard-world-cast.md) pairs via the C5
+  wizard-commit seam — doc-as-contract, not a gate.
+
+## Goal
+
+The embedding substrate: the per-type vec0 virtual tables (the one
+schema-landing job M1.5 deliberately excluded), a single embedder
+service with local-ONNX and provider backends behind lazy init, the
+curated-catalog download flow with license attestation, the minimal
+app-settings embedder surface, and the story-creation hard gate —
+the wizard's Finish now embeds cast and lore inside its commit
+transaction and blocks until an embedder is configured.
+
+## Background
+
+Retrieval compares vectors, so every story needs an embedder before
+it has anything to retrieve — v1 makes it a hard requirement at
+story creation rather than shipping a degraded LLM-only fallback.
+The sqlite-vec extension itself has loaded since M1.2; this slice
+adds the physical `*_vec` tables and the service that writes them.
+M2.3's wizard already commits `embeddingBackend: 'local'` and an
+`embedding_model_id` into fresh story settings; this slice makes
+those values real. Downloads are curated: a bundled catalog pins a
+HuggingFace revision and file hashes, and the license is fetched
+live and attested per download. The full embedder-management tab is
+M7.1; only the gate-required minimum ships here.
+
+## Required reading
+
+- [`retrieval.md → Embedding infrastructure`](../../../../memory/retrieval.md#embedding-infrastructure)
+  — runtimes, logical schema, per-type vec0 physical layout,
+  per-branch single-model invariant, `source_hash` tripwire.
+- [`retrieval.md → Compute lifecycle`](../../../../memory/retrieval.md#compute-lifecycle)
+  — sync-before-read contract, `embedding_stale` flag semantics,
+  blocking-failure posture (this slice lands the helpers; 3.4 lands
+  the sync stage).
+- [`model-management.md → Curated catalog`](../../../../memory/model-management.md#curated-catalog),
+  [`Storage layout`](../../../../memory/model-management.md#storage-layout),
+  [`Download flow`](../../../../memory/model-management.md#download-flow),
+  [`License attestation`](../../../../memory/model-management.md#license-attestation)
+  — catalog shape, per-platform embedders root, fetch + verify +
+  attest semantics, `@huggingface/hub` implementation note.
+- [`model-management.md → Embedder failures`](../../../../memory/model-management.md#embedder-failures)
+  — lazy init, test button, wizard-commit failure surface.
+- [`model-management.md → Embedder config`](../../../../memory/model-management.md#embedder-config--where-it-lives-in-settings)
+  — the three settings surfaces; only the gate-required subset
+  ships here.
+- [`ui/patterns/embedder-download.md`](../../../../ui/patterns/embedder-download.md)
+  — the shipped `EmbedderDownloadDialog` per-state UI this slice
+  wires.
+- [`wizard.md → What Finish does`](../../../../ui/screens/wizard/wizard.md#what-finish-does--atomic-commit)
+  and
+  [`Embedder-unavailable on Finish`](../../../../ui/screens/wizard/wizard.md#embedder-unavailable-on-finish)
+  — the embed-in-transaction exception to sync-before-read and its
+  failure surface.
+- [`data-model.md → App settings storage`](../../../../data-model.md#app-settings-storage)
+  — `embedding_model_id` / `embedding_provider_id` /
+  `embeddingBackend` placement.
+
+## Scope: in
+
+- **vec0 migration:** `entities_vec`, `lore_vec`, `happenings_vec`,
+  `threads_vec`, `chapter_summaries_vec` with `branch_id` (and
+  `model_id`, `dim`) filtering columns; `source_hash` placement
+  resolved at planning (auxiliary column vs sidecar). Creation via
+  Drizzle's `sql` escape hatch per the PoC finding.
+- **Embedder service module (C1):** lazy init; batched embed entry
+  point resolving backend + model from story settings with app
+  default; local backend via ONNX Runtime against the installed
+  model folder (catalog `default_ep`, CPU-default posture);
+  provider backend via the M2.1 provider layer's embedding
+  endpoint; typed init-vs-call failures; vec0 write helper
+  (vector + metadata + `source_hash`) and the per-row
+  `embedding_stale` recompute-and-revalidate helper.
+- **Catalog + download:** bundled catalog JSON (v1 model list is a
+  planning decision); download flow wiring the shipped
+  `EmbedderDownloadDialog` — live model-card fetch at pinned
+  revision, license accept / decline / cancel semantics, resumable
+  download, SHA256 verify, `LICENSE.txt` + `.attestation` writes,
+  partial-file cleanup on every abort path.
+- **Minimal settings surface:** installed-models list (catalog
+  entries + install state), `Test embedder` (init + smoke embed +
+  result surface), and the App Settings · Memory default selection
+  (backend toggle + model pick). No custom import, no EP picker, no
+  remove flow (M7.1).
+- **Story-creation hard gate:** wizard Finish (and wizard entry)
+  checks for a usable embedder configuration; blocked state routes
+  to the settings surface and back.
+- **Wizard Finish embed step (C5):** every `entities` / `lore` row
+  in the commit embeds in-transaction; any embed failure rolls back
+  the entire commit and surfaces
+  `Couldn't initialize the embedder. [Retry] [Settings] [Cancel]`.
+  Implemented against the M2 commit shape (lead entity only); 3.6's
+  rows flow through unchanged.
+
+## Scope: out
+
+- Pre-retrieval sync stage and query embeds — 3.4 (consumes C1).
+- Drain worker, model-swap flow, staleness UI, Matryoshka —
+  [Slice 3.1b](./01b-embedder-lifecycle.md).
+- Custom file import, per-model EP picker, remove flow, HF-id
+  import, cross-story staleness aggregate — M7.1.
+- Onboarding-flow embedder screen — M7.4 (the gate exists from this
+  slice; the guided first-launch path comes later).
+- Any embedding of `story_entries` prose — not embedded in v1 (scene
+  digests are per-turn ephemeral).
+
+## Acceptance criteria
+
+- Migration applies idempotently on Expo (Android) and Electron
+  desktop; all five `*_vec` tables exist and accept an
+  insert + KNN round-trip (vitest against the desktop runtime;
+  manual smoke on Android).
+- With no embedder configured, opening the wizard surfaces the
+  blocked state and routes to settings; after a curated download
+  completes (license dialog shown, SHA256 verified, `.attestation`
+  written), the same wizard path proceeds to Finish.
+- Finish embeds every cast / lore row in the commit transaction —
+  post-commit, every committed row has `embedding_stale = 0` and a
+  vec0 counterpart; a fault-injected embed failure rolls back the
+  entire commit (no stories / branches / entities / lore rows
+  persist) and shows the retry surface (vitest on the transaction,
+  manual smoke on the dialog).
+- Decline leaves no files; cancel mid-download deletes partials and
+  records no attestation; SHA256 mismatch aborts with the
+  verification-failed message (vitest on the state machine, fixture
+  server for the fetch paths).
+- `Test embedder` reports success for a correctly installed model
+  and a typed failure for a corrupted one, without crashing at boot
+  (lazy init asserted — no embedder code runs before first call).
+- Provider backend: a story with `embeddingBackend: 'provider'`
+  embeds through the configured provider's endpoint and lands
+  vectors in vec0 with the right `model_id` (vitest against a stub
+  endpoint).
+
+## Tests
+
+- Vitest: vec0 round-trip + branch/model filtering; C1 service
+  (backend resolution, typed failures, `source_hash` compute +
+  revalidation); download state machine incl. abort paths; Finish
+  transaction rollback on embed failure.
+- Storybook: any new settings-surface compounds (the download
+  dialog already has stories).
+- Manual smoke: full download → create-story → play-a-turn on
+  desktop + Android; kill-app-mid-download resume.
+
+## Open questions
+
+- **Catalog v1 contents** — which models beyond
+  `Xenova/all-MiniLM-L6-v2-q8`; sizes and tags per entry.
+- **`source_hash` physical placement** — auxiliary vec0 column vs
+  per-type sidecar; explicitly left open by canon.
+- **ORT packaging on Electron** — whether the desktop path runs
+  onnxruntime in the main process (alongside sqlite-vec) or the
+  renderer; decide at planning with the M1.2 IPC layout in view.
+
+## Implementation notes
+
+_Populated at finish: notable deviations from the plan and resolved developer decisions._

--- a/docs/implementation/milestones/03-memory-floor/slices/01b-embedder-lifecycle.md
+++ b/docs/implementation/milestones/03-memory-floor/slices/01b-embedder-lifecycle.md
@@ -1,0 +1,157 @@
+# Slice 3.1b — Embedder lifecycle: drain, swap, staleness UI, Matryoshka
+
+## Metadata
+
+- **Milestone:** [Milestone 3 — Memory floor](../milestone.md)
+- **Depends on:** [Slice 3.1a](./01a-embedder-core.md) (the C1
+  service every piece here extends);
+  [Slice 3.11](./11-story-settings-shell.md) — partial: only the
+  embedding-status panel's host section waits on the shell (C7);
+  swap flow, drain worker, and Matryoshka proceed regardless
+- **Blocks:** none as a build gate — 3.4 imports this slice's
+  swap-dialog open action per C8 (doc-contract; 3.4's Retry path
+  tests independently and the switch routing verifies at
+  integration)
+
+## Goal
+
+The lifecycle machinery around the core embedder: the opportunistic
+`embedding_stale` drain worker, the crash-safe stage-then-flip
+model-swap flow with its story-open resume / cancel prompt, the
+two-surface staleness UI (top-bar pill + Settings · Memory
+resolution panel), and the Matryoshka effective-dim machinery —
+`effectiveDim` resolution with truncation + renorm at every
+embed-write, plus the wizard step-5 memory-cost disclosure.
+
+## Background
+
+The core slice makes embeds work; this slice makes them survivable.
+Rows dirtied while the embedder is unavailable accumulate as
+`embedding_stale = 1` and need a worker that drains them once
+conditions allow — a warm-cache optimization, never an excuse to
+ignore failures (the blocking sync stage in 3.4 stays the
+contract). Swapping a story's embedding model invalidates every
+stored vector, so the swap is a non-destructive re-embed staged
+next to the old vectors, then an atomic flip — resumable or
+cancellable after a crash via the `embedding_swap_target` marker
+(the settings field landed in M1.5). Matryoshka-trained provider
+models let a story store truncated vectors at a fraction of the
+cost; the capability flags already ship in the M1.5 app-settings
+Zod, and `stories.settings.effectiveDim` is locked at creation.
+
+## Required reading
+
+- [`retrieval.md → Compute lifecycle`](../../../../memory/retrieval.md#compute-lifecycle)
+  — the worker's role relative to the blocking sync stage.
+- [`retrieval.md → Model swap UX`](../../../../memory/retrieval.md#model-swap-ux)
+  — the three-option dialog, stage-then-flip transactions,
+  crash-recovery resume / cancel, second-swap block, the standalone
+  re-index button.
+- [`retrieval.md → Matryoshka effective dim`](../../../../memory/retrieval.md#matryoshka-effective-dim)
+  — schema, capability flags, truncation contract (truncate +
+  re-normalize; server-side `dimensions` where supported), defaults,
+  edge cases.
+- [`model-management.md → Staleness UI`](../../../../memory/model-management.md#staleness-ui)
+  — the resolution panel and the top-bar discovery pill.
+- [`model-management.md → Removal`](../../../../memory/model-management.md#removal)
+  — the recovery path staleness UI serves (the remove flow itself is
+  M7.1; the panel must still handle "model missing" as a reason).
+- [`wizard.md → Memory cost — Matryoshka effective dim`](../../../../ui/screens/wizard/wizard.md#memory-cost--matryoshka-effective-dim)
+  — the step-5 disclosure: visibility conditions, curated ladder,
+  custom dim, platform-aware suggestion, storage-only preview.
+- [`probe.md → Embedding model swap`](../../../../memory/probe.md#embedding-model-swap)
+  — captures stay valid across swaps; nothing here touches them.
+
+## Scope: in
+
+- **Drain worker:** between-turns opportunistic pass over
+  `WHERE embedding_stale = 1` (partial index assumed from M1.5
+  schema; verify) through the C1 service; backs off while the
+  embedder is unavailable; never surfaces errors itself (the sync
+  stage owns blocking UX).
+- **Model-swap flow:** the three-option AlertDialog (re-index /
+  keep / skip-with-relabel) fired from the switch-embedder action;
+  the dialog-open action is exported per C8 (name fixed in this
+  slice's first commit — 3.4's sync-failure surface imports it);
+  stage-then-flip per canon — swap-start
+  marker transaction, phase-1 foreground re-embed with progress
+  ("re-indexing X / N — retrieval limited"), phase-2 atomic
+  DELETE-old + settings flip + marker clear; cancel path deleting
+  staged NEW vectors; story-open resume / cancel prompt while
+  `embedding_swap_target` is set; "Change embedding model" disabled
+  while set; standalone "Re-index this story now."
+- **Staleness UI:** the per-story embedding-status resolution panel
+  (stale count, reason, `Switch embedder` action) registered into
+  the Story Settings shell's Memory tab per C7
+  ([Slice 3.11](./11-story-settings-shell.md) hosts), and the
+  top-bar error-state pill in affected stories routing to that
+  panel.
+- **Matryoshka machinery:** `effectiveDim` resolution inside the C1
+  service — truncate to N + re-normalize on every stored vector and
+  every query embed; server-side `dimensions` parameter where the
+  provider supports it; dim recorded per row; re-index reuses the
+  story's stored dim.
+- **Wizard step-5 memory-cost disclosure:** conditional visibility
+  (provider backend + `matryoshkaSupported`), curated-ladder radios
+  with platform-aware suggestion, `Custom…` input with validation
+  gate on Finish, storage-only cost preview; writes
+  `stories.settings.effectiveDim` at Finish (the third
+  Finish-transaction toucher pinned in C5; step 5 is co-edited by
+  3.6's opening refine / regenerate in a non-overlapping region).
+
+## Scope: out
+
+- Blocking sync-stage UX (the Retry / Switch / Roll-back failure
+  surface) — 3.4 owns the stage; the switch action routes into this
+  slice's swap dialog.
+- Model removal flow and cross-story staleness aggregate — M7.1.
+- Per-story EP override — parked.
+- Local-model truncation — canon scopes Matryoshka to provider
+  mode.
+
+## Acceptance criteria
+
+- Rows flagged stale while the embedder is down are drained by the
+  worker after the embedder recovers, without user action; the
+  drained rows' vectors match a direct embed (vitest with a
+  fault-injectable service).
+- Full swap: re-index N rows, verify old-model vectors gone,
+  new-model vectors present, `embedding_model_id` updated, marker
+  cleared — one atomic phase-2 transaction (vitest).
+- Kill mid-phase-1; reopening the story surfaces resume / cancel;
+  resume skips rows that already have NEW-model counterparts and
+  completes; cancel deletes NEW rows and keeps the story on the old
+  model (vitest on marker states + manual smoke for the kill).
+- Skip-with-relabel updates the recorded id without touching vec0
+  and shows the user-assertion disclaimer.
+- With a Matryoshka-capable provider model and `effectiveDim = N`:
+  stored and query vectors are length-N and unit-norm (float
+  tolerance); a non-Matryoshka story stores native dim (vitest).
+- Wizard disclosure appears only under its two visibility
+  conditions; custom-dim validation blocks Finish out-of-range;
+  the chosen dim lands in `stories.settings.effectiveDim`.
+- Staleness pill appears in a story with stale rows, routes to the
+  resolution panel, and clears once the drain empties the set.
+
+## Tests
+
+- Vitest: worker drain + backoff, swap state machine (all marker
+  transitions incl. crash-resume matrix), truncation + renorm math,
+  effective-dim persistence.
+- Storybook: resolution-panel compound, swap dialog states,
+  memory-cost disclosure.
+- Manual smoke: kill-mid-re-index on desktop; staleness pill
+  round-trip on Android.
+
+## Open questions
+
+- **Worker trigger** — timer-based between turns vs hooked on
+  pipeline-idle events; pick at planning (must not contend with an
+  in-flight sync stage).
+- **Progress UI host for phase-1** — inline panel in Story
+  Settings · Memory vs the generation-status pill; canon says
+  foreground job with progress indicator, host unpinned.
+
+## Implementation notes
+
+_Populated at finish: notable deviations from the plan and resolved developer decisions._

--- a/docs/implementation/milestones/03-memory-floor/slices/02-piggyback.md
+++ b/docs/implementation/milestones/03-memory-floor/slices/02-piggyback.md
@@ -1,0 +1,164 @@
+# Slice 3.2 — Piggyback layer: trailing block, scene metadata, computed bookkeeping
+
+## Metadata
+
+- **Milestone:** [Milestone 3 — Memory floor](../milestone.md)
+- **Depends on:** none (day-one; the M2.7 per-turn pipeline and
+  M2.8 id-substitution are merged prerequisites)
+- **Blocks:** [Slice 3.7](./07-suggestions.md) (both emission folds
+  ride this slice's paths; `<suggestions>` parses through C2)
+
+## Goal
+
+The per-turn fast path of the memory cadence: the narrative model
+emits a tagged `<state>` block alongside its prose, and this slice
+parses it, applies the scene-metadata and state writes, derives the
+computed bookkeeping, auto-promotes staged entities on ID emission,
+and falls back to a per-turn classifier pass when the model can't
+be trusted with tagged blocks. Also extracts the shared
+entry-metadata placeholder helper flagged during M2 reconciliation.
+
+## Background
+
+Piggyback exists so the prose and the state it produces are
+mutually consistent by construction, at near-zero marginal cost —
+a few hundred output tokens on a call already paying full input
+cost. Its write set is deliberately narrow: entry scene metadata,
+entity state fields, and the monotonic staged→active status flip.
+**It creates no rows** — entity / lore / happening creation belongs
+to the periodic classifier per the canonical write-set split
+(resolved at promotion against a stale roadmap phrase). Parsing is
+best-effort per field: a malformed block skips the LLM-emitted
+fields for the turn and the periodic classifier eventually covers
+the prose. When the narrative model's tagged-block reliability flag
+is off, a separate per-turn classifier call writes the same subset.
+
+## Required reading
+
+- [`piggyback.md`](../../../../memory/piggyback.md) — the whole
+  contract: write table, trailing-block format, jsonrepair
+  fallback, auto-promote, capability gate, mode-mixing.
+- [`cadence.md → Concurrency`](../../../../memory/cadence.md#concurrency)
+  — the write-set table and per-field-UPDATE discipline; the
+  `entities.status` monotonic-overlap invariant.
+- [`edge-cases.md → Staged-entity promotion`](../../../../memory/edge-cases.md#staged-entity-promotion)
+  — fast path semantics and the staged-entity prompt framing.
+- [`generation-pipeline.md → ID placeholder substitution`](../../../../generation-pipeline.md#id-placeholder-substitution)
+  — placeholder swap both directions; failure modes.
+- [`generation-pipeline.md → Narrow action functions over write-set declarations`](../../../../generation-pipeline.md#narrow-action-functions-over-write-set-declarations)
+  — how the write-set boundary is enforced in code.
+- [`generation-pipeline.md → Config pre-flight validation`](../../../../generation-pipeline.md#config-pre-flight-validation)
+  — the resolver-input declaration + halt semantics the fallback
+  phase's agent declaration rides.
+- [`architecture.md → Classifier contract — metadata fields`](../../../../architecture.md#classifier-contract--metadata-fields)
+  — `worldTime` delta invariant (`≥ 0`, flashback `0`, re-roll then
+  clamp + warn), user-action inheritance.
+- [`data-model.md → Entry metadata shape`](../../../../data-model.md#entry-metadata-shape)
+  — the metadata fields this slice writes.
+
+## Scope: in
+
+- **Trailing-block parse utility (C2):** segment isolation per
+  top-level tag, repair fallback, per-field best-effort, placeholder
+  swap integration; exported for 3.7's `<suggestions>` block.
+- **Prompt fragment:** the `<state>` emission instructions +
+  bracketed-ID entity list framing in the bundled per-turn template
+  (including the staged-entities block with promotion instructions,
+  and the active calendar's vocabulary — tier names, weekday and
+  era labels — so the model converts prose like "two days later"
+  into a seconds delta per
+  [`data-model.md → In-world time tracking`](../../../../data-model.md#in-world-time-tracking)).
+- **Piggyback apply:** `sceneEntities` / `currentLocationId` /
+  `worldTime` delta onto the new entry's metadata (the first
+  non-zero `worldTime` values flow through the M2.5 calendar
+  renderer from this slice); `visual.*` and
+  transfer writes via per-field narrow actions; the `worldTime`
+  validation ladder (reject negative → re-roll once → clamp to 0 +
+  `logger.warn`).
+- **`<summary>` enrichment hand-off:** parse the trailing block's
+  optional one-sentence summary and hand it off for the next
+  turn's Q2 structural digest
+  ([`retrieval.md → Q2`](../../../../memory/retrieval.md#q2-structural-digest)
+  treats it as optional enrichment — absent on parse failure or
+  restart is fine); the transport (run-scoped vs store-scoped) is a
+  planning decision recorded at finish.
+- **Computed bookkeeping:** per-character `current_location_id`
+  from scene presence; `lastSeenAt` on scene-exit from the previous
+  entry's metadata — code-side, no LLM.
+- **Staged→active fast path:** auto-promote on staged-ID emission
+  under the turn's `action_id`.
+- **Capability gate + fallback:** `piggybackMode` resolution from
+  story settings + the model's tagged-block capability flag; when
+  off, a per-turn classifier pass (own phase inserted after the
+  narrative phase through the C6 phase-list seam, declared resolver
+  input per M2.9) writes the same subset; mode-mixing mid-story
+  needs no migration.
+- **Shared metadata-placeholder helper:** extract the hand-built
+  `{ sceneEntities: [], currentLocationId: null, worldTime }`
+  placeholder duplicated across `submit-turn.ts` and `pipeline.ts`
+  (surfaced by Slice 2.7) into one helper, now that real values
+  flow.
+
+## Scope: out
+
+- Any row creation (entities, lore, happenings) and any
+  `description` authorship — [Slice 3.3](./03-classifier.md).
+- `<suggestions>` emission and parse wiring —
+  [Slice 3.7](./07-suggestions.md) (consumes C2).
+- Retirement (`active → retired`) — classifier-only per canon.
+- The piggybackMode settings UI (Story Settings · Memory · Classifier
+  panel) — M7.2; the setting itself is readable since M1.5.
+- Embedding anything — piggyback's writes touch no embedded fields
+  (state is excluded from embeddings by design).
+
+## Acceptance criteria
+
+- A stub-provider turn with a well-formed `<state>` block lands
+  scene metadata on the new entry, per-field state updates on the
+  named entities, and computed `current_location_id` / `lastSeenAt`
+  transitions — all under one turn `action_id`, reversible by one
+  CTRL-Z (vitest end-to-end over the pipeline).
+- A malformed block (fixture set: truncated tag, bad JSON-ish
+  interior, unknown placeholder) skips LLM-emitted fields, still
+  applies computed bookkeeping, and completes the turn; the parse
+  failure logs (vitest per fixture).
+- A staged entity emitted in `<scene_entities>` flips to `active`
+  in the same action; a second emission no-ops (monotonic).
+- Negative `worldTime` delta: rejected, re-rolled once, then
+  clamped to 0 with `classifier.delta_clamped` warn (vitest, fault
+  injection).
+- With the capability flag off, the per-turn classifier fallback
+  phase runs, writes the same subset, and pre-flight fails cleanly
+  when its agent is unassigned (M2.9 vocabulary).
+- Write-set discipline: no read-modify-write on `entities` rows —
+  per-field UPDATEs only (asserted by reviewing the narrow actions'
+  tests; a concurrent-writer vitest exercises the status overlap).
+- The metadata-placeholder helper is the single construction site
+  for empty entry metadata (grep-level assertion in review;
+  `submit-turn.ts` and `pipeline.ts` both consume it).
+
+## Tests
+
+- Vitest: parse utility (well-formed / repaired / malformed
+  matrix), apply path, computed bookkeeping transitions, fast-path
+  promotion, worldTime ladder, fallback-mode phase, concurrent
+  status-write no-clobber.
+- No new compounds expected; no Storybook scope unless one is
+  extracted.
+- Manual smoke: real-provider turn with a tagged-block-capable
+  model; visual state change reflected on a second turn's prompt.
+
+## Open questions
+
+- **Tagged format final shape** — canon says "exact tagged format
+  firms up at implementation"; pin the grammar in this slice and
+  record it in Implementation notes (3.7's `<suggestions>` inherits
+  it).
+- **Capability flag sourcing** — the tagged-block reliability flag
+  is "curation + detection, user-overridable"; what seeds it for
+  OAI-compat models where no curation exists yet (default-off vs
+  default-on-with-fallback).
+
+## Implementation notes
+
+_Populated at finish: notable deviations from the plan and resolved developer decisions._

--- a/docs/implementation/milestones/03-memory-floor/slices/03-classifier.md
+++ b/docs/implementation/milestones/03-memory-floor/slices/03-classifier.md
@@ -1,0 +1,210 @@
+# Slice 3.3 — Periodic classifier: extraction, reconciliation, provenance, barrier
+
+## Metadata
+
+- **Milestone:** [Milestone 3 — Memory floor](../milestone.md)
+- **Depends on:** [Slice 3.1a](./01a-embedder-core.md) (the
+  disambiguation flow embeds extracted descriptions at decision
+  time)
+- **Blocks:** [Slice 3.9](./09-undo-batched.md) and
+  [Slice 3.10](./10-regenerate.md) (both consume the C3 shared
+  reversal sweep)
+
+## Goal
+
+The background pipeline that populates the structured graph
+retrieval queries against: happenings with involvements and
+severity-judged awareness, relationship UPSERT-merge, entity status
+flips, first-introduction descriptions, and name-collision
+disambiguation — every delta stamped with survival-anchor
+provenance. Ships the `periodic-classifier` pipeline
+declaration, its cadence scheduler, the auto-retry policy over
+per-branch `classifier_status`, and the in-flight classifier
+barrier that prose reversals bracket.
+
+## Background
+
+Piggyback keeps the crucial per-turn subset consistent; the
+classifier amortizes everything deeper over many turns — it reads
+the prose window past `processedThrough` and emits batch
+extractions as a `no-gate` background pipeline that coexists with
+per-turn runs on disjoint write sets. Its output references
+entities by placeholder and creates new ones as full objects with
+no id; code-side reconciliation (name index, then embedding
+similarity) decides create vs promote vs flag. Every fact carries a
+provenance anchor in `deltas.entry_id` so reversals spare facts
+about surviving turns; the predicate itself already landed in M2.2
+(dormant), and this slice makes it live — including the
+`processedThrough` clamp, kept here rather than the undo slice
+because it is load-bearing from the first write of the watermark
+(promotion decision).
+
+## Required reading
+
+- [`classifier.md`](../../../../memory/classifier.md) — the whole
+  contract: write set, provenance attribution, ID handling,
+  embedding-compute boundary, disambiguation, background-task
+  framing, auto-retry, persistence.
+- [`cadence.md → User-tunable knobs`](../../../../memory/cadence.md#user-tunable-knobs)
+  and [`Concurrency`](../../../../memory/cadence.md#concurrency)
+  — `classifierCadence`, write-set disjointness, status-overlap
+  invariant.
+- [`data-model.md → Survival anchor`](../../../../data-model.md#survival-anchor)
+  — the predicate, the clamp, and redo's accepted re-derive
+  tolerance.
+- [`data-model.md → Character-to-character relationships`](../../../../data-model.md#character-to-character-relationships)
+  — `normalizeForWrite`, UPSERT-merge, the classifier prompt
+  contract (fill only the observed POV).
+- [`data-model.md → Happenings & character knowledge`](../../../../data-model.md#happenings--character-knowledge)
+  — happening / involvement / awareness shapes, entry-id refs,
+  the awareness UNIQUE upsert.
+- [`edge-cases.md → Name collision and disambiguation`](../../../../memory/edge-cases.md#name-collision-and-disambiguation)
+  and [`Retirement`](../../../../memory/edge-cases.md#retirement)
+  — Layer B reconciliation, `name_collision_flag`, hard-finality
+  retirement bias.
+- [`generation-pipeline.md → Prose reversals and the classifier barrier`](../../../../generation-pipeline.md#prose-reversals-and-the-classifier-barrier)
+  — `awaitRunTerminal` dispositions, `reversalInProgress`, the
+  abort-free commit burst.
+- [`generation-pipeline.md → Background scheduler`](../../../../generation-pipeline.md#background-scheduler--out-of-framework-scope)
+  and [`V1 declarations`](../../../../generation-pipeline.md#v1-declarations)
+  — the declaration values and the scheduler's out-of-framework
+  placement.
+- [`generation-pipeline.md → ID placeholder substitution`](../../../../generation-pipeline.md#id-placeholder-substitution)
+  — the walker, `IdBiMap`, and unknown-placeholder failure modes
+  the parse must honor — plus its
+  [`New-entity emission`](../../../../generation-pipeline.md#new-entity-emission)
+  subsection: no-id full-object creation, temporary-handle
+  registration.
+
+## Scope: in
+
+- **Pipeline declaration + scheduler:** `periodic-classifier`
+  (`no-gate`, `blockedBy: ['periodic-classifier', 'chapter-close']`,
+  pill-only affordance at low priority), resolver-input declaration
+  for pre-flight; the cadence tick reading
+  `stories.settings.classifierCadence` and calling `runPipeline`,
+  rejected-start = wait for next tick.
+- **Extraction pass:** prompt/context over `(processedThrough,
+head]` with the placeholder universe;
+  structured output (wire format is this slice's planning
+  decision); parse through id-substitution; per-fact provenance
+  handles resolved to `deltas.entry_id` per the attribution rules
+  (single-turn, cross-turn-latest, flip-trigger, window-head
+  fallback).
+- **Writes:** happenings + involvements + awareness (severity →
+  `decay_resistance`; UNIQUE upsert), `character_relationships`
+  UPSERT-merge via `normalizeForWrite`, status flips (staged→active
+  slow path; active→retired on hard finality only), and
+  first-introduction `description` authorship. All embedded-field
+  writes set `embedding_stale = 1`; nothing embeds on the write
+  path.
+- **Disambiguation:** name-index lookup, transient
+  embedding-similarity check via C1, τ-banded create / promote /
+  flag with `entities.name_collision_flag` (drives the M4 review
+  surface).
+- **Happening reconcile cascade:** delete / merge of a happening
+  also drops or reattaches its `happening_involvements` and
+  `happening_awareness` rows (the M1.5 `deleteHappening` arm
+  orphans them; first consumer lands the cascade).
+- **Status persistence + retry:** `branches.classifier_status`
+  lifecycle (idle / running / retrying / failed-persistent,
+  last-error, attempt count, `processedThrough` advanced in the
+  commit transaction); 30 s → 2 m → 5 m backoff; cadence suspension
+  in failed-persistent; manual-run entry point (the settings panel
+  UI is M7.2 — the action is exported now).
+- **Classifier barrier (C3):** relocate `awaitRunTerminal` into the
+  generation store; extend the shared sweep with the
+  `'cancel'`-disposition drain and the `processedThrough` clamp
+  inside the sweep transaction; the classifier's abort-free commit
+  burst (ignore `signal.aborted` once parsing begins).
+
+## Scope: out
+
+- Per-turn scene metadata — including `metadata.worldTime` —
+  computed bookkeeping, and fast-path promotion —
+  [Slice 3.2](./02-piggyback.md). The periodic classifier never
+  writes `story_entries.metadata` per the
+  [write-set table](../../../../memory/cadence.md#concurrency);
+  the roadmap's contrary phrasing was ruled stale at promotion.
+- Turn-capture wiring — grouping comes free via the orchestrator's
+  generic `anchorEntryId` stamp per
+  [`observability.md → Anchor attribution`](../../../../observability.md#anchor-attribution);
+  no per-kind capture work in M3.
+- Chapter-close phase 0 catch-up and lore-mgmt — M5.2 (it consumes
+  `processedThrough` and the `'finish'` disposition unchanged).
+- CTRL-Z / regenerate user surfaces —
+  [Slice 3.9](./09-undo-batched.md) /
+  [Slice 3.10](./10-regenerate.md) over C3.
+- The Settings · Memory · Classifier panel (cadence edit, status
+  block, error pill routing) — M7.2.
+- `common_knowledge` auto-emission — rejected by canon; user-only.
+- Retired→active transitions — user-only in v1.
+
+## Acceptance criteria
+
+- A seeded story with N unclassified turns: one pass writes
+  happenings with involvements + awareness rows carrying
+  `decay_resistance` and `learned_at_entry_id`, relationship rows
+  canonically ordered (the data-model two-entry worked example
+  reproduces), and `processedThrough = head` — all rows
+  `embedding_stale = 1`, zero vec0 writes (vitest over stub LLM
+  fixtures).
+- Disambiguation matrix: no-name-match creates; high-sim promotes
+  staged; low-sim creates flagged; ambiguous creates flagged
+  (vitest with a deterministic stub embedder).
+- Provenance: a fixture emitting facts about turns 3 and 5 in one
+  pass anchors each delta to its source turn; reversing turn 5
+  spares turn 3's facts and clamps `processedThrough` to 4; the
+  re-run pass re-processes only turn 5 and re-derives nothing
+  spared (vitest end-to-end).
+- Barrier: a reversal fired while a classifier run is mid-stream
+  cancels it (no committed deltas) and no new run starts inside the
+  `reversalInProgress` window; a reversal fired during the commit
+  burst lets the burst land and sweeps it positionally (vitest with
+  a controllable stub).
+- Retry policy: three injected failures walk the backoff into
+  failed-persistent; cadence ticks no-op there; the manual-run
+  action clears it on success (vitest, fake timers).
+- Happening delete / merge cascades involvements + awareness
+  (vitest on the reconcile arms).
+- Retirement, two assertions: (1) apply path — a fixture emitting a
+  hard-finality retirement writes `active → retired` and a
+  non-final "wandered off" fixture writes nothing; (2) prompt — the
+  rendered classifier prompt carries the hard-finality retirement
+  directive (snapshot test).
+- Pre-flight: an unassigned `periodic-classifier` agent halts a
+  cadence-triggered run before phase 0 with the M2 failure
+  vocabulary — no HTTP call, no deltas (vitest).
+- Concurrency: a classifier run mid-flight while a per-turn run
+  commits — both land, no clobbered rows (the cadence.md
+  disjointness test).
+
+## Tests
+
+- Vitest throughout (this is the highest-risk slice): extraction
+  parse fixtures, provenance matrix, disambiguation bands, retry
+  state machine, barrier interleavings, cascade, UPSERT-merge,
+  pre-flight halt for an unassigned agent, retirement prompt
+  snapshot.
+- Manual smoke: real provider, cadence 2–3 turns, verify graph
+  population and the pill's low-priority behavior during a
+  foreground turn.
+
+## Open questions
+
+- **Output wire format** — strict structured-output mode
+  (capability-gated) vs tagged trailing block; also whether one
+  call emits all write kinds or the pass splits into a small number
+  of calls.
+- **Scheduler placement** — store-subscription on entry commits vs
+  an orchestrator-adjacent tick module.
+- **τ_high / τ_low starting values** — canon suggests 0.75 / 0.50
+  cosine as starting ranges; pin the constants and their config
+  location (hardcoded v1 per the tuning-surface parking).
+- **Prompt-window truncation cap** — `app_settings` carries
+  classifier truncation caps (app-only settings); confirm the M1.5
+  field and apply it to the window build.
+
+## Implementation notes
+
+_Populated at finish: notable deviations from the plan and resolved developer decisions._

--- a/docs/implementation/milestones/03-memory-floor/slices/04-retrieval.md
+++ b/docs/implementation/milestones/03-memory-floor/slices/04-retrieval.md
@@ -1,0 +1,184 @@
+# Slice 3.4 — Retrieval: sync stage, query stack, ranker, budgets, memory templates
+
+## Metadata
+
+- **Milestone:** [Milestone 3 — Memory floor](../milestone.md)
+- **Depends on:** [Slice 3.1a](./01a-embedder-core.md) (vec0 +
+  query embeds via C1). Develops against `pnpm db:seed` rows —
+  no build gate on [Slice 3.3](./03-classifier.md); real-data
+  validation is a milestone DoD item. Pairs with
+  [Slice 3.1b](./01b-embedder-lifecycle.md) via C8 (the
+  sync-failure `Switch embedder` route) — doc-contract, not a
+  gate.
+- **Blocks:** [Slice 3.5](./05-dev-probe.md) (capture writer
+  serializes the C4 trace; parity test needs the pure module)
+
+## Goal
+
+Each turn's prompt gains a retrieved slice: the pre-retrieval sync
+stage embeds dirty rows, three query vectors rank per-type
+candidate pools through the pure ranker module (scoring, decay,
+pinning, high-similarity bypass, MMR, greedy budget-fill), and the
+selected bundle renders into the prompt through new memory pack
+templates. `js-tiktoken` lands as the first budget-accounting
+consumer; injected awareness rows get their `retrieval_count`
+increment; `lore.keywords` drives the keyword pathway.
+
+## Background
+
+Retrieval is a phase in the per-turn pipeline, after Pre commits
+the user-action delta. It never reads vec0 without syncing first —
+the sync stage embeds every `embedding_stale` row in one batch, and
+a row it cannot embed blocks the turn like a failed LLM call.
+Scoring blends three query similarities, decays by chapter age
+scaled by the pin signal, adds keyword boosts, and revives
+deeply-decayed rows on very high similarity; MMR de-dupes within
+each type; hard-partitioned per-type token budgets fill greedily
+and stop at the noise floor. Chapter summaries and the
+chapter-match boost are structurally present but inert until M5
+closes chapters. The ranker must be a pure module — the probe's
+simulator re-runs it bit-for-bit.
+
+## Required reading
+
+- [`retrieval.md`](../../../../memory/retrieval.md) — the whole
+  doc; load-bearing sections:
+  [`Compute lifecycle`](../../../../memory/retrieval.md#compute-lifecycle),
+  [`Query construction`](../../../../memory/retrieval.md#query-construction--three-vector-stack),
+  [`Candidate pools`](../../../../memory/retrieval.md#candidate-pools),
+  [`Hybrid retrieval per type`](../../../../memory/retrieval.md#hybrid-retrieval-per-type),
+  [`Keywords schema`](../../../../memory/retrieval.md#keywords-schema),
+  [`Pinning`](../../../../memory/retrieval.md#pinning--decay_resistance),
+  [`Per-type retrieval budgets`](../../../../memory/retrieval.md#per-type-retrieval-budgets),
+  [`The ranker`](../../../../memory/retrieval.md#the-ranker) with
+  [`Pseudocode`](../../../../memory/retrieval.md#pseudocode).
+- [`architecture.md → Retrieval / injection phase`](../../../../architecture.md#retrieval--injection-phase)
+  — structural floor, injection-mode filtering, POV-awareness
+  union.
+- [`architecture.md → Prompt templates and authoring`](../../../../architecture.md#prompt-templates-and-authoring)
+  and [`Context groups`](../../../../architecture.md#context-groups)
+  — where memory templates extend the engine — plus
+  [`Empty retrieval buckets — author contract`](../../../../architecture.md#empty-retrieval-buckets--author-contract)
+  for the bucket guards.
+- [`model-management.md → Embed failure is blocking`](../../../../memory/model-management.md#embed-failure-is-blocking)
+  — the sync-stage failure surface this slice implements.
+- [`edge-cases.md → Layer A`](../../../../memory/edge-cases.md#layer-a--retrieval-time-same-name-suppression)
+  — same-name suppression of staged entities in the pool build.
+- [`memory/probe.md → What gets captured`](../../../../memory/probe.md#what-gets-captured--light-mode-default)
+  — the trace fields C4 must expose (consumed by 3.5).
+- [`tech-stack.md → js-tiktoken`](../../../../tech-stack.md#6-js-tiktoken)
+  — encoding choice, on-demand table loading, accepted drift.
+
+## Scope: in
+
+- **Pre-retrieval sync stage:** batch-embed `embedding_stale` rows
+  via C1 at the head of the retrieval phase (inserted before the
+  narrative phase through the C6 phase-list seam); blocking failure
+  surface (`Retry / Switch embedder / Roll back this turn`,
+  next-turn affordance disabled — the switch action imports 3.1b's
+  swap-dialog open action per C8); stale-at-KNN rows excluded from
+  pools.
+- **Query stack:** Q1 user action; Q2 structural digest
+  (code-template floor + optional piggyback `summary` enrichment,
+  handed off by 3.2's parse);
+  Q3 heuristic prose extract (per-sentence scoring over the
+  entity-name and lore-keyword indexes, top-K concatenated);
+  weight re-normalization when a component is missing; cold-start
+  per canon.
+- **Pool build:** structural floor first (mode-dependent prompt
+  buffer, active+in-scene, location, active threads, `always`
+  rows), then per-type pools — three-sub-pool entity model,
+  POV-awareness union, common-knowledge bypass, pending / resolved
+  / failed threads by mode, Layer-A same-name suppression,
+  chapter-summaries pool (empty until M5).
+- **Pure ranker module (C4):** scoring function with decay + pin +
+  bypass + kw_boost, chapter-match boost hook, top-200 pre-filter,
+  MMR, greedy budget-fill with noise floor; per-candidate trace
+  output per C4; v1 constants hardcoded per the parked tuning
+  surface.
+- **Budgets + tokens:** `js-tiktoken` install; token estimation
+  (rendered-field text + per-type overhead constants, measured once
+  macros are concrete); per-type budgets read from story settings
+  (additive-slider UI is M7-era; values flow from
+  `default_story_settings` copies); oversized-candidate skip
+  semantics.
+- **Memory pack templates:** bundled-pack extension rendering the
+  selected bundles (entity / lore / happening / thread blocks,
+  staged-entity framing with bracketed IDs, awareness `source`
+  verbatim); empty-bucket guards per the author contract;
+  `retrieval` context-group variables registered in
+  `templateContextMap.ts`.
+- **`retrieval_count` increment** on injected awareness rows,
+  delta-logged under the turn's `action_id` (feeds chapter-close 3d
+  in M5.2).
+- **Token-progress strip:** wire the reader's zero-filled strip
+  (M2.5 interim) with real open-region token counts if it falls out
+  of the tokenizer work cheaply; otherwise record the deferral in
+  Implementation notes (milestone open question).
+
+## Scope: out
+
+- Capture writing and the simulator —
+  [Slice 3.5](./05-dev-probe.md).
+- Chapter summaries as a populated pool and the per-chapter
+  `retrieval_count` reset — M5.2.
+- Ranker-knob user tuning surface —
+  [parked](../../../../parked.md#tier-2-retrieval-ranker-knob-tuning-surface).
+- LLM-fallback leg of `auto` injection mode — post-v1 posture per
+  canon (keyword + embedding ship; the enum stays honest).
+- Budget-slider settings UI — M7-era settings depth; values are
+  consumed here, edited later.
+
+## Acceptance criteria
+
+- Seeded story (entities, lore with keywords, happenings +
+  awareness, threads): a turn's rendered prompt contains the
+  structural floor plus per-type retrieved blocks within each
+  type's budget; an `injection_mode='disabled'` in-scene entity
+  still injects (structural invariant); a disabled off-scene one
+  never does (vitest over rendered output; extends the M2.6
+  structural-floor test).
+- Sync-before-read: rows dirtied by a simulated classifier write
+  embed at the next turn's sync stage before KNN; a fault-injected
+  embed failure blocks the turn with the three-action surface and
+  the affordance re-enables after Retry succeeds (vitest +
+  Storybook for the surface).
+- Ranker unit matrix over fixture pools: pin flat-tops decay;
+  `τ_revive` bypass revives a decayed high-sim row; MMR drops a
+  near-duplicate; budget-fill skips an oversized candidate and
+  stops at the noise floor; common-knowledge rows score without
+  recency or pin (vitest on the pure module — no store, no DB).
+- Q3 extraction picks the fixture's entity-name / keyword / verb
+  sentences over filler (vitest).
+- POV union: awareness of any in-scene character enters the pool;
+  a non-scene character's awareness does not.
+- `retrieval_count` increments exactly once per injected awareness
+  row per turn, delta-logged, and reverses on CTRL-Z of the turn.
+- Per-turn retrieval cost on a seeded 10k-row pool stays within the
+  same order as the
+  [PoC baseline](../../../../memory/retrieval.md#performance-characteristics--poc-findings)
+  (~43 ms per KNN query at 10k rows on flagship Android) on desktop
+  (logged timing, not a CI gate).
+
+## Tests
+
+- Vitest: pure-ranker matrix (the load-bearing suite), query
+  construction incl. cold start and re-normalization, pool
+  exclusions, sync-stage failure paths, token estimation, template
+  rendering with empty buckets, registry parity (context keys vs
+  `templateContextMap`).
+- Storybook: sync-failure surface compound if extracted.
+- Manual smoke: seeded story on desktop + Android; eyeball injected
+  bundle relevance (tuning is out of scope; sanity only).
+
+## Open questions
+
+- **Entity-name / keyword index shape** — in-memory per-branch
+  index rebuilt on hydrate vs SQL-side matching; Q3 and Layer A
+  share it.
+- **Per-type overhead constants** — measured after the memory
+  macros are concrete; record the measured values.
+
+## Implementation notes
+
+_Populated at finish: notable deviations from the plan and resolved developer decisions._

--- a/docs/implementation/milestones/03-memory-floor/slices/05-dev-probe.md
+++ b/docs/implementation/milestones/03-memory-floor/slices/05-dev-probe.md
@@ -1,0 +1,127 @@
+# Slice 3.5 — Developer-only retrieval probe: first captures, parity test
+
+## Metadata
+
+- **Milestone:** [Milestone 3 — Memory floor](../milestone.md)
+- **Depends on:** [Slice 3.4](./04-retrieval.md) (serializes the C4
+  ranker trace; parity test re-runs the pure module)
+- **Blocks:** none in M3 (M7.5's rich probe surface reads what this
+  slice writes)
+
+## Goal
+
+The first `probe_captures` writes and the correctness backstop for
+everything 3.4 built: the capture writer records light-mode ranker
+state in the ranker's transaction behind the two-level gate, FIFO
+eviction holds the per-story cap, a developer-only inspection
+affordance makes captures readable during implementation, and the
+simulator-vs-prod parity test pins the pure-ranker contract. The
+rich user-facing probe screen is deliberately M7.5.
+
+## Background
+
+Calibrating the ranker later is guesswork without captured state,
+and debugging retrieval failures without a capture of the failed
+pass is the worst UX — so captures land with retrieval, not with
+the probe screen. A capture is written right after the ranker emits
+its selection, in the same transaction, including on failure (with
+`failure_reason`). Both gates default off
+(`app_settings.diagnostics.enabled` and
+`stories.settings.probe_mode_active`, landed in M1.5); capture
+writes are best-effort and never block a turn. The simulator that
+M7.5 ships must mirror the prod ranker bit-for-bit — the shared
+pure module plus this slice's parity test is what makes that
+trustworthy.
+
+## Required reading
+
+- [`probe.md → Capture model`](../../../../memory/probe.md#capture-model)
+  — when a capture writes, the light-mode field inventory, the
+  `probe_captures` shape, FIFO-at-100, capture cost + best-effort
+  posture.
+- [`probe.md → Simulator contract`](../../../../memory/probe.md#simulator-contract)
+  — the pure-module mirror requirement this slice's parity test
+  pins (the simulator UI itself is M7.5).
+- [`probe.md → Followups → v1-internal`](../../../../memory/probe.md#v1-internal)
+  — the simulator-math validation item this slice resolves.
+- [`probe.md → Schema delta`](../../../../memory/probe.md#schema-delta)
+  — gates, non-delta-logged posture, fork behavior.
+- [`observability.md → Gating model`](../../../../observability.md#gating-model)
+  — the diagnostics master gate the app-level toggle rides.
+
+## Scope: in
+
+- **Capture writer:** assemble the light-mode record from the C4
+  trace (identity, params snapshot, three queries with per-query
+  metadata and Q3 sentence scores, per-type candidate rows, funnel
+  summary, structural-floor list, stale counts); gzip payload;
+  write in the ranker's transaction; FIFO eviction at 100 per story
+  (across branches) in the same transaction; failure-capture path
+  with `failure_reason` and partial state; write-failure = log and
+  proceed.
+- **Gating:** both toggles must be on to write; existing captures
+  stay readable when either flips off; per-capture delete and
+  clear-all-for-story actions (direct deletes, not delta-logged).
+- **Deep-mode hook:** the capture writer accepts a
+  per-capture deep flag and stores query + candidate vectors when
+  set. The reader-side opt-in checkbox ships with the M7.5 surface;
+  in M3 the flag is reachable from the dev affordance only.
+- **Developer inspection affordance:** a minimal dev-only surface
+  (debug-gated; shape at planning — likely a JSON view over
+  captures for the open story) plus structured `logger.debug`
+  score summaries per pass. Not a designed screen; M7.5 owns that.
+- **Parity test:** re-run the pure ranker module over a captured
+  state with identical params and assert selection + score
+  equality with the capture — the simulator-math validation item
+  from probe.md, resolved here.
+
+## Scope: out
+
+- The memory-probe screen (browse / inspect / simulate UX),
+  per-entry probe icon in the reader, per-turn deep-capture
+  checkbox by the Send button — M7.5.
+- Cross-capture aggregation, multi-turn playback — post-v1 per
+  canon.
+- Any new schema — `probe_captures` and both gate fields landed in
+  M1.5.
+
+## Acceptance criteria
+
+- With both gates on, a turn writes one light capture whose payload
+  round-trips (gunzip → JSON) to the documented field inventory
+  against a fixture pool; with either gate off, no write (vitest).
+- Capture 101 for a story evicts the oldest across branches in the
+  same transaction (vitest).
+- A fault-injected retrieval failure (embedder down at query embed)
+  still writes a capture with `failure_reason` and the reached
+  partial state (vitest).
+- A fault-injected capture write failure (constraint violation)
+  does not fail the turn; the failure logs (vitest).
+- Parity: for three captured fixture states (normal, budget-
+  saturated, bypass-triggered), the re-run module reproduces the
+  captured selection and scores exactly (vitest — the load-bearing
+  test).
+- Fork: captures do not copy to the new branch (vitest over the
+  branch-copy exclusion — asserted against the M1.5 fork fixture if
+  present, else a direct query assertion).
+
+## Tests
+
+- Vitest throughout (this slice is mostly tests + a writer);
+  no Storybook scope (no designed compounds).
+- Manual: dev affordance renders captures for a real seeded story;
+  a deep capture's size lands in the expected ~100x-light order.
+
+## Open questions
+
+- **Dev affordance shape** — JSON viewer route vs logger-only; pick
+  the cheapest thing that lets implementation debugging read
+  captures (it is disposable once M7.5 lands).
+- **Params-snapshot source** — v1 ranker knobs are hardcoded
+  constants (tuning surface parked); the snapshot should read the
+  same constants module so the simulator diff is honest. Confirm at
+  planning.
+
+## Implementation notes
+
+_Populated at finish: notable deviations from the plan and resolved developer decisions._

--- a/docs/implementation/milestones/03-memory-floor/slices/06-wizard-world-cast.md
+++ b/docs/implementation/milestones/03-memory-floor/slices/06-wizard-world-cast.md
@@ -1,0 +1,156 @@
+# Slice 3.6 — Wizard steps 3 (World) + 4 (Cast), opening refine / regenerate
+
+## Metadata
+
+- **Milestone:** [Milestone 3 — Memory floor](../milestone.md)
+- **Depends on:** none (day-one; M1.5 lore / entity layer + M2.3
+  wizard shell are merged prerequisites). Pairs with
+  [Slice 3.1a](./01a-embedder-core.md) via the C5 wizard-commit
+  seam — doc-as-contract, not a gate.
+- **Blocks:** none
+
+## Goal
+
+The wizard's two deferred steps become real: step 3 (World —
+genre / tone preset-plus-prose hybrid, setting, initial lore list
+with inline editor) and step 4 (Cast — all four per-kind bespoke
+editors with disclosures, status / lead / staged logic,
+pick-from-cast pickers, AI-suggest with structured identity), plus
+the refine / regenerate affordances on the step-5 opening preview.
+Opening generation now consumes the seeded world + cast context,
+and the step indicator's disabled World / Cast pills go live.
+
+## Background
+
+M2.3 shipped steps 1, 2, and 5 with a minimal lead input; genre /
+tone / setting commit as empty strings and the cast is at most one
+bare lead row. This slice replaces that floor with the full
+authoring surface. The wizard editors are bespoke — their tier
+shapes exclude classifier-managed fields per the authorship
+contract, and they are not a precursor to the M4 world panel.
+Wizard-authored identity seeds `CharacterState` at first write;
+staged entities are pre-introduced actors the narrative can promote
+later. Everything commits through the existing atomic Finish; the
+rows flow through 3.1a's embed step without this slice knowing its
+internals (C5).
+
+## Required reading
+
+- [`wizard.md → Step 3 — World`](../../../../ui/screens/wizard/wizard.md#step-3--world)
+  — genre / tone three input paths, replace-on-existing confirm,
+  setting, initial-lore list + inline editor, validation gates.
+- [`wizard.md → Step 4 — Cast`](../../../../ui/screens/wizard/wizard.md#step-4--cast)
+  — add affordances, compact rows, all four editors,
+  status field cascades, AI-suggest structured identity,
+  lead-required gating, validation gates.
+- [`wizard.md → AI-assist pattern`](../../../../ui/screens/wizard/wizard.md#ai-assist-pattern)
+  — incl. [`Refine`](../../../../ui/screens/wizard/wizard.md#refine--prose-result-only)
+  (prose-result only) and pagination on list results.
+- [`wizard.md → Step 5`](../../../../ui/screens/wizard/wizard.md#step-5--opening--finish)
+  — the opening preview states refine / regenerate slot into.
+- [`data-model.md → World-state storage`](../../../../data-model.md#world-state-storage)
+  — per-kind `state` shapes the editors map to
+  ([`CharacterState`](../../../../data-model.md#characterstate-shape),
+  [`LocationState`](../../../../data-model.md#locationstate-shape),
+  [`ItemState`](../../../../data-model.md#itemstate-shape),
+  [`FactionState`](../../../../data-model.md#factionstate-shape)).
+- [`data-model.md → Authorship contract`](../../../../data-model.md#authorship-contract)
+  — wizard-authored vs classifier-managed field split (the editors
+  must not expose classifier-managed fields).
+- [`data-model.md → Soft caps`](../../../../data-model.md#soft-caps--compaction-discipline)
+  — traits / drives / agenda chip-input caps.
+- [`data-model.md → Opening entry`](../../../../data-model.md#opening-entry)
+  — the structured-output opening; `sceneEntities` constrained to
+  active cast.
+- [`calendar-systems/spec.md → Rendering pipeline`](../../../../calendar-systems/spec.md#rendering-pipeline)
+  — the renderer the step-2 calendar summary preview samples
+  (cross-cutting roadmap item landing here).
+
+## Scope: in
+
+- **Step 3 — World:** genre / tone label + promptBody with manual /
+  preset-browse / AI-suggest paths and the replace-on-existing
+  confirm; the bundled preset catalog (code-authored JSON, same
+  pattern as suggestion-category defaults); setting textarea with
+  AI-suggest; initial-lore list (compact rows, inline editor with
+  `▼ More options` — tags / injection mode / priority), long-scroll;
+  validation (lore rows need title + body; genre / setting
+  encouraged, not gated).
+- **Step 4 — Cast:** mixed insertion-ordered entity list; `+ Add ▾`
+  per kind; `✨ Suggest cast` (structured per-kind output, guidance
+  steering, cross-batch name resolution, pagination); the four
+  editors with `▼ Visual` / `▼ More options` disclosures and
+  pick-from-cast pickers (faction, parent location); status
+  `active` / `staged` with the lead cascades (auto-unmark toast,
+  gate tightening, opening enum-list filtering); `⭐ Set as lead`
+  visibility rules; validation gates.
+- **Step indicator:** World / Cast pills enable; back-jump pill
+  demotion for the lead rule stays correct across five live steps.
+- **Opening refine / regenerate:** on the step-5 AI preview —
+  regenerate re-rolls with the same guidance; refine opens the
+  guidance popover seeded per the AI-assist pattern's
+  prose-result refine contract.
+- **Opening context:** the wizard-group opening template consumes
+  authored genre / tone / setting / lore / cast; `sceneEntities`
+  enum filters to `status='active'`; the minimal-lead path keeps
+  working when the cast is empty (creative + third).
+- **Step-2 calendar-summary preview** sampling the renderer (the
+  roadmap's calendar-subsystem row for M3.6).
+- Removal of the M2 "minimal lead input" in favor of the real cast
+  editor, preserving draft-session compatibility (old drafts with a
+  bare lead row open into step 4 cleanly).
+
+## Scope: out
+
+- Memory-cost (Matryoshka) disclosure on step 5 —
+  [Slice 3.1b](./01b-embedder-lifecycle.md).
+- The embed step in Finish — [Slice 3.1a](./01a-embedder-core.md)
+  (C5).
+- World-panel editors, collision review — M4.
+- Wizard-time pack selection, prompt-pack editor — parked.
+- Regenerate-opening from reader chrome post-commit — parked.
+
+## Acceptance criteria
+
+- A story is creatable with genre + tone (preset-picked and
+  hand-edited), setting, ≥ 2 lore rows, and a mixed cast
+  (character / location / item / faction, incl. one staged
+  character); Finish commits every row in the one transaction and
+  the opening call's context contains the authored world + cast
+  (vitest on the commit + rendered-context assertion).
+- Staged entities never appear in the opening's `sceneEntities`
+  enum; marking the lead as staged auto-unmarks with the toast and
+  re-blocks `Next` (vitest on the cascade rules).
+- AI-suggest cast: a structured fixture with
+  `parent_location_name` + faction cross-references resolves ids
+  within the batch; unresolved names fall back to null (vitest).
+- Lore inline editor round-trips all `More options` fields;
+  an empty-body row blocks `Next` with an inline error.
+- Refine on the opening preview: guidance popover pre-seeds,
+  re-roll replaces the preview, `Use this` commits the refined
+  prose; regenerate produces a new take without guidance edits
+  (manual smoke + state-machine vitest).
+- A pre-M3.6 draft session (bare lead, empty world) reopens
+  without data loss and completes through the new steps.
+- Every new chrome string routes through `t()`; new compounds have
+  stories.
+
+## Tests
+
+- Vitest: cascade rules (lead / staged), suggest-cast resolution,
+  draft-session migration, commit composition, validation gates.
+- Storybook: step-3 / step-4 bodies, the per-kind editors, preset
+  browser, refine popover states.
+- Manual smoke: full five-step run on desktop + Android (keyboard
+  avoidance on the editors per the wizard doc's mobile expression).
+
+## Open questions
+
+- **Preset catalog contents** — how many genre / tone presets ship
+  and who authors the prose bodies; planning decision.
+- **Suggest-cast batch size vs pagination** — canon default is 5
+  mixed; confirm the pagination interaction with per-kind steering.
+
+## Implementation notes
+
+_Populated at finish: notable deviations from the plan and resolved developer decisions._

--- a/docs/implementation/milestones/03-memory-floor/slices/07-suggestions.md
+++ b/docs/implementation/milestones/03-memory-floor/slices/07-suggestions.md
@@ -1,0 +1,169 @@
+# Slice 3.7 — Next-turn suggestions: emission folds, chip strip, refresh pipeline
+
+## Metadata
+
+- **Milestone:** [Milestone 3 — Memory floor](../milestone.md)
+- **Depends on:** [Slice 3.2](./02-piggyback.md) (both on-turn
+  emission folds ride its per-turn paths; `<suggestions>` parses
+  through C2); [Slice 3.11](./11-story-settings-shell.md) —
+  partial: only the settings section's host waits on the shell
+  (C7); emission, persistence, and the chip strip proceed
+  regardless
+- **Blocks:** none in M3 (the `models.suggestion` slot in the app
+  settings models tab extends in M7.1)
+
+## Goal
+
+After each AI reply, tappable suggestion chips seed the user's next
+turn: a sibling `<suggestions>` block emits in the narrative fold
+(piggyback on) or the classifier fold (piggyback off), persists on
+the entry's metadata, and renders as the reader's chip strip with
+category overlines, a refresh re-roll through the new
+`suggestion-refresh` pipeline, and an empty-state Generate. Story
+Settings gains the Composer categories editor (wiring the shipped
+`SuggestionCategoriesEditor`) plus the `suggestionsEnabled` toggle
+and `suggestionCount` stepper.
+
+## Background
+
+Suggestions are user-customizable per story: a category palette
+(seeded at creation from
+`app_settings.default_suggestion_categories[mode]` — the column and
+seed landed in the M1.5 gate) whose enabled entries the model picks
+from per slot; chip count is decoupled from category count.
+Emissions persist on `story_entries.metadata.nextTurnSuggestions`,
+so chips are reload-, branch-, and rollback-safe through the
+existing metadata delta log. The re-roll path is a dedicated
+2-stage pipeline (`suggestion-refresh`, `no-gate`, self-blocking)
+using the `suggestion` agent slot, with current composer text as
+`refreshGuidance`. Tap fills the composer in `Free` mode; the
+tap-after-typing draft loss is a documented v1 wart.
+
+## Required reading
+
+- [`reader-composer.md → Next-turn suggestions`](../../../../ui/screens/reader-composer/reader-composer.md#next-turn-suggestions)
+  — the full reader surface: chip anatomy, states, chrome row,
+  empty-state, orphan / disabled category rules, and its
+  [edge cases](../../../../ui/screens/reader-composer/reader-composer.md#edge-cases).
+- [`data-model.md → Entry metadata shape`](../../../../data-model.md#entry-metadata-shape)
+  — `nextTurnSuggestions` persistence shape + delta-log behavior.
+- [`data-model.md → Story settings shape`](../../../../data-model.md#story-settings-shape)
+  — `suggestionCategories` / `suggestionCount` /
+  `suggestionsEnabled` and copy-at-creation.
+- [`generation-pipeline.md → V1 declarations`](../../../../generation-pipeline.md#v1-declarations)
+  — the `suggestion-refresh` declaration values (no-gate,
+  `blockedBy: ['per-turn', 'suggestion-refresh']`).
+- [`generation-pipeline.md → Config pre-flight validation`](../../../../generation-pipeline.md#config-pre-flight-validation)
+  — resolver-input declaration for the `suggestion` agent.
+- [`story-settings.md → Suggestion categories`](../../../../ui/screens/story-settings/story-settings.md#suggestion-categories)
+  — the editor's placement and bound data.
+- [`ui/patterns/generation-status-pill.md`](../../../../ui/patterns/generation-status-pill.md)
+  — the refresh pipeline's pill presence at low priority.
+
+## Scope: in
+
+- **Emission fragment:** the shared `<suggestions>` prompt fragment
+  (enabled categories with `cat<N>` placeholders, `suggestionCount`
+  slots, diversity nudge) appended to the narrative fold (3.2's
+  piggyback call) and the classifier fold (3.2's fallback pass);
+  category-id placeholder swap post-parse; parse independence from
+  `<state>` in all four outcome combinations (via C2).
+- **Persistence:** metadata write with `source` tag
+  (`piggyback` / `classifier` / `refresh`), `refreshGuidance` when
+  present; delta-logged like any metadata mutation.
+- **`suggestion-refresh` pipeline:** declaration + registration;
+  stage 1 single-shot emission via the `suggestion` agent
+  resolution; stage 2 conditional translation is a declared no-op
+  skip in M3 (no translation settings UI before M7.2 — the M2
+  short-circuit posture carries over); abort on branch switch;
+  pill copy "Refreshing suggestions" at low priority;
+  click-to-cancel before write.
+- **Chip strip:** panel between entries and composer on terminal
+  AI entries; chip anatomy (overline, prose body, accent strip,
+  theme-resolved palette slot); states
+  (`visible / loading / error / collapsed / hidden / empty-state`);
+  chrome row (⟳ refresh with composer text as guidance, ⌄
+  collapse); tap → composer fill + `Free` mode; orphan-category
+  `(removed)` fallback; disabled-category render rules;
+  accessibility (chip = button with category label, `aria-busy`
+  loading, refresh `aria-label`).
+- **Settings surface:** the Composer section registered into the
+  Story Settings shell per C7
+  ([Slice 3.11](./11-story-settings-shell.md) hosts), with
+  `suggestionsEnabled` master toggle, `suggestionCount` stepper,
+  and the categories editor wiring the shipped
+  `SuggestionCategoriesEditor` over
+  `stories.settings.suggestionCategories` (drag order, enable,
+  label validation, ColorPicker, prompt hint, delete confirm,
+  reset-to-mode-defaults).
+- **Pre-flight:** resolver-input declarations so an unassigned
+  `suggestion` agent halts the refresh pipeline before phase 0
+  with the M2 vocabulary; the on-turn folds ride the narrative /
+  classifier agents' existing declarations.
+
+## Scope: out
+
+- The App Settings → Story Defaults categories editor (per-mode
+  tabs over `default_suggestion_categories`) — M7.1 settings depth;
+  the seed data flows from M1.5 regardless.
+- The `models.suggestion` assignment UI — M7.1 models tab; the
+  resolution chain + failure vocabulary cover M3.
+- Chip-text translation (stage 2 active path) — M8.1/M8.2.
+- Recency-bias category-mix hint, split capability flag, split
+  translation toggle, restore-draft on tap-after-typing,
+  cancel-and-restart re-roll — all parked-until-signal per canon.
+
+## Acceptance criteria
+
+- Narrative fold: a stub turn emitting `<state>` + `<suggestions>`
+  persists chips with `source: 'piggyback'` and renders the strip;
+  `<suggestions>` parse failure alone leaves state applied and the
+  strip in empty-state Generate; the inverse leaves chips rendered
+  (vitest over the four combinations).
+- Classifier fold: with `piggybackMode='off'`, the fallback pass
+  emits both blocks in one call; chips persist with
+  `source: 'classifier'` (vitest).
+- Refresh: ⟳ with composer text passes it as `refreshGuidance`
+  (persisted), strip shows loading, second click no-ops
+  (self-block), result overwrites chips with `source: 'refresh'`
+  under a delta CTRL-Z reverses (vitest + manual).
+- Empty-state: opening / user / system terminal entries show ⟳
+  Generate; click produces chips ex nihilo.
+- Tap: composer text replaced, mode set to `Free`; chip from a
+  deleted category renders `(removed)` with neutral color and
+  still taps.
+- Rollback: after CTRL-Z of a turn, the prior terminal entry's
+  chips become the active strip (vitest over the metadata delta).
+- Settings: category edits round-trip; zero enabled categories
+  stops emission but historical chips still render;
+  `suggestionsEnabled` toggles per the mid-story matrix (vitest on
+  the emission gate; manual on the editor).
+- Pre-flight: unassigned `suggestion` agent blocks the refresh
+  pipeline before phase 0 with a system entry naming the failure.
+
+## Tests
+
+- Vitest: parse-combination matrix, persistence + rollback,
+  refresh pipeline state machine incl. self-block + branch-switch
+  abort, pre-flight halt for an unassigned `suggestion` agent,
+  emission gating (enabled categories, master toggle),
+  placeholder swap for category ids.
+- Storybook: chip strip in all six states; categories-editor
+  binding story if the wiring extracts a new compound.
+- Manual smoke: real-provider turns with chips on desktop +
+  Android; refresh with guidance.
+
+## Open questions
+
+- **Fragment placement in the classifier-fold call** — one call
+  emitting `<state>` + `<suggestions>` is canon; confirm ordering
+  and token budget interaction with 3.2's fallback prompt at
+  planning.
+- **Strip virtualization interaction** — the strip sits between the
+  virtualized entry list and the composer; confirm it lives outside
+  the scroll container (reader-document pattern) rather than as a
+  list row.
+
+## Implementation notes
+
+_Populated at finish: notable deviations from the plan and resolved developer decisions._

--- a/docs/implementation/milestones/03-memory-floor/slices/08-worldtime-edit.md
+++ b/docs/implementation/milestones/03-memory-floor/slices/08-worldtime-edit.md
@@ -1,0 +1,120 @@
+# Slice 3.8 — Per-entry worldTime click-to-edit + monotonicity flag
+
+## Metadata
+
+- **Milestone:** [Milestone 3 — Memory floor](../milestone.md)
+- **Depends on:** none (day-one build — entry metadata + the M2.3
+  `lib/calendar` substrate and M2.5 footer rendering are merged
+  prerequisites). Milestone-level validation waits on
+  [Slice 3.2](./02-piggyback.md) writing non-zero `worldTime`
+  values (the per-turn layer owns that write); that is a
+  verification gate, not a build gate.
+- **Blocks:** none
+
+## Goal
+
+The world-time footer becomes the manual-correction surface for
+`metadata.worldTime`: click opens an edit overlay hosting a
+`TierTupleInput` for the active calendar, Save writes one
+`op=update` delta, and the reader computes the per-entry
+monotonicity-break flag that EntryCard renders as a warning glyph
+and overlay banner.
+
+## Background
+
+The classifier estimates elapsed time and will get it wrong;
+the correction is direct manipulation with no cascade — one edit,
+one reversible delta, downstream consumers tolerate any
+non-negative value. M2.5 already renders the footer label
+opaquely through the calendar formatter; this slice supplies the
+interactive half the EntryCard pattern pins: `onEditTime` +
+`worldTimeRaw` make the footer clickable on AI, opening, and user
+entries, and `worldTimeMonotonicityBreak` drives the indicator.
+The monotonicity walk is host-side — O(N) per list render against
+the entries collection, comparing each entry to the most recent
+preceding entry with `worldTime > 0` (flashback zeros skipped).
+
+## Required reading
+
+- [`entry-card.md → World-time footer`](../../../../ui/patterns/entry-card.md#world-time-footer)
+  — the host contract this slice fulfills: props, overlay shape
+  (Popover desktop / Sheet phone), TierTupleInput body, warning
+  banner, indicator semantics, edit-restrictions gating.
+- [`reader-composer.md → Per-entry world-time footer`](../../../../ui/screens/reader-composer/reader-composer.md#per-entry-world-time-footer)
+  — host responsibilities incl. the cached monotonicity walk.
+- [`data-model.md → In-world time tracking`](../../../../data-model.md#in-world-time-tracking)
+  — the three-layer invariant split, no-cascade contract,
+  flashback-promotion semantics, storage floor (`≥ 0`).
+- [`data-model.md → Entry metadata shape`](../../../../data-model.md#entry-metadata-shape)
+  — metadata edits are delta-logged.
+- [`calendar-systems/spec.md → Rendering pipeline`](../../../../calendar-systems/spec.md#rendering-pipeline)
+  — tuple ↔ seconds walks the overlay round-trips.
+
+## Scope: in
+
+- **Edit overlay:** footer click (respecting the in-flight
+  `disabled` gate) opens Popover / Sheet per breakpoint; body hosts
+  `TierTupleInput` (the shipped wizard primitive) pre-populated
+  from `worldTimeRaw + worldTimeOrigin` through the calendar's tier
+  stack; Save recomputes cumulative seconds, validates `≥ 0`, and
+  invokes the metadata-update action (one `op=update` delta);
+  Cancel discards.
+- **Monotonicity walk:** reader-side computation cached against
+  the entries-collection identity; passes
+  `worldTimeMonotonicityBreak` (with the previous entry's label
+  for the banner / tooltip string) into EntryCard.
+- **Wiring on all editable kinds:** AI, opening, and user entries
+  (user entries inherit `worldTime` at write since M2; they edit on
+  the same terms).
+- The warning banner inside the overlay and the tooltip on desktop
+  indicator hover, per the pattern doc.
+
+## Scope: out
+
+- Footer rendering itself — shipped in M2.5.
+- Per-turn `worldTime` writes — [Slice 3.2](./02-piggyback.md)
+  (the per-turn classification layer owns entry metadata).
+- Era-flip affordances (time-chip popover, flip-era modal) — M7.2.
+- `sceneTime` flashback modeling — explicitly a future exit in
+  canon.
+
+## Acceptance criteria
+
+- Editing an AI entry's time via the overlay writes exactly one
+  `op=update` delta against `metadata.worldTime`; CTRL-Z reverses
+  it; no other entry's metadata changes (vitest on the action;
+  manual on the overlay).
+- The tuple round-trip is lossless: open-edit-save with no change
+  writes no delta (or a no-op guard prevents the write — pick at
+  planning and test it).
+- Setting entry N's time below entry N−1's flags entry N with the
+  indicator; the overlay banner names the previous entry's label;
+  fixing the value clears the flag on next render (component test +
+  Storybook states).
+- Flashback entries (`worldTime = 0`) are skipped as comparison
+  ancestors and are not themselves flagged (vitest on the walk).
+- Footer click is inert while generation is in flight (edit
+  restrictions gate).
+- The walk is computed once per entries-collection identity
+  (memoization asserted — no per-row recomputation in profiling
+  smoke).
+
+## Tests
+
+- Vitest: monotonicity walk matrix (in-order, out-of-order,
+  flashback-skips, head / tail edges), tuple ↔ seconds round-trip
+  against `earth-gregorian`, action delta shape.
+- Storybook: footer editable / indicator / overlay states on
+  EntryCard (extends the shipped stories).
+- Manual smoke: phone Sheet variant with keyboard (fixed-shape
+  body, `avoidKeyboard` only per the pattern).
+
+## Open questions
+
+- **No-change Save semantics** — suppress the delta on equal value
+  vs always-write; lean suppress (delta-log hygiene), confirm at
+  planning.
+
+## Implementation notes
+
+_Populated at finish: notable deviations from the plan and resolved developer decisions._

--- a/docs/implementation/milestones/03-memory-floor/slices/09-undo-batched.md
+++ b/docs/implementation/milestones/03-memory-floor/slices/09-undo-batched.md
@@ -1,0 +1,122 @@
+# Slice 3.9 — CTRL-Z action-batched extension over the survival anchor
+
+## Metadata
+
+- **Milestone:** [Milestone 3 — Memory floor](../milestone.md)
+- **Depends on:** [Slice 3.3](./03-classifier.md) (the C3 shared
+  reversal sweep with drain + clamp; classifier-source deltas to
+  skip and spare)
+- **Blocks:** none
+
+## Goal
+
+CTRL-Z grows from M2.5's single-action undo into the full
+undoable-unit algorithm: head-selection that steps over
+`periodic_classifier` groups, prose-turn undo as a positional
+suffix reversal from the turn's start (carrying piggyback deltas
+and lagging classifier deltas anchored to the undone turn, sparing
+facts anchored to surviving turns), group reversal for non-prose
+actions, and the redo stack over the batched units.
+
+## Background
+
+M2.5 shipped CTRL-Z as "reverse the most recent action group" —
+correct while every delta was foreground. The classifier breaks
+both halves: its groups sit at the log head but are never undo
+targets, and its lagging facts about old turns commit at new tail
+positions, so a bare suffix sweep would over-reverse them. The
+canonical algorithm selects the most recent undoable unit skipping
+classifier groups, then reverses either the positional suffix from
+a prose turn's first `log_position` (filtered by the survival-
+anchor predicate, live since M2.2 and exercised since 3.3) or just
+the `action_id` group otherwise. The sweep itself — barrier drain,
+`reversalInProgress` bracket, watermark clamp — is C3; this slice
+is the selection logic, the redo semantics over batched units, and
+the reader keybinding behavior.
+
+## Required reading
+
+- [`data-model.md → Entry mutability & rollback`](../../../../data-model.md#entry-mutability--rollback)
+  — action boundaries, the three-step CTRL-Z algorithm, redo-stack
+  semantics.
+- [`data-model.md → Survival anchor`](../../../../data-model.md#survival-anchor)
+  — the predicate, the clamp, and the redo re-derive tolerance
+  ("redo does not restore `processedThrough`").
+- [`classifier.md → Background-task framing`](../../../../memory/classifier.md#background-task-framing)
+  — why classifier `action_id`s are never undo targets.
+- [`generation-pipeline.md → Prose reversals and the classifier barrier`](../../../../generation-pipeline.md#prose-reversals-and-the-classifier-barrier)
+  — the bracket this slice's reversals must run inside (via C3).
+
+## Scope: in
+
+- **Target selection:** walk back from the head to the most recent
+  undoable unit (user turn, user edit, chapter close later),
+  skipping `source = periodic_classifier` groups.
+- **Prose-turn reversal:** detect "group creates a `story_entries`
+  row"; reverse the positional suffix from the turn's first
+  `log_position` through the C3 sweep (predicate-filtered, drained,
+  clamped) — the M2.5 single-group path for prose turns is
+  superseded.
+- **Group reversal:** non-prose units reverse their `action_id`
+  group only; classifier deltas above them stay put.
+- **Redo:** reversed deltas move to the in-memory redo stack as one
+  unit; redo re-applies the unit; the stack clears on any new
+  action; no `processedThrough` restore on redo (accepted
+  re-derive, cleaned at M5 chapter-close dedup).
+- **Reader integration:** keybinding + any toast copy unchanged in
+  surface; disabled states while a reversal or pipeline gate is
+  active follow the existing edit-restrictions rules.
+
+## Scope: out
+
+- The sweep internals (barrier, clamp, prune) — C3, owned by
+  [Slice 3.3](./03-classifier.md).
+- Regenerate — [Slice 3.10](./10-regenerate.md) (same sweep,
+  different trigger + re-dispatch).
+- Chapter-close as an undoable unit — the algorithm handles
+  "otherwise" groups generically; the first real chapter-close
+  group arrives in M5.2 (its atomic-unit test lands there).
+- Deep rollback surface (multi-chapter reverse-replay UI) — M5.5.
+- Rollback-to-entry (per-entry delete) — shipped in M2.2; unchanged
+  here beyond riding the C3 sweep.
+
+## Acceptance criteria
+
+- Fixture log: user turn A, classifier pass anchored to A, user
+  turn B, classifier pass with facts anchored to both A and B.
+  CTRL-Z once: B's entry, its piggyback deltas, and classifier
+  facts anchored to B reverse; facts anchored to A survive;
+  `processedThrough` clamps below B; redo restores the unit
+  (vitest — the load-bearing scenario).
+- A classifier group at the literal head is stepped over: CTRL-Z
+  targets the user turn beneath it and the suffix sweep carries the
+  classifier group down with it (vitest).
+- A user field-edit above a classifier group reverses alone
+  (group path); the classifier group stays (vitest).
+- CTRL-Z fired while a classifier run is mid-flight drains it via
+  the C3 bracket before sweeping (vitest with the controllable
+  stub; the interleaving matrix itself is 3.3's suite).
+- Redo of a classifier-processed turn may re-derive that turn's
+  facts (asserted as tolerated: no crash, no duplicate-key
+  violation — awareness UNIQUE upsert absorbs).
+- Undo in a fresh wizard-created story remains a no-op; undo floor
+  stops at the opening (M2 behavior preserved, re-asserted).
+
+## Tests
+
+- Vitest: the fixture-log matrix above, selection walk edge cases
+  (empty log, all-classifier head run, consecutive prose turns),
+  redo-stack unit semantics.
+- No Storybook scope (no new compounds); manual smoke on desktop
+  keybinding + Android (if a UI undo affordance exists per M2.5's
+  surface, exercise it).
+
+## Open questions
+
+- **Redo-stack shape for suffix units** — M2.5's stack stores
+  single groups; batched units need ordered multi-group frames.
+  Confirm the frame shape at planning (runtime-only, no schema).
+
+## Implementation notes
+
+_Populated at finish: notable deviations from the plan and resolved developer decisions._

--- a/docs/implementation/milestones/03-memory-floor/slices/10-regenerate.md
+++ b/docs/implementation/milestones/03-memory-floor/slices/10-regenerate.md
@@ -1,0 +1,133 @@
+# Slice 3.10 — Reader regenerate over the shared reversal sweep
+
+## Metadata
+
+- **Milestone:** [Milestone 3 — Memory floor](../milestone.md)
+- **Depends on:** [Slice 3.3](./03-classifier.md) (the C3 shared
+  reversal sweep — regenerate must drain the in-flight classifier
+  and clamp the watermark like any prose reversal)
+- **Blocks:** none
+
+## Goal
+
+The regen action on AI entries goes live: regenerating a reply
+reverses its turn through the shared sweep, then re-runs the
+per-turn pipeline from the same user input — no confirm in the
+common case. Added at milestone promotion: the roadmap's
+cross-cutting table assigned reader regenerate to M3 but no slice
+bullet owned it.
+
+## Background
+
+Regenerate is "roll this turn back, then generate again": the same
+delta reversal as rollback (survival anchor sparing lagging
+classifier facts about surviving turns, `reversalInProgress`
+bracket, classifier-cancel drain, watermark clamp — all C3),
+followed by re-dispatching the per-turn pipeline against the
+still-standing user action. Discarding the prior take is the
+action's point, so it fires without a confirm; the confirm branch
+canon defines for turns that chained a chapter close is dormant
+until M5.2 (no chapter-close exists in M3) but the seam is named so
+M5.2 lands it without reshaping this flow. The regen glyph shipped
+on EntryCard's action cluster in M2.5's subset as deferred; this
+slice enables it.
+
+## Required reading
+
+- [`reader-composer.md → Per-entry actions`](../../../../ui/screens/reader-composer/reader-composer.md#per-entry-actions)
+  and
+  [`Regenerate confirmation`](../../../../ui/screens/reader-composer/reader-composer.md#regenerate-confirmation)
+  — action placement, no-confirm common case, the chapter-close
+  confirm branch (M5-dormant).
+- [`data-model.md → Entry mutability & rollback`](../../../../data-model.md#entry-mutability--rollback)
+  and [`Survival anchor`](../../../../data-model.md#survival-anchor)
+  — reversal semantics; regenerate is explicitly named as a
+  survival-anchor consumer ("it fires even on
+  regenerate-the-last-reply, when a catch-up pass landed between
+  the reply and its regenerate").
+- [`generation-pipeline.md → Prose reversals and the classifier barrier`](../../../../generation-pipeline.md#prose-reversals-and-the-classifier-barrier)
+  — regenerate is one of the four bracketing reversal kinds.
+- [`ui/patterns/entry-card.md → Action cluster`](../../../../ui/patterns/entry-card.md#action-cluster)
+  — regen's per-kind availability (AI entries only).
+
+## Scope: in
+
+- **Regenerate action:** on an AI entry — resolve the turn's first
+  `log_position` and its entry set, reverse the positional suffix
+  through the C3 sweep, keep the originating `user_action` entry,
+  and re-dispatch the per-turn pipeline under a fresh turn
+  `action_id` with the same wrapped input (the C6 turn-submit
+  surface from M2 or its pipeline-internal equivalent — planning
+  decision on which layer re-dispatches).
+- **Regen on the latest reply and on older replies:** regenerating
+  a non-terminal reply is a deeper rollback (later entries go too)
+  — it routes through the same sweep. **Slice design decision, not
+  canon:** the canonical
+  [regenerate confirmation](../../../../ui/screens/reader-composer/reader-composer.md#regenerate-confirmation)
+  defines a confirm only for the chapter-close case; this slice
+  extends the M2.5 rollback-confirm vocabulary to the multi-entry
+  older-reply case (cascade counts before proceeding) while the
+  terminal-reply case stays confirm-free. Recorded here rather
+  than in canon; flag for a future reader-composer design pass if
+  the behavior should be canonized.
+- **UI wiring:** enable the ↻ glyph per the action-cluster matrix;
+  in-flight edit restrictions (no regen during a running pipeline);
+  streamed replacement renders through the existing streaming entry
+  states.
+- **Chapter-close seam (named, dormant):** the pre-sweep check
+  "does this turn's group include a chapter-close chain" is
+  structured so M5.2 adds the cost-confirm without touching the
+  common path.
+
+## Scope: out
+
+- Refine-with-guidance on replies — not in canon for reader entries
+  (refine is a wizard-opening affordance, 3.6); the composer +
+  suggestions are the steering surface.
+- Swipe-switch between alternate takes — not a v1 reader feature;
+  the barrier lists it for completeness but no surface exists.
+- The chapter-close confirm branch's live path — M5.2.
+- Changes to the sweep itself — C3, owned by 3.3.
+
+## Acceptance criteria
+
+- Regenerating the terminal reply: old reply entry + its piggyback
+  deltas + classifier facts anchored to it reverse; facts anchored
+  to earlier turns survive; `processedThrough` clamps; a new reply
+  streams in under a fresh `action_id`; the user action entry is
+  untouched (vitest end-to-end over the stub provider — the
+  canonical catch-up-pass-then-regenerate scenario).
+- Regenerate fires with no confirm on the terminal reply;
+  regenerating an older reply surfaces the rollback-confirm modal
+  with correct cascade counts before proceeding (vitest on the
+  gate; manual on the modal).
+- Regenerate during an in-flight classifier run drains it first
+  (C3 bracket) and the reversal never strands committed classifier
+  deltas about the regenerated turn (vitest with the controllable
+  stub).
+- Regen is unavailable during any in-flight pipeline and on
+  non-AI entries (matrix per the action cluster).
+- A mid-stream failure of the regenerated call surfaces the M2
+  failure vocabulary and leaves the log at the post-reversal state
+  (no orphan placeholder — same contract as a normal turn).
+- CTRL-Z after a completed regenerate undoes the new take (the
+  regenerated turn is a normal undoable unit).
+
+## Tests
+
+- Vitest: the end-to-end regenerate scenario, older-reply cascade
+  path, barrier interleaving, failure-mid-regen, undo-after-regen.
+- No new compounds expected (glyph + modal already shipped); manual
+  smoke on desktop + Android with a real provider.
+
+## Open questions
+
+- **Re-dispatch layer** — reuse the C6 `submitTurn`-shaped action
+  minus the entry write, vs a pipeline-internal re-run entry point;
+  pick at planning (affects where the "same wrapped input" is
+  sourced from — the surviving `user_action` entry's content is the
+  natural source).
+
+## Implementation notes
+
+_Populated at finish: notable deviations from the plan and resolved developer decisions._

--- a/docs/implementation/milestones/03-memory-floor/slices/11-story-settings-shell.md
+++ b/docs/implementation/milestones/03-memory-floor/slices/11-story-settings-shell.md
@@ -1,0 +1,108 @@
+# Slice 3.11 — Story Settings shell (minimal host + section registration)
+
+## Metadata
+
+- **Milestone:** [Milestone 3 — Memory floor](../milestone.md)
+- **Depends on:** none (day-one; the M1.5 settings substrate and
+  the M2 in-story routing are merged prerequisites)
+- **Blocks:** the settings-section portions of
+  [Slice 3.1b](./01b-embedder-lifecycle.md) (embedding-status
+  panel) and [Slice 3.7](./07-suggestions.md) (Composer section) —
+  partial gates; both slices' core work is independent of this
+  shell.
+
+## Goal
+
+A minimal Story Settings host so M3's two settings surfaces have
+somewhere to live: the route, the screen scaffold with tab /
+section structure per the canonical layout, and a
+section-registration seam (C7) that lets 3.1b and 3.7 add their
+sections without touching shared files. Added at milestone
+promotion — the audit found 3.1b and 3.7 authoring sections into a
+screen the roadmap doesn't build until M4.4.
+
+## Background
+
+The canonical Story Settings screen is large — models, generation,
+memory, translation, pack, and calendar tabs — and its real basic
+surface is M4.4's job, with deep tabs in M7.2. M3 needs only a
+host: the staleness resolution panel canon places in Story
+Settings · Memory, and the suggestions controls canon places in
+Story Settings → Composer. This slice ships the smallest honest
+version of the screen — navigable route, canonical tab skeleton
+with empty-state placeholders, and a registration mechanism —
+explicitly _not_ the M4.4 surface. M4.4 extends this shell rather
+than replacing it.
+
+## Required reading
+
+- [`story-settings.md → Layout`](../../../../ui/screens/story-settings/story-settings.md#layout)
+  and
+  [`Two sections under one roof`](../../../../ui/screens/story-settings/story-settings.md#two-sections-under-one-roof--wizard-editable-vs-post-creation-tuning)
+  — the canonical screen structure the skeleton must not
+  contradict.
+- [`story-settings.md → Memory tab`](../../../../ui/screens/story-settings/story-settings.md#memory-tab)
+  and
+  [`Suggestion categories`](../../../../ui/screens/story-settings/story-settings.md#suggestion-categories)
+  — the two sections M3 consumers register into.
+- [`docs/ui/patterns/save-sessions.md`](../../../../ui/patterns/save-sessions.md)
+  — the save-semantics pattern settings sections bind into (3.7's
+  editor cites it).
+
+## Scope: in
+
+- **Route + entry point:** the Story Settings route reachable from
+  the in-story chrome per the existing navigation model; back
+  routing.
+- **Screen scaffold:** the canonical tab / section skeleton with
+  empty-state placeholders for tabs M3 doesn't fill ("lands in a
+  later milestone" copy), themed per foundations, mobile
+  expression per the standard narrow-tier rules.
+- **Section-registration seam (C7):** each section is a
+  self-registered module (same spirit as the M1.5 delta-dispatch
+  registration — consumers touch no shared file); registration
+  names fixed in this slice's first commit.
+- **Save plumbing floor:** whatever minimal save-session wiring the
+  two M3 sections need to persist through the existing
+  story-settings mutators (3.7's editor and 3.1b's panel bring
+  their own bodies; this slice hosts them).
+
+## Scope: out
+
+- The real basic surface (model overrides, per-story config) —
+  M4.4.
+- Deep tabs (pack, definition, calendar, translation, Advanced,
+  the classifier panel) — M7.2.
+- Any section body — 3.1b and 3.7 own theirs.
+
+## Acceptance criteria
+
+- The Story Settings route opens from an open story and renders
+  the tab skeleton with empty-state placeholders on desktop and
+  Android; navigation back to the reader preserves reader state.
+- A fixture section registered through C7 renders in its declared
+  tab without edits to any shared file (vitest / component test on
+  the registration, mirroring the M1.5 registration-API test
+  shape).
+- Unfilled tabs show the placeholder, not blank panes; no dead
+  controls.
+- Every chrome string routes through `t()`; new compounds have
+  stories.
+
+## Tests
+
+- Component test: registration seam (fixture section), tab
+  rendering, empty states.
+- Storybook: shell + placeholder states.
+- Manual smoke: route round-trip on both platforms.
+
+## Open questions
+
+- **Skeleton breadth** — render all six canonical tabs with
+  placeholders vs only the tabs M3 fills (Memory, Generation /
+  Composer). Lean minimal (two tabs) to avoid advertising dead
+  surface; confirm at planning.
+
+## Implementation notes
+
+_Populated at finish: notable deviations from the plan and resolved developer decisions._

--- a/docs/implementation/milestones/README.md
+++ b/docs/implementation/milestones/README.md
@@ -20,3 +20,9 @@ directory (`NN-name/`) with a `milestone.md` definition and a
   provider + resolution chain, minimum-viable wizard, story list,
   reader-composer minimum, Liquid engine + bundled pack, end-to-end
   wiring; ten slices, eight day-one startable.
+- [Milestone 3 — Memory floor](./03-memory-floor/milestone.md).
+  Memory pipeline online: embedder substrate + vec0 tables +
+  creation hard gate, piggyback layer, periodic classifier,
+  retrieval + ranker, dev probe, full wizard World / Cast steps,
+  suggestions, worldTime editing, batched undo, regenerate;
+  twelve slices, five day-one startable.

--- a/docs/implementation/roadmap.md
+++ b/docs/implementation/roadmap.md
@@ -15,8 +15,9 @@ defined `milestone.md`.
 - **Defined milestones** with full `milestone.md` files live under
   [`milestones/`](./milestones/README.md). Defined today: M1 (Spine),
   [M1.5 — Data foundation](./milestones/01b-data-foundation/milestone.md)
-  (inserted between M1 and M2; no renumber), and
-  [M2 — First user loop](./milestones/02-first-user-loop/milestone.md).
+  (inserted between M1 and M2; no renumber),
+  [M2 — First user loop](./milestones/02-first-user-loop/milestone.md),
+  and [M3 — Memory floor](./milestones/03-memory-floor/milestone.md).
   M1.5 front-loads
   the full relational schema, typed working-set stores, and Tier-1 CRUD
   arms, so the planned milestones below **no longer carry their own
@@ -138,161 +139,9 @@ M9.3.
 
 ### M3 — Memory floor
 
-**Goal.** The memory pipeline is online: piggyback writes scene
-metadata + structured tool calls during main generation; periodic
-classifier reconciles entities + lore + happenings + awareness in
-the background; retrieval surfaces relevant context into each
-turn's prompt. Stories made in M3 are coherent across a session.
-
-**Why now.** Real story data exists from M2; this milestone is
-where classifier prompt engineering and retrieval ranking get
-their first contact with real inputs. Lands before the rich UX
-because UX needs **populated** entity / awareness / happening data
-to render against (the tables + stores exist from M1.5; M3 fills them).
-
-**Likely slices.**
-
-- M3.1 — Embedder integration + the hard onboarding gate (story
-  creation requires embedder per
-  [`memory/model-management.md`](../memory/model-management.md));
-  lands the per-type vec0 `embeddings` virtual tables — the one
-  schema piece M1.5 deliberately excluded (the sqlite-vec
-  extension itself loads since M1.2);
-  embedder configuration in app settings;
-  `embedding_stale` opportunistic drain worker (makes "retry"
-  meaningful after embedder failure per
-  [`memory/retrieval.md → Compute lifecycle`](../memory/retrieval.md#compute-lifecycle));
-  `embedding_swap_target` two-phase stage-then-flip pipeline +
-  crash-recovery resume / cancel prompt on story-open (per
-  [`memory/retrieval.md → Model swap UX`](../memory/retrieval.md#model-swap-ux)).
-  Adds the Matryoshka effective-dim machinery — `effectiveDim`
-  resolution plus truncation + renorm at every embed-write; the
-  `matryoshkaSupported` / `matryoshkaDims` capability flags
-  already ship in the M1.5 app-settings Zod — per
-  [`memory/retrieval.md → Matryoshka effective dim`](../memory/retrieval.md#matryoshka-effective-dim)
-  and the top-bar staleness pill + Settings · Memory per-story
-  resolution panel per
-  [`memory/model-management.md → Staleness UI`](../memory/model-management.md#staleness-ui).
-  Embedder management UI extends in M7.1.
-- M3.2 — Piggyback layer: inline structured tool calls during
-  main generation; scene metadata writes;
-  entities + lore + happenings stub creation.
-- M3.3 — Periodic classifier: background pipeline; entity
-  reconciliation; awareness graph; happenings extraction. Drives the
-  `character_relationships` UPSERT-merge / canonical-ordering write
-  primitive landed in M1.5 per
-  [`data-model.md → Character-to-character relationships`](../data-model.md#character-to-character-relationships).
-  Classifier writes `metadata.worldTime` to each new entry —
-  first non-zero values flow through the calendar renderer
-  shipped in M2.5. Auto-retry policy (30s → 2m → 5m backoff,
-  3-strike failed-persistent state per
-  [`memory/classifier.md → Auto-retry policy`](../memory/classifier.md#auto-retry-policy))
-  - per-branch `classifier_status` persistence (the column landed in
-    M1.5; this slice writes lifecycle into it). Sets
-    `entities.name_collision_flag` on collision (the column landed in
-    M1.5; drives the M4 collision-review surface) per
-    [`memory/classifier.md → Disambiguation`](../memory/classifier.md#disambiguation-on-new-character-mentions).
-  - Survival-anchor logic (makes the classifier reversible-correct):
-    stamps `periodic_classifier` source + per-fact provenance into
-    `deltas.entry_id` (the `source` value landed in M1.5); maintains
-    `processedThrough` in `classifier_status` plus its reversal clamp;
-    and the reversal predicate that refines M2.5's naive suffix sweep
-    so a lagging fact about a surviving turn isn't over-reversed, per
-    [`data-model.md → Survival anchor`](../data-model.md#survival-anchor).
-  - In-flight classifier barrier for prose reversals (rollback,
-    regenerate, CTRL-Z). M2.2 brackets the rollback sweep with
-    `reversalInProgress` (selection runs inside the barrier), but the
-    `awaitRunTerminal` classifier-cancel drain lands here — it needs
-    `awaitRunTerminal` relocated from `lib/pipeline` into the
-    generation store (mirroring M2.2's gate move) so `lib/actions`
-    stays cycle-free, per
-    [`generation-pipeline.md → Prose reversals and the classifier barrier`](../generation-pipeline.md#prose-reversals-and-the-classifier-barrier).
-  - Happening reconcile cascades to the FK-less link tables: deleting
-    or merging a happening must also drop / reattach its
-    `happening_involvements` and `happening_awareness` rows. The M1.5
-    `deleteHappening` arm removes only the `happenings` row, orphaning
-    them — cascade lands with whichever consumes it first (this
-    reconcile or the M4 Plot delete-flow).
-- M3.4 — Retrieval: embedding queries; ranker; budgets;
-  context-bundle assembly into the per-turn prompt. Memory pack
-  templates extend the Liquid engine to inject retrieved bundles.
-  Per-injection `retrieval_count` increment on awareness rows
-  (the delta-logged column landed in M1.5; load-bearing for
-  chapter-close phase 3d in M5.2 per
-  [`memory/chapter-close.md → 3d awareness pin tuning`](../memory/chapter-close.md#3d--awareness-pin-tuning)).
-  Drives the `lore.keywords` column (distinct from `lore.tags`; landed
-  in M1.5) through the keyword-retrieval pathway per
-  [`memory/retrieval.md → Keywords schema`](../memory/retrieval.md#keywords-schema).
-  `js-tiktoken` install lands here as the first budget-accounting
-  consumer (per [`tech-stack.md`](../tech-stack.md)).
-- M3.5 — Minimal developer-only retrieval probe: log / inspect
-  retrieval scores during impl. User-facing probe surface
-  deferred to M7. Consumes the `probe_captures` table +
-  `app_settings.diagnostics.enabled` + `stories.settings.probe_mode_active`
-  (all landed in M1.5) and writes the first captures per
-  [`memory/probe.md → Schema delta`](../memory/probe.md#schema-delta).
-  Simulator-vs-prod-pass parity test ships alongside.
-- M3.6 — Wizard step 3 (lore editor) + step 4 (full bespoke cast
-  editor — all 4 per-kind editors with `▼ Visual` / `▼ More
-options` disclosures, status / lead / staged logic,
-  pick-from-cast pickers): pre-author opening's lore + entities
-  at story creation; opening generation consumes seeded context.
-  Refine / regenerate affordances on opening land here. The
-  wizard editor is bespoke (its own tier shape, excludes
-  classifier-managed fields per the authorship contract); not a
-  precursor to the world panel.
-- M3.7 — Next-turn suggestions: pipeline emission (sibling
-  `<suggestions>` block alongside narrative in piggyback mode
-  and/or alongside `<state>` in classifier mode per
-  [`reader-composer.md → Next-turn suggestions`](../ui/screens/reader-composer/reader-composer.md#next-turn-suggestions)),
-  reader-composer suggestions panel between AI replies and the
-  next composer input, `suggestionsEnabled` story setting toggle.
-  Adds the Story Settings · Composer categories editor (consuming
-  the shipped `SuggestionCategoriesEditor`) over
-  `app_settings.default_suggestion_categories` — the column and
-  its seed default landed in the M1.5 gate — plus a
-  `kind: 'suggestion-refresh'` pipeline declaration per
-  [`next-turn-suggestions exploration`](../explorations/2026-05-19-next-turn-suggestions.md).
-  Suggestion agent profile slot in app-settings extends M7.1.
-- M3.8 — Per-entry worldTime click-to-edit overlay (TierTupleInput)
-  - monotonicity-break flag (O(N) walk feeding
-    `worldTimeMonotonicityBreak` into EntryCard per
-    [`reader-composer.md → Per-entry world-time footer`](../ui/screens/reader-composer/reader-composer.md#per-entry-world-time-footer)).
-    Needs classifier writes from M3.3 to be useful.
-- M3.9 — CTRL-Z action-batched extension: extends M2.5's basic
-  single-action undo so undoing a prose turn reverses the positional
-  suffix from the turn's start — carrying its piggyback deltas, skipping
-  `periodic_classifier` deltas (never undo targets), and sparing
-  surviving turns' facts via the survival anchor — per
-  [`data-model.md → Entry mutability & rollback`](../data-model.md#entry-mutability--rollback).
-  Redo stack semantics unchanged.
-
-**Parallel paths.** Day-one startable: {M3.1} || {M3.2} || {M3.6} —
-M3.6's editor build needs only the M1.5 lore / entity layer and
-M2.3's wizard shell; the earlier "after M3.2" gate was about the
-classifier consuming seeded cast, which is verification, not a
-build dependency. M3.3 runs in parallel with M3.4 once M3.2's stub
-writes populate retrievable rows (M3.4 also needs M3.1's
-embeddings); M3.5 follows M3.4; M3.7 gates on M3.2 + M3.3; M3.8
-gates on M3.3; M3.9 gates on M3.3 (needs the survival-anchor
-reversal substrate).
-
-**Slice-authoring notes.** M3.3 as sketched exceeds the
-days-not-weeks sizing rule. First split to take: the reversal
-predicate and `processedThrough` clamp are undo-side code — move
-them to M3.9 (which owns undo semantics), leaving M3.3 the
-stamp / provenance side, and pin that seam explicitly since both
-slices touch the survival anchor. If M3.3 still stretches, its
-output processors (entity reconciliation vs awareness /
-happenings / cascade) can split against a pinned classifier
-structured-output shape.
-
-**Gates.** M2 (entries + real provider needed before classifier
-has anything to classify).
-
-**Scope: out.** Chapter-close, rich world panel, rich plot panel,
-multi-axis salience, pinning policy refinements, rich
-user-facing memory probe (M7).
+**Promoted** — defined in
+[`milestones/03-memory-floor/`](./milestones/03-memory-floor/milestone.md)
+(milestone + twelve slice docs).
 
 ---
 
@@ -787,11 +636,13 @@ the screen its goal requires; later milestones extend.
     basic edit / delete entry actions, rollback-confirm modal
     compound (single-entry cascade), markdown rendering pipeline,
     Harper.js spellcheck, CTRL-Z basic single-action undo.
-  - **M3** — Refine / regenerate affordances on entries (consume
-    memory context); next-turn suggestions panel between AI
-    replies and the composer (M3.7); per-entry worldTime
-    click-to-edit + monotonicity flag (M3.8); CTRL-Z
-    action-batched extension across classifier writes (M3.9).
+  - **M3** — Regenerate affordance on entries (M3.10; the earlier
+    "refine on entries" phrase was dropped at promotion — canon
+    defines refine only on the wizard opening); next-turn
+    suggestions panel between AI replies and the composer (M3.7);
+    per-entry worldTime click-to-edit + monotonicity flag (M3.8);
+    CTRL-Z action-batched extension across classifier writes
+    (M3.9).
   - **M4** — Peek drawer + awareness chips on entries.
   - **M5** — Chapter management affordances (insert break,
     navigate by chapter, chapter context badge); deep-rollback
@@ -853,9 +704,11 @@ explicit.
   - **M2.5** — Renderer (`worldTime + worldTimeOrigin → tier-tuple
 → Liquid render`) for reader chrome. Exercised meaningfully
     only after M3.3 begins writing non-zero `worldTime` values.
-  - **M3.3** — Classifier writes `metadata.worldTime` on each new
-    entry; first non-zero worldTime values flow through the
-    renderer.
+  - **M3.2** — the per-turn piggyback / fallback-classifier layer
+    writes `metadata.worldTime` on each new entry (entry metadata
+    is per-turn-owned per the cadence write-set table; an earlier
+    M3.3 attribution was corrected at M3 promotion); first
+    non-zero worldTime values flow through the renderer.
   - **M3.6** — Wizard's calendar-summary preview samples the
     renderer to show how dates will format.
   - **M5.3** — Chapter timeline time column consumes the renderer.
@@ -958,10 +811,11 @@ only.
 
 ### Milestones that may merge or split
 
-- **M3 + M4 might merge** if memory-pipeline implementation reveals
-  that the world / plot surfaces are needed mid-correctness-check
-  (e.g., human inspection of classifier output is faster than log
-  reads). Defer the decision until M3 is authored.
+- **M3 + M4 did not merge** — M3 was authored standalone
+  (2026-07-20). The mid-correctness-check inspection need is served
+  by M3.5's developer probe and by building M4 read surfaces early
+  against seeded rows per the look-ahead rule; M4 remains a
+  separate roadmap entry.
 - **M9 might split** if Storybook + per-surface audit + backup +
   ship gate are too much for one milestone. Natural split: M9a
   (Storybook + VI audit) → M9b (backup + ship).

--- a/docs/implementation/triage.md
+++ b/docs/implementation/triage.md
@@ -202,3 +202,13 @@ doc-amendment before Slice 2.5.
   [Slice 2.10](./milestones/02-first-user-loop/slices/10-recovery-ui.md) owns the
   parse-failure badge that renders this; confirm 2.10 also covers the tap-with-no-feedback
   interim (or accept silent-until-badge). Surfaced by Slice 2.7.
+- **`generation-pipeline.md → New-entity emission` "(or piggyback)"
+  parenthetical contradicts the memory write-set canon.** The section
+  opens "The classifier (or piggyback) creating a brand-new entity…", but
+  [`cadence.md → Concurrency`](../memory/cadence.md#concurrency) and
+  [`piggyback.md`](../memory/piggyback.md) give piggyback zero creation
+  rights — creation is classifier-only (disambiguation lives there by
+  design). Surfaced by the M3 promotion audit (2026-07-20). The
+  id-allocation mechanic the section describes is correct either way; the
+  fix is dropping or rewording the parenthetical. Canonical edit — route
+  through a design / cleanup pass, not a planning commit.


### PR DESCRIPTION
Promotion decisions: M3.1 split into 3.1a/3.1b; the processedThrough clamp stays in 3.3 (M2.2 already landed the survival-anchor predicate, and the clamp is load-bearing from the watermark's first write); 3.7 gates on 3.2 only; 3.4 develops against seeded rows; the roadmap's stale "stub creation" and classifier-worldTime attributions were dropped per the cadence write-set canon.
Added at promotion from the six-angle audit: Slice 3.10 (reader regenerate — cross-cutting table named it, no slice owned it) and Slice 3.11 (minimal Story Settings shell — 3.1b/3.7 sections had no host before M4.4); the generation-pipeline.md "(or piggyback)" canon drift is queued in triage.md.