### PR TITLE
Slice/m3.11 story settings shell

### DIFF
--- a/app/reader-composer/[branchId].tsx
+++ b/app/reader-composer/[branchId].tsx
@@ -1,3 +1,4 @@
+import { useIsFocused } from '@react-navigation/native'
 import { and, desc, eq, lt } from 'drizzle-orm'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -79,6 +80,7 @@ export default function ReaderComposerRoute() {
   const router = useRouter()
   const tier = useTier()
   const showRail = tier !== 'phone'
+  const isFocused = useIsFocused()
   const { branchId } = useLocalSearchParams<{ branchId: string }>()
 
   const [storyId, setStoryId] = useState<string | null>(null)
@@ -462,7 +464,10 @@ export default function ReaderComposerRoute() {
     },
     [branchId],
   )
-  useGlobalHotkey(matchesUndoRedoShortcut, handleUndoRedoShortcut, { ignoreEditableTargets: true })
+  useGlobalHotkey(matchesUndoRedoShortcut, handleUndoRedoShortcut, {
+    ignoreEditableTargets: true,
+    enabled: isFocused,
+  })
 
   // Touch-tier path to undo/redo (the shortcut is keyboard-only). A tapped menu
   // item silently doing nothing reads as broken, so rejections toast — unlike
@@ -490,7 +495,10 @@ export default function ReaderComposerRoute() {
   const handleFixSystemEntry = useCallback(async () => fixAction?.onPress(), [fixAction])
   const matchesJumpToBottomShortcut = useCallback((ev: KeyboardEvent) => ev.key === 'End', [])
   // Editable-target exclusion keeps End moving the caret inside the composer.
-  useGlobalHotkey(matchesJumpToBottomShortcut, jumpToBottom, { ignoreEditableTargets: true })
+  useGlobalHotkey(matchesJumpToBottomShortcut, jumpToBottom, {
+    ignoreEditableTargets: true,
+    enabled: isFocused,
+  })
   const contextualActions: ActionGroup = useMemo(() => {
     const blocked = {
       disabled: isGenerating,
@@ -559,6 +567,9 @@ export default function ReaderComposerRoute() {
       title={<Text className="font-semibold">{storyTitle ?? t('reader:placeholderTitle')}</Text>}
       chapterProgress={0}
       onBack={() => router.back()}
+      onOpenStorySettings={() => {
+        if (storyId != null) router.push(`/story-settings/${storyId}`)
+      }}
       actions={<AppActionsMenu contextual={contextualActions} />}
       statusSlot={
         <GenerationStatusPill

--- a/app/story-settings/[storyId].tsx
+++ b/app/story-settings/[storyId].tsx
@@ -137,7 +137,7 @@ function StorySettingsSurface({ storyId }: { storyId: string | undefined }) {
 
   const groups = STORY_SETTINGS_TAB_GROUPS.map((group) => ({
     id: group.id,
-    header: t(`storySettings:sections.${group.id}`),
+    header: t(`storySettings:groups.${group.id}`),
     tabs: group.tabs.map((id) => ({ id, label: t(`storySettings:tabs.${id}`) })),
   }))
 
@@ -220,14 +220,21 @@ function StorySettingsSurface({ storyId }: { storyId: string | undefined }) {
               dirtyFields={session.snapshot.dirtyFields}
               dirtyCount={session.snapshot.dirtyFields.length}
               saving={session.saving}
+              enabled={isFocused}
               onSave={() => void session.save()}
               onDiscard={session.discard}
             />
           ) : null
         }
       />
+      {/* No focus gate: `pendingLeave` is only set by this screen's own back
+          arrow or the window-close guard, and a pushed-under screen's back
+          arrow can't fire — so a pending leave while unfocused means the user
+          is closing the window, which is exactly when the dialog must show.
+          Gating it there held the close open with nothing on screen to answer
+          it, leaving the window unclosable. */}
       <UnsavedChangesDialog
-        open={session.pendingLeave && isFocused}
+        open={session.pendingLeave}
         saving={session.saving}
         onSave={() => session.resolveLeave('save')}
         onDiscard={() => session.resolveLeave('discard')}

--- a/app/story-settings/[storyId].tsx
+++ b/app/story-settings/[storyId].tsx
@@ -1,0 +1,192 @@
+import { useIsFocused } from '@react-navigation/native'
+import { useLocalSearchParams, useRouter } from 'expo-router'
+import { useCallback, useEffect, useState } from 'react'
+
+import { AppActionsMenu } from '@/components/compounds/app-actions-menu'
+import { SaveBar } from '@/components/compounds/save-bar'
+import { ScreenShell } from '@/components/shells/screen-shell'
+import { StorySettingsShell } from '@/components/shells/story-settings-shell'
+import {
+  StorySettingsSaveSessionProvider,
+  useStorySettingsSaveSession,
+} from '@/components/story-settings/save-session'
+import { UnsavedChangesDialog } from '@/components/story-settings/unsaved-changes-dialog'
+import { EmptyState } from '@/components/ui/empty-state'
+import { Text } from '@/components/ui/text'
+import { useMasterDetailBack } from '@/hooks/use-master-detail-back'
+import { useTier } from '@/hooks/use-tier'
+import { updateStorySettings } from '@/lib/actions'
+import { db, runInTransaction, type StorySettings } from '@/lib/db'
+import { logger } from '@/lib/diagnostics'
+import { t } from '@/lib/i18n'
+import { rehydrateStories, storiesStore } from '@/lib/stores'
+import { toast } from '@/lib/toast'
+
+// C7 seam: a consumer slice adds its tab here (if new), then renders its
+// section in the ternary below. Sections join the save session from inside
+// their own body via useStorySettingsSection.
+type StorySettingsTabId =
+  | 'about'
+  | 'generation'
+  | 'models'
+  | 'memory'
+  | 'translation'
+  | 'pack'
+  | 'calendar'
+  | 'advanced'
+
+const STORY_SETTINGS_TAB_IDS = [
+  'about',
+  'generation',
+  'models',
+  'memory',
+  'translation',
+  'pack',
+  'calendar',
+  'advanced',
+] as const satisfies readonly StorySettingsTabId[]
+
+const ctx = { db, runInTransaction }
+
+export default function StorySettingsRoute() {
+  const { storyId } = useLocalSearchParams<{ storyId: string }>()
+  // All three are in the provider's `save` dep chain; inline arrows would give
+  // every consumer a new context identity on each render.
+  const onCommit = useCallback(
+    (patch: Partial<StorySettings>) => updateStorySettings(storyId, patch, ctx),
+    [storyId],
+  )
+  const onSaved = useCallback(() => toast.success(t('storySettings:save.saved')), [])
+  const onSaveFailed = useCallback((error: unknown) => {
+    logger.error('action_layer.story_settings_save_failed', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    toast.error(t('storySettings:save.failed'))
+  }, [])
+  return (
+    <StorySettingsSaveSessionProvider
+      onCommit={onCommit}
+      onSaved={onSaved}
+      onSaveFailed={onSaveFailed}
+    >
+      <StorySettingsSurface />
+    </StorySettingsSaveSessionProvider>
+  )
+}
+
+function StorySettingsSurface() {
+  const router = useRouter()
+  const isPhone = useTier() === 'phone'
+  const isFocused = useIsFocused()
+  const { storyId, tab } = useLocalSearchParams<{ storyId: string; tab?: string }>()
+  const session = useStorySettingsSaveSession()
+
+  const initialTab = STORY_SETTINGS_TAB_IDS.includes(tab as StorySettingsTabId)
+    ? (tab as StorySettingsTabId)
+    : null
+  const [selectedTab, setSelectedTab] = useState<StorySettingsTabId | null>(initialTab)
+
+  // Desktop / tablet always shows a detail pane, so fall back to a default tab;
+  // phone is list-first, so no tab is open until one is tapped.
+  const activeTab: StorySettingsTabId | null = selectedTab ?? (isPhone ? null : 'about')
+
+  // Only the story-list and reader routes hydrate this store, so a deep link
+  // straight here would render the breadcrumb without its story title.
+  useEffect(() => {
+    void rehydrateStories(db)
+  }, [])
+  const storyTitle = storiesStore.useStories((s) => s.rows.find((r) => r.id === storyId)?.title)
+
+  const leaveSurface = useCallback(() => {
+    session.requestLeave(() => router.back())
+  }, [session, router])
+
+  // Phone is list-first, so a tab open there collapses back to the list
+  // (within-session, unguarded); every other back exits through the dirty guard.
+  const handleBack = useCallback(() => {
+    if (isPhone && selectedTab != null) setSelectedTab(null)
+    else leaveSurface()
+  }, [isPhone, selectedTab, leaveSurface])
+
+  // Always intercepts on this surface. Returning false would let Android pop
+  // the route without ever consulting the dirty guard.
+  useMasterDetailBack(true, handleBack)
+
+  const groups = [
+    {
+      id: 'story',
+      header: t('storySettings:sections.story'),
+      tabs: [
+        { id: 'about' as const, label: t('storySettings:tabs.about') },
+        { id: 'generation' as const, label: t('storySettings:tabs.generation') },
+      ],
+    },
+    {
+      id: 'settings',
+      header: t('storySettings:sections.settings'),
+      tabs: [
+        { id: 'models' as const, label: t('storySettings:tabs.models') },
+        { id: 'memory' as const, label: t('storySettings:tabs.memory') },
+        { id: 'translation' as const, label: t('storySettings:tabs.translation') },
+        { id: 'pack' as const, label: t('storySettings:tabs.pack') },
+        { id: 'calendar' as const, label: t('storySettings:tabs.calendar') },
+        { id: 'advanced' as const, label: t('storySettings:tabs.advanced') },
+      ],
+    },
+  ]
+
+  const placeholder = (
+    <EmptyState title={t('storySettings:landsLater')} subtext={t('storySettings:landsLaterBody')} />
+  )
+  const missingStory = <EmptyState title={t('storySettings:missingStory')} />
+
+  // C7 seam: consumer slices replace a placeholder branch with their section.
+  // 3.1b → 'memory' (embedding status). 3.7 → 'generation' (authoring aids).
+  // Called for every tab, not just the active one — see StorySettingsShell.
+  const renderPanel = (_id: StorySettingsTabId) => (storyId == null ? missingStory : placeholder)
+
+  return (
+    <ScreenShell
+      variant="in-story"
+      title={
+        <Text className="font-semibold">
+          {storyTitle != null
+            ? `${storyTitle} / ${t('storySettings:title')}`
+            : t('storySettings:title')}
+        </Text>
+      }
+      chapterProgress={0}
+      hideSelfReferentialIcon
+      onBack={handleBack}
+      actions={<AppActionsMenu />}
+    >
+      <StorySettingsShell
+        groups={groups}
+        activeTab={activeTab}
+        onSelectTab={setSelectedTab}
+        renderPanel={renderPanel}
+        saveBar={
+          session.snapshot.isDirty ? (
+            <SaveBar
+              dirtyFields={session.snapshot.dirtyFields}
+              dirtyCount={session.snapshot.dirtyCount}
+              saving={session.saving}
+              onSave={() => void session.save()}
+              onDiscard={session.discard}
+            />
+          ) : null
+        }
+      />
+      <UnsavedChangesDialog
+        open={session.pendingLeave && isFocused}
+        saving={session.saving}
+        onSave={() => session.resolveLeave('save')}
+        onDiscard={() => session.resolveLeave('discard')}
+        onCancel={() => session.resolveLeave('cancel')}
+      />
+    </ScreenShell>
+  )
+}
+
+export { STORY_SETTINGS_TAB_IDS }
+export type { StorySettingsTabId }

--- a/app/story-settings/[storyId].tsx
+++ b/app/story-settings/[storyId].tsx
@@ -1,12 +1,13 @@
 import { useIsFocused } from '@react-navigation/native'
 import { useLocalSearchParams, useRouter } from 'expo-router'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState, type ReactElement } from 'react'
 
 import { AppActionsMenu } from '@/components/compounds/app-actions-menu'
 import { GenerationStatusPill } from '@/components/compounds/generation-status-pill'
 import { SaveBar } from '@/components/compounds/save-bar'
 import { ScreenShell } from '@/components/shells/screen-shell'
 import { StorySettingsShell } from '@/components/shells/story-settings-shell'
+import { type StorySettingsPanelData } from '@/components/story-settings/panel-data'
 import {
   StorySettingsSaveSessionProvider,
   useStorySettingsSaveSession,
@@ -14,6 +15,7 @@ import {
 import {
   isStorySettingsTabId,
   STORY_SETTINGS_TAB_GROUPS,
+  STORY_SETTINGS_TAB_IDS,
   type StorySettingsTabId,
 } from '@/components/story-settings/tabs'
 import { UnsavedChangesDialog } from '@/components/story-settings/unsaved-changes-dialog'
@@ -21,7 +23,8 @@ import { EmptyState } from '@/components/ui/empty-state'
 import { Text } from '@/components/ui/text'
 import { useMasterDetailBack } from '@/hooks/use-master-detail-back'
 import { useTier } from '@/hooks/use-tier'
-import { updateStorySettings } from '@/lib/actions'
+import { useUnsavedChangesGuard } from '@/hooks/use-unsaved-changes-guard'
+import { StorySettingsStaleStoreError, updateStorySettings } from '@/lib/actions'
 import { db, runInTransaction, type StorySettings } from '@/lib/db'
 import { logger } from '@/lib/diagnostics'
 import { t } from '@/lib/i18n'
@@ -31,22 +34,36 @@ import { toast } from '@/lib/toast'
 
 const ctx = { db, runInTransaction }
 
+// expo-router types params as strings but hands back `string[]` for a repeated
+// query param.
+function singleParam(value: string | string[] | undefined): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
 export default function StorySettingsRoute() {
-  const { storyId } = useLocalSearchParams<{ storyId: string }>()
+  const params = useLocalSearchParams<{ storyId?: string | string[] }>()
+  const storyId = singleParam(params.storyId)
   // All three are in the provider's `save` dep chain; inline arrows would give
   // every consumer a new context identity on each render.
   const onCommit = useCallback(
-    (patch: Partial<StorySettings>) => updateStorySettings(storyId, patch, ctx),
+    (patch: Partial<StorySettings>) => {
+      if (storyId == null) return Promise.reject(new Error('Story not found'))
+      return updateStorySettings(storyId, patch, ctx)
+    },
     [storyId],
   )
   const onSaved = useCallback(() => toast.success(t('storySettings:save.saved')), [])
   const onSaveFailed = useCallback(
     (error: unknown) => {
+      // A stale store means the write landed — telling the user it failed would
+      // send them to re-enter values that are already persisted.
+      const stale = error instanceof StorySettingsStaleStoreError
       logger.error('action_layer.story_settings_save_failed', {
         storyId,
+        stale,
         error: error instanceof Error ? error.message : String(error),
       })
-      toast.error(t('storySettings:save.failed'))
+      toast.error(stale ? t('storySettings:save.stale') : t('storySettings:save.failed'))
     },
     [storyId],
   )
@@ -56,44 +73,52 @@ export default function StorySettingsRoute() {
       onSaved={onSaved}
       onSaveFailed={onSaveFailed}
     >
-      <StorySettingsSurface />
+      <StorySettingsSurface storyId={storyId} />
     </StorySettingsSaveSessionProvider>
   )
 }
 
-function StorySettingsSurface() {
+function StorySettingsSurface({ storyId }: { storyId: string | undefined }) {
   const router = useRouter()
   const isPhone = useTier() === 'phone'
   const isFocused = useIsFocused()
-  const { storyId, tab } = useLocalSearchParams<{ storyId: string; tab?: string }>()
+  const params = useLocalSearchParams<{ tab?: string | string[] }>()
+  const tab = singleParam(params.tab)
   const session = useStorySettingsSaveSession()
 
   const [selectedTab, setSelectedTab] = useState<StorySettingsTabId | null>(
     isStorySettingsTabId(tab) ? tab : null,
   )
 
-  // Desktop / tablet always shows a detail pane, so fall back to a default tab;
-  // phone is list-first, so no tab is open until one is tapped.
-  const activeTab: StorySettingsTabId | null = selectedTab ?? (isPhone ? null : 'about')
+  // Desktop / tablet always shows a detail pane, so fall back to the first rail
+  // entry; phone is list-first, so no tab is open until one is tapped.
+  const activeTab: StorySettingsTabId | null =
+    selectedTab ?? (isPhone ? null : (STORY_SETTINGS_TAB_IDS[0] ?? null))
 
-  // Only the story-list and reader routes hydrate this store, so a deep link
+  // Only routes that open or list a story hydrate this store, so a deep link
   // straight here starts empty — the missing-story state has to wait for the
   // read or it flashes over a story that does exist.
-  const [hydrated, setHydrated] = useState(false)
+  // rehydrateStories swallows its own read failures and reports them in its
+  // return value, so a failed read has to be tracked apart from an empty one —
+  // otherwise it renders as "this story is gone".
+  const [hydration, setHydration] = useState<'pending' | 'ok' | 'failed'>('pending')
   useEffect(() => {
-    void rehydrateStories(db).then(() => setHydrated(true))
+    void rehydrateStories(db).then((ok) => setHydration(ok ? 'ok' : 'failed'))
   }, [])
   const storyTitle = storiesStore.useStories((s) => s.rows.find((r) => r.id === storyId)?.title)
   const storyExists = storiesStore.useStories((s) => s.rows.some((r) => r.id === storyId))
   // The route owns the source: `currentStoryStore` is null on any cold entry
-  // here (only the index and the reader open a story), and `updateStorySettings`
-  // rehydrates this store, so a saved section re-derives from the fresh row.
+  // here, and `updateStorySettings` rehydrates this store, so a saved section
+  // re-derives from the fresh row.
   const settings = storiesStore.useStories(
     (s) => s.rows.find((r) => r.id === storyId)?.settings ?? null,
   )
   const isGenerating = generationStore.useGeneration((s) =>
     [...s.txState.runs.values()].some((r) => r.storyId === storyId),
   )
+
+  const isDirty = session.snapshot.dirtyFields.length > 0
+  useUnsavedChangesGuard(isDirty, session.requestLeave)
 
   const leaveSurface = useCallback(() => {
     session.requestLeave(() => router.back())
@@ -106,8 +131,8 @@ function StorySettingsSurface() {
     else leaveSurface()
   }, [isPhone, selectedTab, leaveSurface])
 
-  // Unconditional: on tablet `isPhone` is false, so returning false here would
-  // let Android's default pop the route straight past the dirty guard.
+  // Constant true on every tier: any false here falls through to Android's
+  // route-pop, which never sees the dirty guard.
   useMasterDetailBack(true, handleBack)
 
   const groups = STORY_SETTINGS_TAB_GROUPS.map((group) => ({
@@ -116,17 +141,50 @@ function StorySettingsSurface() {
     tabs: group.tabs.map((id) => ({ id, label: t(`storySettings:tabs.${id}`) })),
   }))
 
-  const placeholder = (
-    <EmptyState title={t('storySettings:landsLater')} subtext={t('storySettings:landsLaterBody')} />
-  )
-  const missingStory = <EmptyState title={t('storySettings:missingStory')} />
+  const panelData: StorySettingsPanelData =
+    storyId == null
+      ? { status: 'missing' }
+      : hydration === 'pending'
+        ? { status: 'loading' }
+        : hydration === 'failed'
+          ? { status: 'unavailable' }
+          : !storyExists
+            ? { status: 'missing' }
+            : settings == null
+              ? { status: 'uninitialized' }
+              : { status: 'ready', settings }
 
-  // C7 seam: consumer slices replace a placeholder branch with their section,
-  // deriving its draft from `settings` rather than a store — null covers both
-  // the pre-hydration window and a story that isn't there.
-  // Called for every tab, not just the active one — see StorySettingsShell.
-  const renderPanel = (_id: StorySettingsTabId, resolved: StorySettings | null) =>
-    resolved != null ? placeholder : hydrated && !storyExists ? missingStory : placeholder
+  // Consumer slices switch on `id` here and render their section for the
+  // `ready` branch, deriving its draft from `data.settings`.
+  const renderPanel = (_id: StorySettingsTabId, data: StorySettingsPanelData): ReactElement => {
+    switch (data.status) {
+      case 'loading':
+        return <EmptyState title={t('storySettings:loading')} />
+      case 'unavailable':
+        return (
+          <EmptyState
+            title={t('storySettings:unavailable')}
+            subtext={t('storySettings:unavailableBody')}
+          />
+        )
+      case 'missing':
+        return <EmptyState title={t('storySettings:missingStory')} />
+      case 'uninitialized':
+        return (
+          <EmptyState
+            title={t('storySettings:uninitialized')}
+            subtext={t('storySettings:uninitializedBody')}
+          />
+        )
+      case 'ready':
+        return (
+          <EmptyState
+            title={t('storySettings:landsLater')}
+            subtext={t('storySettings:landsLaterBody')}
+          />
+        )
+    }
+  }
 
   return (
     <ScreenShell
@@ -154,13 +212,13 @@ function StorySettingsSurface() {
         groups={groups}
         activeTab={activeTab}
         onSelectTab={setSelectedTab}
-        panelData={settings}
+        panelData={panelData}
         renderPanel={renderPanel}
         saveBar={
-          session.snapshot.isDirty ? (
+          isDirty ? (
             <SaveBar
               dirtyFields={session.snapshot.dirtyFields}
-              dirtyCount={session.snapshot.dirtyCount}
+              dirtyCount={session.snapshot.dirtyFields.length}
               saving={session.saving}
               onSave={() => void session.save()}
               onDiscard={session.discard}

--- a/app/story-settings/[storyId].tsx
+++ b/app/story-settings/[storyId].tsx
@@ -22,19 +22,10 @@ import { t } from '@/lib/i18n'
 import { rehydrateStories, storiesStore } from '@/lib/stores'
 import { toast } from '@/lib/toast'
 
-// C7 seam: a consumer slice adds its tab here (if new), then renders its
-// section in the ternary below. Sections join the save session from inside
-// their own body via useStorySettingsSection.
-type StorySettingsTabId =
-  | 'about'
-  | 'generation'
-  | 'models'
-  | 'memory'
-  | 'translation'
-  | 'pack'
-  | 'calendar'
-  | 'advanced'
-
+// C7 seam: adding an id here registers a tab — the union derives from this
+// array, so a consumer slice adds its id (if new), lists it in `groups`, then
+// renders its section in the ternary below. Sections join the save session
+// from inside their own body via useStorySettingsSection.
 const STORY_SETTINGS_TAB_IDS = [
   'about',
   'generation',
@@ -44,7 +35,9 @@ const STORY_SETTINGS_TAB_IDS = [
   'pack',
   'calendar',
   'advanced',
-] as const satisfies readonly StorySettingsTabId[]
+] as const
+
+type StorySettingsTabId = (typeof STORY_SETTINGS_TAB_IDS)[number]
 
 const ctx = { db, runInTransaction }
 

--- a/app/story-settings/[storyId].tsx
+++ b/app/story-settings/[storyId].tsx
@@ -85,6 +85,12 @@ function StorySettingsSurface() {
   }, [])
   const storyTitle = storiesStore.useStories((s) => s.rows.find((r) => r.id === storyId)?.title)
   const storyExists = storiesStore.useStories((s) => s.rows.some((r) => r.id === storyId))
+  // The route owns the source: `currentStoryStore` is null on any cold entry
+  // here (only the index and the reader open a story), and `updateStorySettings`
+  // rehydrates this store, so a saved section re-derives from the fresh row.
+  const settings = storiesStore.useStories(
+    (s) => s.rows.find((r) => r.id === storyId)?.settings ?? null,
+  )
   const isGenerating = generationStore.useGeneration((s) =>
     [...s.txState.runs.values()].some((r) => r.storyId === storyId),
   )
@@ -115,10 +121,12 @@ function StorySettingsSurface() {
   )
   const missingStory = <EmptyState title={t('storySettings:missingStory')} />
 
-  // C7 seam: consumer slices replace a placeholder branch with their section.
+  // C7 seam: consumer slices replace a placeholder branch with their section,
+  // deriving its draft from `settings` rather than a store — null covers both
+  // the pre-hydration window and a story that isn't there.
   // Called for every tab, not just the active one — see StorySettingsShell.
-  const renderPanel = (_id: StorySettingsTabId) =>
-    hydrated && !storyExists ? missingStory : placeholder
+  const renderPanel = (_id: StorySettingsTabId, resolved: StorySettings | null) =>
+    resolved != null ? placeholder : hydrated && !storyExists ? missingStory : placeholder
 
   return (
     <ScreenShell
@@ -146,6 +154,7 @@ function StorySettingsSurface() {
         groups={groups}
         activeTab={activeTab}
         onSelectTab={setSelectedTab}
+        panelData={settings}
         renderPanel={renderPanel}
         saveBar={
           session.snapshot.isDirty ? (

--- a/app/story-settings/[storyId].tsx
+++ b/app/story-settings/[storyId].tsx
@@ -3,6 +3,7 @@ import { useLocalSearchParams, useRouter } from 'expo-router'
 import { useCallback, useEffect, useState } from 'react'
 
 import { AppActionsMenu } from '@/components/compounds/app-actions-menu'
+import { GenerationStatusPill } from '@/components/compounds/generation-status-pill'
 import { SaveBar } from '@/components/compounds/save-bar'
 import { ScreenShell } from '@/components/shells/screen-shell'
 import { StorySettingsShell } from '@/components/shells/story-settings-shell'
@@ -10,6 +11,11 @@ import {
   StorySettingsSaveSessionProvider,
   useStorySettingsSaveSession,
 } from '@/components/story-settings/save-session'
+import {
+  isStorySettingsTabId,
+  STORY_SETTINGS_TAB_GROUPS,
+  type StorySettingsTabId,
+} from '@/components/story-settings/tabs'
 import { UnsavedChangesDialog } from '@/components/story-settings/unsaved-changes-dialog'
 import { EmptyState } from '@/components/ui/empty-state'
 import { Text } from '@/components/ui/text'
@@ -19,25 +25,9 @@ import { updateStorySettings } from '@/lib/actions'
 import { db, runInTransaction, type StorySettings } from '@/lib/db'
 import { logger } from '@/lib/diagnostics'
 import { t } from '@/lib/i18n'
-import { rehydrateStories, storiesStore } from '@/lib/stores'
+import { awaitRunTerminal, PER_TURN_KIND } from '@/lib/pipeline'
+import { generationStore, rehydrateStories, storiesStore } from '@/lib/stores'
 import { toast } from '@/lib/toast'
-
-// C7 seam: adding an id here registers a tab — the union derives from this
-// array, so a consumer slice adds its id (if new), lists it in `groups`, then
-// renders its section in the ternary below. Sections join the save session
-// from inside their own body via useStorySettingsSection.
-const STORY_SETTINGS_TAB_IDS = [
-  'about',
-  'generation',
-  'models',
-  'memory',
-  'translation',
-  'pack',
-  'calendar',
-  'advanced',
-] as const
-
-type StorySettingsTabId = (typeof STORY_SETTINGS_TAB_IDS)[number]
 
 const ctx = { db, runInTransaction }
 
@@ -50,12 +40,16 @@ export default function StorySettingsRoute() {
     [storyId],
   )
   const onSaved = useCallback(() => toast.success(t('storySettings:save.saved')), [])
-  const onSaveFailed = useCallback((error: unknown) => {
-    logger.error('action_layer.story_settings_save_failed', {
-      error: error instanceof Error ? error.message : String(error),
-    })
-    toast.error(t('storySettings:save.failed'))
-  }, [])
+  const onSaveFailed = useCallback(
+    (error: unknown) => {
+      logger.error('action_layer.story_settings_save_failed', {
+        storyId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      toast.error(t('storySettings:save.failed'))
+    },
+    [storyId],
+  )
   return (
     <StorySettingsSaveSessionProvider
       onCommit={onCommit}
@@ -74,21 +68,26 @@ function StorySettingsSurface() {
   const { storyId, tab } = useLocalSearchParams<{ storyId: string; tab?: string }>()
   const session = useStorySettingsSaveSession()
 
-  const initialTab = STORY_SETTINGS_TAB_IDS.includes(tab as StorySettingsTabId)
-    ? (tab as StorySettingsTabId)
-    : null
-  const [selectedTab, setSelectedTab] = useState<StorySettingsTabId | null>(initialTab)
+  const [selectedTab, setSelectedTab] = useState<StorySettingsTabId | null>(
+    isStorySettingsTabId(tab) ? tab : null,
+  )
 
   // Desktop / tablet always shows a detail pane, so fall back to a default tab;
   // phone is list-first, so no tab is open until one is tapped.
   const activeTab: StorySettingsTabId | null = selectedTab ?? (isPhone ? null : 'about')
 
   // Only the story-list and reader routes hydrate this store, so a deep link
-  // straight here would render the breadcrumb without its story title.
+  // straight here starts empty — the missing-story state has to wait for the
+  // read or it flashes over a story that does exist.
+  const [hydrated, setHydrated] = useState(false)
   useEffect(() => {
-    void rehydrateStories(db)
+    void rehydrateStories(db).then(() => setHydrated(true))
   }, [])
   const storyTitle = storiesStore.useStories((s) => s.rows.find((r) => r.id === storyId)?.title)
+  const storyExists = storiesStore.useStories((s) => s.rows.some((r) => r.id === storyId))
+  const isGenerating = generationStore.useGeneration((s) =>
+    [...s.txState.runs.values()].some((r) => r.storyId === storyId),
+  )
 
   const leaveSurface = useCallback(() => {
     session.requestLeave(() => router.back())
@@ -101,32 +100,15 @@ function StorySettingsSurface() {
     else leaveSurface()
   }, [isPhone, selectedTab, leaveSurface])
 
-  // Always intercepts on this surface. Returning false would let Android pop
-  // the route without ever consulting the dirty guard.
+  // Unconditional: on tablet `isPhone` is false, so returning false here would
+  // let Android's default pop the route straight past the dirty guard.
   useMasterDetailBack(true, handleBack)
 
-  const groups = [
-    {
-      id: 'story',
-      header: t('storySettings:sections.story'),
-      tabs: [
-        { id: 'about' as const, label: t('storySettings:tabs.about') },
-        { id: 'generation' as const, label: t('storySettings:tabs.generation') },
-      ],
-    },
-    {
-      id: 'settings',
-      header: t('storySettings:sections.settings'),
-      tabs: [
-        { id: 'models' as const, label: t('storySettings:tabs.models') },
-        { id: 'memory' as const, label: t('storySettings:tabs.memory') },
-        { id: 'translation' as const, label: t('storySettings:tabs.translation') },
-        { id: 'pack' as const, label: t('storySettings:tabs.pack') },
-        { id: 'calendar' as const, label: t('storySettings:tabs.calendar') },
-        { id: 'advanced' as const, label: t('storySettings:tabs.advanced') },
-      ],
-    },
-  ]
+  const groups = STORY_SETTINGS_TAB_GROUPS.map((group) => ({
+    id: group.id,
+    header: t(`storySettings:sections.${group.id}`),
+    tabs: group.tabs.map((id) => ({ id, label: t(`storySettings:tabs.${id}`) })),
+  }))
 
   const placeholder = (
     <EmptyState title={t('storySettings:landsLater')} subtext={t('storySettings:landsLaterBody')} />
@@ -134,9 +116,9 @@ function StorySettingsSurface() {
   const missingStory = <EmptyState title={t('storySettings:missingStory')} />
 
   // C7 seam: consumer slices replace a placeholder branch with their section.
-  // 3.1b → 'memory' (embedding status). 3.7 → 'generation' (authoring aids).
   // Called for every tab, not just the active one — see StorySettingsShell.
-  const renderPanel = (_id: StorySettingsTabId) => (storyId == null ? missingStory : placeholder)
+  const renderPanel = (_id: StorySettingsTabId) =>
+    hydrated && !storyExists ? missingStory : placeholder
 
   return (
     <ScreenShell
@@ -152,6 +134,13 @@ function StorySettingsSurface() {
       hideSelfReferentialIcon
       onBack={handleBack}
       actions={<AppActionsMenu />}
+      statusSlot={
+        <GenerationStatusPill
+          activePhase={isGenerating ? 'generating-narrative' : undefined}
+          onCancel={() => void awaitRunTerminal(PER_TURN_KIND, 'cancel')}
+          onErrorTap={() => {}}
+        />
+      }
     >
       <StorySettingsShell
         groups={groups}
@@ -180,6 +169,3 @@ function StorySettingsSurface() {
     </ScreenShell>
   )
 }
-
-export { STORY_SETTINGS_TAB_IDS }
-export type { StorySettingsTabId }

--- a/components/compounds/save-bar.tsx
+++ b/components/compounds/save-bar.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Icon } from '@/components/ui/icon'
 import { Text } from '@/components/ui/text'
 import { useGlobalHotkey } from '@/hooks/use-global-hotkey'
+import { t } from '@/lib/i18n'
 import { cn } from '@/lib/utils'
 
 type SaveBarProps = {
@@ -83,7 +84,7 @@ export function SaveBar({
         <View className="h-2 w-2 shrink-0 rounded-full bg-warning" aria-hidden />
         <Text size="xs" numberOfLines={1} className="shrink">
           <Text size="xs" className="font-semibold text-fg-primary">
-            {count} unsaved change{count === 1 ? '' : 's'}
+            {t('saveBar.unsavedChanges', { count })}
           </Text>
           {fieldList != null ? (
             <Text size="xs" variant="secondary">
@@ -107,10 +108,13 @@ export function SaveBar({
 
       <View className="shrink-0 flex-row items-center gap-2">
         <Button variant="secondary" size="sm" onPress={onDiscard} disabled={saving}>
-          <Text>Discard</Text>
+          <Text>{t('saveBar.discard')}</Text>
         </Button>
         <Button variant="primary" size="sm" onPress={onSave} disabled={saving}>
-          <Text>Save{shortcutHint != null ? ` ${shortcutHint}` : ''}</Text>
+          <Text>
+            {t('saveBar.save')}
+            {shortcutHint != null ? ` ${shortcutHint}` : ''}
+          </Text>
         </Button>
       </View>
     </View>

--- a/components/compounds/save-bar.tsx
+++ b/components/compounds/save-bar.tsx
@@ -34,6 +34,12 @@ type SaveBarProps = {
    * keyboard shortcut.
    */
   saving?: boolean
+  /**
+   * The host screen's focus state. A pushed-under expo-router screen stays
+   * mounted, so leaving this unset lets its Cmd-S fire from behind whatever
+   * screen is on top. Defaults to `true` for hosts that never push.
+   */
+  enabled?: boolean
   className?: string
 }
 
@@ -44,6 +50,7 @@ export function SaveBar({
   onSave,
   onDiscard,
   saving = false,
+  enabled = true,
   className,
 }: SaveBarProps) {
   const count = dirtyCount ?? dirtyFields.length
@@ -56,7 +63,11 @@ export function SaveBar({
   const handleSaveShortcut = useCallback(() => {
     if (!saving) onSave()
   }, [onSave, saving])
-  useGlobalHotkey(matchesSaveShortcut, handleSaveShortcut, { capture: true, stopPropagation: true })
+  useGlobalHotkey(matchesSaveShortcut, handleSaveShortcut, {
+    capture: true,
+    stopPropagation: true,
+    enabled,
+  })
 
   const shortcutHint = useMemo(() => {
     if (Platform.OS !== 'web') return null

--- a/components/shells/story-settings-shell.stories.tsx
+++ b/components/shells/story-settings-shell.stories.tsx
@@ -1,0 +1,218 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite'
+import { useState } from 'react'
+import { View } from 'react-native'
+import { expect, fn, screen, userEvent, waitFor } from 'storybook/test'
+
+import { SaveBar } from '@/components/compounds/save-bar'
+import { SwitchRow } from '@/components/compounds/switch-row'
+import { EmptyState } from '@/components/ui/empty-state'
+import { Input } from '@/components/ui/input'
+import { Text } from '@/components/ui/text'
+
+import { StorySettingsShell, type RailGroup } from './story-settings-shell'
+
+type TabId =
+  | 'about'
+  | 'generation'
+  | 'models'
+  | 'memory'
+  | 'translation'
+  | 'pack'
+  | 'calendar'
+  | 'advanced'
+
+const GROUPS: RailGroup<TabId>[] = [
+  {
+    id: 'story',
+    header: 'Story',
+    tabs: [
+      { id: 'about', label: 'About' },
+      { id: 'generation', label: 'Generation' },
+    ],
+  },
+  {
+    id: 'settings',
+    header: 'Settings',
+    tabs: [
+      { id: 'models', label: 'Models' },
+      { id: 'memory', label: 'Memory' },
+      { id: 'translation', label: 'Translation' },
+      { id: 'pack', label: 'Pack' },
+      { id: 'calendar', label: 'Calendar' },
+      { id: 'advanced', label: 'Advanced' },
+    ],
+  },
+]
+
+const PLACEHOLDER_TITLE = 'Lands in a later milestone'
+const TAB_COUNT = GROUPS.flatMap((group) => group.tabs).length
+
+const noop = () => {}
+
+function Placeholder() {
+  return (
+    <EmptyState
+      title={PLACEHOLDER_TITLE}
+      subtext="This tab isn't built yet. Nothing here is configurable."
+    />
+  )
+}
+
+function MemoryPanel() {
+  return (
+    <View className="gap-1">
+      <Text className="font-medium">Chapter memory</Text>
+      <SwitchRow
+        label="Full-chapter recall"
+        hint="Send the whole open chapter instead of the recent tail."
+        checked
+        onCheckedChange={noop}
+      />
+      <SwitchRow
+        label="Resolve stale entities before generating"
+        hint="Pauses generation when a pinned entity drifted out of date."
+        checked={false}
+        onCheckedChange={noop}
+      />
+    </View>
+  )
+}
+
+function GenerationPanel() {
+  return (
+    <View className="gap-1">
+      <Text className="font-medium">Authoring aids</Text>
+      <SwitchRow
+        label="Suggestions"
+        hint="Offer next-move suggestions after each beat."
+        checked
+        onCheckedChange={noop}
+      />
+      <SwitchRow
+        label="Composer modes"
+        hint="Wrap plain input in the story's narration point of view."
+        checked={false}
+        onCheckedChange={noop}
+      />
+    </View>
+  )
+}
+
+const meta: Meta<typeof StorySettingsShell<TabId>> = {
+  title: 'Shells/StorySettingsShell',
+  component: StorySettingsShell,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <View style={{ height: 620 }}>
+        <Story />
+      </View>
+    ),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * Every canonical tab renders the M3 placeholder. The play function
+ * pins the shell's core invariant: all eight panels are mounted, not
+ * just the active one — a section's draft has to survive a tab switch
+ * because the whole surface is one save session.
+ */
+export const PlaceholderTab: Story = {
+  args: {
+    groups: GROUPS,
+    activeTab: 'pack',
+    onSelectTab: fn(),
+    renderPanel: () => <Placeholder />,
+  },
+  play: async ({ args }) => {
+    await expect(screen.findAllByText(PLACEHOLDER_TITLE)).resolves.toHaveLength(TAB_COUNT)
+    expect(screen.getByRole('tab', { name: 'Pack' })).toHaveAttribute('aria-selected', 'true')
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Memory' }))
+    await waitFor(() => expect(args.onSelectTab).toHaveBeenCalledWith('memory'))
+  },
+}
+
+/**
+ * One filled tab beside seven placeholders — the M3 shape, where only
+ * the sections this milestone ships have bodies.
+ */
+export const FilledTab: Story = {
+  args: {
+    groups: GROUPS,
+    activeTab: 'memory',
+    onSelectTab: fn(),
+    renderPanel: (id) => (id === 'memory' ? <MemoryPanel /> : <Placeholder />),
+  },
+  play: async () => {
+    await expect(screen.findByText('Chapter memory')).resolves.toBeInTheDocument()
+    expect(screen.getAllByText(PLACEHOLDER_TITLE)).toHaveLength(TAB_COUNT - 1)
+  },
+}
+
+/**
+ * Dirty session — the route mounts the SaveBar as a flex footer under
+ * the panel scroller, so it stays put while the panel scrolls.
+ */
+export const DirtySession: Story = {
+  args: {
+    groups: GROUPS,
+    activeTab: 'generation',
+    onSelectTab: fn(),
+    renderPanel: (id) => (id === 'generation' ? <GenerationPanel /> : <Placeholder />),
+    saveBar: (
+      <SaveBar dirtyFields={['suggestions', 'suggestion count']} onSave={noop} onDiscard={noop} />
+    ),
+  },
+  play: async () => {
+    await expect(screen.findByText(/2 unsaved changes\b/)).resolves.toBeInTheDocument()
+  },
+}
+
+// Panel-local draft state — the whole point of the harness. If the
+// shell swapped panels instead of hiding them, this `useState` would
+// reset on every tab switch and the typed draft would be gone.
+function DraftPanel() {
+  const [draft, setDraft] = useState('')
+  return <Input placeholder="Story title" value={draft} onChangeText={setDraft} />
+}
+
+/**
+ * Draft survival across a tab switch, end to end: type into About,
+ * move to Memory, come back. Same DOM node, same value — the About
+ * panel was hidden, never unmounted.
+ */
+export const DraftSurvivesTabSwitch: Story = {
+  render: function DraftHarness() {
+    const [activeTab, setActiveTab] = useState<TabId>('about')
+    return (
+      <StorySettingsShell<TabId>
+        groups={GROUPS}
+        activeTab={activeTab}
+        onSelectTab={setActiveTab}
+        renderPanel={(id) => (id === 'about' ? <DraftPanel /> : <Placeholder />)}
+      />
+    )
+  },
+  play: async () => {
+    const input = screen.getByPlaceholderText('Story title')
+    await userEvent.type(input, 'Aria')
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Memory' }))
+    await waitFor(() =>
+      expect(screen.getByRole('tab', { name: 'Memory' })).toHaveAttribute('aria-selected', 'true'),
+    )
+    expect(screen.getByPlaceholderText('Story title')).toBe(input)
+    expect(input).toHaveValue('Aria')
+
+    await userEvent.click(screen.getByRole('tab', { name: 'About' }))
+    await waitFor(() =>
+      expect(screen.getByRole('tab', { name: 'About' })).toHaveAttribute('aria-selected', 'true'),
+    )
+    expect(screen.getByPlaceholderText('Story title')).toBe(input)
+    expect(input).toHaveValue('Aria')
+  },
+}

--- a/components/shells/story-settings-shell.stories.tsx
+++ b/components/shells/story-settings-shell.stories.tsx
@@ -98,7 +98,7 @@ function GenerationPanel() {
   )
 }
 
-const meta: Meta<typeof StorySettingsShell<TabId>> = {
+const meta: Meta<typeof StorySettingsShell<TabId, null>> = {
   title: 'Shells/StorySettingsShell',
   component: StorySettingsShell,
   parameters: { layout: 'fullscreen' },
@@ -125,6 +125,7 @@ export const PlaceholderTab: Story = {
     groups: GROUPS,
     activeTab: 'pack',
     onSelectTab: fn(),
+    panelData: null,
     renderPanel: () => <Placeholder />,
   },
   play: async ({ args }) => {
@@ -145,6 +146,7 @@ export const FilledTab: Story = {
     groups: GROUPS,
     activeTab: 'memory',
     onSelectTab: fn(),
+    panelData: null,
     renderPanel: (id) => (id === 'memory' ? <MemoryPanel /> : <Placeholder />),
   },
   play: async () => {
@@ -162,6 +164,7 @@ export const DirtySession: Story = {
     groups: GROUPS,
     activeTab: 'generation',
     onSelectTab: fn(),
+    panelData: null,
     renderPanel: (id) => (id === 'generation' ? <GenerationPanel /> : <Placeholder />),
     saveBar: (
       <SaveBar dirtyFields={['suggestions', 'suggestion count']} onSave={noop} onDiscard={noop} />
@@ -189,10 +192,11 @@ export const DraftSurvivesTabSwitch: Story = {
   render: function DraftHarness() {
     const [activeTab, setActiveTab] = useState<TabId>('about')
     return (
-      <StorySettingsShell<TabId>
+      <StorySettingsShell<TabId, null>
         groups={GROUPS}
         activeTab={activeTab}
         onSelectTab={setActiveTab}
+        panelData={null}
         renderPanel={(id) => (id === 'about' ? <DraftPanel /> : <Placeholder />)}
       />
     )

--- a/components/shells/story-settings-shell.tsx
+++ b/components/shells/story-settings-shell.tsx
@@ -1,0 +1,102 @@
+import { type ReactNode } from 'react'
+import { Platform, Pressable, ScrollView, View } from 'react-native'
+
+import { MasterDetailLayout } from '@/components/shells/master-detail-layout'
+import { Text } from '@/components/ui/text'
+import { cn } from '@/lib/utils'
+
+const STORY_SETTINGS_RAIL_WIDTH = 240
+
+type RailTab<TId extends string> = { id: TId; label: string }
+type RailGroup<TId extends string> = { id: string; header: string; tabs: RailTab<TId>[] }
+
+type StorySettingsShellProps<TId extends string> = {
+  groups: RailGroup<TId>[]
+  activeTab: TId | null
+  onSelectTab: (id: TId) => void
+  /**
+   * Renders one tab's panel. Called for EVERY tab in `groups`, not
+   * just the active one — every panel stays mounted and inactive
+   * ones are hidden, so a section's draft survives a tab switch.
+   * Unmounting would unpublish the section's dirty fields and
+   * silently discard its edits, which the one-session-per-surface
+   * contract forbids.
+   */
+  renderPanel: (id: TId) => ReactNode
+  /** Mounted by the route only while the session is dirty. */
+  saveBar?: ReactNode
+}
+
+export function StorySettingsShell<TId extends string>({
+  groups,
+  activeTab,
+  onSelectTab,
+  renderPanel,
+  saveBar,
+}: StorySettingsShellProps<TId>) {
+  const tabIds = groups.flatMap((group) => group.tabs.map((tab) => tab.id))
+
+  const rail = (
+    <ScrollView
+      accessibilityRole="tablist"
+      className="flex-1"
+      contentContainerClassName="gap-3 p-3"
+    >
+      {groups.map((group) => (
+        <View key={group.id} className="gap-1">
+          <Text variant="muted" size="xs" className="px-row-x-md uppercase">
+            {group.header}
+          </Text>
+          {group.tabs.map((tab) => {
+            const selected = tab.id === activeTab
+            return (
+              <Pressable
+                key={tab.id}
+                accessibilityRole="tab"
+                accessibilityState={{ selected }}
+                // RN-Web doesn't derive aria-selected from accessibilityState,
+                // and role="tab" without it is an axe violation.
+                aria-selected={selected}
+                onPress={() => onSelectTab(tab.id)}
+                className={cn(
+                  'rounded-md px-row-x-md py-row-y-md',
+                  selected ? 'bg-tint-press' : Platform.select({ web: 'hover:bg-tint-hover' }),
+                )}
+              >
+                <Text className={selected ? 'font-medium text-fg-primary' : 'text-fg-secondary'}>
+                  {tab.label}
+                </Text>
+              </Pressable>
+            )
+          })}
+        </View>
+      ))}
+    </ScrollView>
+  )
+
+  const detailPane = (
+    <View className="min-h-0 flex-1">
+      {tabIds.map((id) => (
+        <View key={id} className={cn('min-h-0 flex-1', id !== activeTab && 'hidden')}>
+          <ScrollView className="flex-1" contentContainerClassName="gap-4 p-4">
+            {renderPanel(id)}
+          </ScrollView>
+        </View>
+      ))}
+      {/* Outside the scroller: the pattern anchors the bar to the pane bottom as a flex item, not a sticky overlay. */}
+      {saveBar}
+    </View>
+  )
+
+  return (
+    <MasterDetailLayout
+      isRowSelected={activeTab != null}
+      listPaneWidth={STORY_SETTINGS_RAIL_WIDTH}
+      listPane={rail}
+      detailPane={detailPane}
+    />
+  )
+}
+
+export { STORY_SETTINGS_RAIL_WIDTH }
+export type { RailGroup, RailTab, StorySettingsShellProps }

--- a/components/shells/story-settings-shell.tsx
+++ b/components/shells/story-settings-shell.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react'
+import { type ReactElement, type ReactNode } from 'react'
 import { Platform, Pressable, ScrollView, View } from 'react-native'
 
 import { MasterDetailLayout } from '@/components/shells/master-detail-layout'
@@ -8,10 +8,14 @@ import { cn } from '@/lib/utils'
 const STORY_SETTINGS_RAIL_WIDTH = 240
 
 type RailTab<TId extends string> = { id: TId; label: string }
-type RailGroup<TId extends string> = { id: string; header: string; tabs: RailTab<TId>[] }
+type RailGroup<TId extends string> = {
+  id: string
+  header: string
+  tabs: readonly RailTab<TId>[]
+}
 
 type StorySettingsShellProps<TId extends string, TPanelData> = {
-  groups: RailGroup<TId>[]
+  groups: readonly RailGroup<TId>[]
   activeTab: TId | null
   onSelectTab: (id: TId) => void
   /**
@@ -28,9 +32,12 @@ type StorySettingsShellProps<TId extends string, TPanelData> = {
    * Unmounting would unpublish the section's dirty fields and
    * silently discard its edits, which the one-session-per-surface
    * contract forbids.
+   *
+   * Returns an element, not a `ReactNode`: a `switch` over the tab union that
+   * misses a case would otherwise return `undefined` and compile.
    */
-  renderPanel: (id: TId, data: TPanelData) => ReactNode
-  /** Mounted by the route only while the session is dirty. */
+  renderPanel: (id: TId, data: TPanelData) => ReactElement
+  /** Rendered at the bottom of the detail pane, outside the panel scroller. */
   saveBar?: ReactNode
 }
 
@@ -62,8 +69,8 @@ export function StorySettingsShell<TId extends string, TPanelData>({
                 key={tab.id}
                 accessibilityRole="tab"
                 accessibilityState={{ selected }}
-                // RN-Web doesn't derive aria-selected from accessibilityState,
-                // and role="tab" without it is an axe violation.
+                // RN-Web doesn't map accessibilityState.selected to
+                // aria-selected, so AT reports every tab unselected without it.
                 aria-selected={selected}
                 onPress={() => onSelectTab(tab.id)}
                 className={cn(
@@ -91,7 +98,7 @@ export function StorySettingsShell<TId extends string, TPanelData>({
           </ScrollView>
         </View>
       ))}
-      {/* Outside the scroller: the pattern anchors the bar to the pane bottom as a flex item, not a sticky overlay. */}
+      {/* Outside the scroller — see docs/ui/patterns/save-sessions.md → Positioning. */}
       {saveBar}
     </View>
   )

--- a/components/shells/story-settings-shell.tsx
+++ b/components/shells/story-settings-shell.tsx
@@ -98,7 +98,7 @@ export function StorySettingsShell<TId extends string, TPanelData>({
           </ScrollView>
         </View>
       ))}
-      {/* Outside the scroller — see docs/ui/patterns/save-sessions.md → Positioning. */}
+      {/* Outside the scroller — see docs/ui/patterns/save-sessions.md#visual. */}
       {saveBar}
     </View>
   )

--- a/components/shells/story-settings-shell.tsx
+++ b/components/shells/story-settings-shell.tsx
@@ -10,10 +10,17 @@ const STORY_SETTINGS_RAIL_WIDTH = 240
 type RailTab<TId extends string> = { id: TId; label: string }
 type RailGroup<TId extends string> = { id: string; header: string; tabs: RailTab<TId>[] }
 
-type StorySettingsShellProps<TId extends string> = {
+type StorySettingsShellProps<TId extends string, TPanelData> = {
   groups: RailGroup<TId>[]
   activeTab: TId | null
   onSelectTab: (id: TId) => void
+  /**
+   * Everything the panels read, resolved once by the owner. Threaded
+   * through so a panel takes its data from the surface that owns the
+   * screen rather than reaching into a store whose readiness it can't
+   * see.
+   */
+  panelData: TPanelData
   /**
    * Renders one tab's panel. Called for EVERY tab in `groups`, not
    * just the active one — every panel stays mounted and inactive
@@ -22,18 +29,19 @@ type StorySettingsShellProps<TId extends string> = {
    * silently discard its edits, which the one-session-per-surface
    * contract forbids.
    */
-  renderPanel: (id: TId) => ReactNode
+  renderPanel: (id: TId, data: TPanelData) => ReactNode
   /** Mounted by the route only while the session is dirty. */
   saveBar?: ReactNode
 }
 
-export function StorySettingsShell<TId extends string>({
+export function StorySettingsShell<TId extends string, TPanelData>({
   groups,
   activeTab,
   onSelectTab,
+  panelData,
   renderPanel,
   saveBar,
-}: StorySettingsShellProps<TId>) {
+}: StorySettingsShellProps<TId, TPanelData>) {
   const tabIds = groups.flatMap((group) => group.tabs.map((tab) => tab.id))
 
   const rail = (
@@ -79,7 +87,7 @@ export function StorySettingsShell<TId extends string>({
       {tabIds.map((id) => (
         <View key={id} className={cn('min-h-0 flex-1', id !== activeTab && 'hidden')}>
           <ScrollView className="flex-1" contentContainerClassName="gap-4 p-4">
-            {renderPanel(id)}
+            {renderPanel(id, panelData)}
           </ScrollView>
         </View>
       ))}

--- a/components/story-settings/panel-data.ts
+++ b/components/story-settings/panel-data.ts
@@ -1,0 +1,15 @@
+import type { StorySettings } from '@/lib/db'
+
+/**
+ * What a tab panel is given to render. `stories.settings` is nullable and the
+ * wizard inserts a draft row before settings exist, so "the story is there but
+ * has no settings" is a real persisted state — distinct from a cold read that
+ * hasn't landed yet and from a story that isn't there at all.
+ */
+export type StorySettingsPanelData =
+  | { status: 'loading' }
+  /** The story rows could not be read. Not the same as a story that is gone. */
+  | { status: 'unavailable' }
+  | { status: 'missing' }
+  | { status: 'uninitialized' }
+  | { status: 'ready'; settings: StorySettings }

--- a/components/story-settings/save-session-state.test.ts
+++ b/components/story-settings/save-session-state.test.ts
@@ -24,11 +24,14 @@ describe('computeSnapshot', () => {
   })
 
   it('reports a clean session when every section is clean', () => {
-    const snapshot = computeSnapshot([{ id: 'a', order: 0, dirtyFields: [] }])
+    const snapshot = computeSnapshot([
+      { id: 'a', order: 0, dirtyFields: [] },
+      { id: 'b', order: 10, dirtyFields: [] },
+    ])
     expect(snapshot).toEqual({ isDirty: false, dirtyFields: [], dirtyCount: 0 })
   })
 
-  it('flattens dirty fields in ascending order, then by id', () => {
+  it('flattens dirty fields in ascending rail order', () => {
     const snapshot = computeSnapshot([memory, generation])
     expect(snapshot).toEqual({
       isDirty: true,
@@ -69,6 +72,11 @@ describe('upsertSection', () => {
   it('replaces a known section when a dirty field is appended', () => {
     const grown = { ...memory, dirtyFields: ['embedder', 'auto-embed'] }
     expect(upsertSection([generation, memory], grown)).toEqual([generation, grown])
+  })
+
+  it('replaces a known section when a dirty field is swapped for another', () => {
+    const swapped = { ...memory, dirtyFields: ['auto-embed'] }
+    expect(upsertSection([generation, memory], swapped)).toEqual([generation, swapped])
   })
 
   it('returns the same array reference when nothing changed', () => {

--- a/components/story-settings/save-session-state.test.ts
+++ b/components/story-settings/save-session-state.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  cloneDraft,
   computeSnapshot,
   removeSection,
+  sameDraft,
   upsertSection,
   type SectionDirtyState,
 } from './save-session-state'
@@ -110,5 +112,55 @@ describe('removeSection', () => {
   it('returns the same array reference when the id is absent', () => {
     const list = [generation]
     expect(removeSection(list, 'nope')).toBe(list)
+  })
+})
+
+describe('sameDraft', () => {
+  // JSON.stringify collapses this pair. Harmless while `updateStorySettings`
+  // also strips undefined — the point is that the reset decision no longer
+  // rests on the two modules happening to agree.
+  it('separates a cleared key from an absent one', () => {
+    expect(sameDraft({ embedding_swap_target: undefined }, {})).toBe(false)
+    expect(sameDraft({}, { embedding_swap_target: undefined })).toBe(false)
+    expect(
+      sameDraft({ embedding_swap_target: undefined }, { embedding_swap_target: undefined }),
+    ).toBe(true)
+  })
+
+  it('compares nested values structurally', () => {
+    expect(sameDraft({ models: { narrative: 'a' } }, { models: { narrative: 'a' } })).toBe(true)
+    expect(sameDraft({ models: { narrative: 'a' } }, { models: { narrative: 'b' } })).toBe(false)
+    expect(sameDraft({ models: { narrative: undefined } }, { models: {} })).toBe(false)
+  })
+
+  it('does not confuse an array with an object holding the same keys', () => {
+    expect(sameDraft(['a'], { 0: 'a' })).toBe(false)
+  })
+
+  it('reads an unrepresentable draft as changed rather than throwing', () => {
+    const cyclic: Record<string, unknown> = {}
+    cyclic.self = cyclic
+    const twin: Record<string, unknown> = {}
+    twin.self = twin
+    expect(sameDraft(cyclic, twin)).toBe(false)
+  })
+})
+
+describe('cloneDraft', () => {
+  // getPatch may hand back the section's own draft object; holding it by
+  // reference would let a later edit rewrite what we compare against.
+  it('detaches the copy from later mutation', () => {
+    const draft = { models: { narrative: 'a' }, packVariables: { tone: 'wry' } }
+    const before = cloneDraft(draft)
+
+    draft.models.narrative = 'b'
+    expect(sameDraft(draft, before)).toBe(false)
+  })
+
+  it('preserves a cleared key', () => {
+    expect(sameDraft(cloneDraft({ activePackId: undefined }), { activePackId: undefined })).toBe(
+      true,
+    )
+    expect(sameDraft(cloneDraft({ activePackId: undefined }), {})).toBe(false)
   })
 })

--- a/components/story-settings/save-session-state.test.ts
+++ b/components/story-settings/save-session-state.test.ts
@@ -9,41 +9,45 @@ import {
 
 const memory: SectionDirtyState = {
   id: 'embedding-status',
-  order: 20,
+  tab: 'memory',
   dirtyFields: ['embedder'],
 }
 const generation: SectionDirtyState = {
   id: 'authoring-aids',
-  order: 10,
+  tab: 'generation',
   dirtyFields: ['suggestions', 'suggestion count'],
 }
 
 describe('computeSnapshot', () => {
   it('reports a clean session for no sections', () => {
-    expect(computeSnapshot([])).toEqual({ isDirty: false, dirtyFields: [], dirtyCount: 0 })
+    expect(computeSnapshot([])).toEqual({ dirtyFields: [] })
   })
 
   it('reports a clean session when every section is clean', () => {
     const snapshot = computeSnapshot([
-      { id: 'a', order: 0, dirtyFields: [] },
-      { id: 'b', order: 10, dirtyFields: [] },
+      { id: 'a', tab: 'about', dirtyFields: [] },
+      { id: 'b', tab: 'memory', dirtyFields: [] },
     ])
-    expect(snapshot).toEqual({ isDirty: false, dirtyFields: [], dirtyCount: 0 })
+    expect(snapshot).toEqual({ dirtyFields: [] })
   })
 
   it('flattens dirty fields in ascending rail order', () => {
     const snapshot = computeSnapshot([memory, generation])
-    expect(snapshot).toEqual({
-      isDirty: true,
-      dirtyFields: ['suggestions', 'suggestion count', 'embedder'],
-      dirtyCount: 3,
-    })
+    expect(snapshot).toEqual({ dirtyFields: ['suggestions', 'suggestion count', 'embedder'] })
   })
 
-  it('breaks an order tie deterministically by id', () => {
+  it('ranks a section by its tab, not its registration order', () => {
     const snapshot = computeSnapshot([
-      { id: 'zulu', order: 0, dirtyFields: ['z'] },
-      { id: 'alpha', order: 0, dirtyFields: ['a'] },
+      { id: 'late', tab: 'about', dirtyFields: ['first in the rail'] },
+      { id: 'early', tab: 'advanced', dirtyFields: ['last in the rail'] },
+    ])
+    expect(snapshot.dirtyFields).toEqual(['first in the rail', 'last in the rail'])
+  })
+
+  it('breaks a same-tab tie deterministically by id', () => {
+    const snapshot = computeSnapshot([
+      { id: 'zulu', tab: 'about', dirtyFields: ['z'] },
+      { id: 'alpha', tab: 'about', dirtyFields: ['a'] },
     ])
     expect(snapshot.dirtyFields).toEqual(['a', 'z'])
   })
@@ -55,8 +59,8 @@ describe('computeSnapshot', () => {
   })
 
   it('ignores clean sections when others are dirty', () => {
-    const snapshot = computeSnapshot([generation, { id: 'quiet', order: 99, dirtyFields: [] }])
-    expect(snapshot.dirtyCount).toBe(2)
+    const snapshot = computeSnapshot([generation, { id: 'quiet', tab: 'pack', dirtyFields: [] }])
+    expect(snapshot.dirtyFields).toEqual(['suggestions', 'suggestion count'])
   })
 })
 
@@ -70,8 +74,8 @@ describe('upsertSection', () => {
     expect(upsertSection([generation, memory], updated)).toEqual([updated, memory])
   })
 
-  it('replaces a known section when only its order changed', () => {
-    const moved = { ...generation, order: 30 }
+  it('replaces a known section when only its tab changed', () => {
+    const moved: SectionDirtyState = { ...generation, tab: 'advanced' }
     expect(upsertSection([generation, memory], moved)).toEqual([moved, memory])
   })
 
@@ -85,9 +89,16 @@ describe('upsertSection', () => {
     expect(upsertSection([generation, memory], swapped)).toEqual([generation, swapped])
   })
 
-  it('returns the same array reference when nothing changed', () => {
+  it('returns the same array reference for an equal but freshly built section', () => {
+    // A fresh array literal, not a spread of the same one: the anti-loop guard
+    // has to compare per field, and an identity check would also pass a spread.
     const list = [generation]
-    expect(upsertSection(list, { ...generation })).toBe(list)
+    const republished: SectionDirtyState = {
+      id: 'authoring-aids',
+      tab: 'generation',
+      dirtyFields: ['suggestions', 'suggestion count'],
+    }
+    expect(upsertSection(list, republished)).toBe(list)
   })
 })
 

--- a/components/story-settings/save-session-state.test.ts
+++ b/components/story-settings/save-session-state.test.ts
@@ -48,6 +48,12 @@ describe('computeSnapshot', () => {
     expect(snapshot.dirtyFields).toEqual(['a', 'z'])
   })
 
+  it('does not reorder the caller’s array', () => {
+    const input = [memory, generation]
+    computeSnapshot(input)
+    expect(input).toEqual([memory, generation])
+  })
+
   it('ignores clean sections when others are dirty', () => {
     const snapshot = computeSnapshot([generation, { id: 'quiet', order: 99, dirtyFields: [] }])
     expect(snapshot.dirtyCount).toBe(2)

--- a/components/story-settings/save-session-state.test.ts
+++ b/components/story-settings/save-session-state.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  computeSnapshot,
+  removeSection,
+  upsertSection,
+  type SectionDirtyState,
+} from './save-session-state'
+
+const memory: SectionDirtyState = {
+  id: 'embedding-status',
+  order: 20,
+  dirtyFields: ['embedder'],
+}
+const generation: SectionDirtyState = {
+  id: 'authoring-aids',
+  order: 10,
+  dirtyFields: ['suggestions', 'suggestion count'],
+}
+
+describe('computeSnapshot', () => {
+  it('reports a clean session for no sections', () => {
+    expect(computeSnapshot([])).toEqual({ isDirty: false, dirtyFields: [], dirtyCount: 0 })
+  })
+
+  it('reports a clean session when every section is clean', () => {
+    const snapshot = computeSnapshot([{ id: 'a', order: 0, dirtyFields: [] }])
+    expect(snapshot).toEqual({ isDirty: false, dirtyFields: [], dirtyCount: 0 })
+  })
+
+  it('flattens dirty fields in ascending order, then by id', () => {
+    const snapshot = computeSnapshot([memory, generation])
+    expect(snapshot).toEqual({
+      isDirty: true,
+      dirtyFields: ['suggestions', 'suggestion count', 'embedder'],
+      dirtyCount: 3,
+    })
+  })
+
+  it('breaks an order tie deterministically by id', () => {
+    const snapshot = computeSnapshot([
+      { id: 'zulu', order: 0, dirtyFields: ['z'] },
+      { id: 'alpha', order: 0, dirtyFields: ['a'] },
+    ])
+    expect(snapshot.dirtyFields).toEqual(['a', 'z'])
+  })
+
+  it('ignores clean sections when others are dirty', () => {
+    const snapshot = computeSnapshot([generation, { id: 'quiet', order: 99, dirtyFields: [] }])
+    expect(snapshot.dirtyCount).toBe(2)
+  })
+})
+
+describe('upsertSection', () => {
+  it('appends an unknown section', () => {
+    expect(upsertSection([generation], memory)).toEqual([generation, memory])
+  })
+
+  it('replaces a known section in place', () => {
+    const updated = { ...generation, dirtyFields: ['suggestions'] }
+    expect(upsertSection([generation, memory], updated)).toEqual([updated, memory])
+  })
+
+  it('replaces a known section when only its order changed', () => {
+    const moved = { ...generation, order: 30 }
+    expect(upsertSection([generation, memory], moved)).toEqual([moved, memory])
+  })
+
+  it('replaces a known section when a dirty field is appended', () => {
+    const grown = { ...memory, dirtyFields: ['embedder', 'auto-embed'] }
+    expect(upsertSection([generation, memory], grown)).toEqual([generation, grown])
+  })
+
+  it('returns the same array reference when nothing changed', () => {
+    const list = [generation]
+    expect(upsertSection(list, { ...generation })).toBe(list)
+  })
+})
+
+describe('removeSection', () => {
+  it('drops the matching section', () => {
+    expect(removeSection([generation, memory], 'authoring-aids')).toEqual([memory])
+  })
+
+  it('returns the same array reference when the id is absent', () => {
+    const list = [generation]
+    expect(removeSection(list, 'nope')).toBe(list)
+  })
+})

--- a/components/story-settings/save-session-state.ts
+++ b/components/story-settings/save-session-state.ts
@@ -59,3 +59,54 @@ export function removeSection(
   if (!sections.some((s) => s.id === id)) return sections
   return sections.filter((s) => s.id !== id)
 }
+
+// Deeper than any `StorySettings` branch. `packVariables` is an open record, so
+// the floor has to be a depth cap rather than the schema — anything past it
+// reads as "changed", which only costs a stale save bar.
+const DRAFT_DEPTH_LIMIT = 12
+
+/**
+ * Point-in-time copy of a section's draft, for comparing against a later read.
+ * Copied rather than held by reference: `getPatch` may hand back the section's
+ * own draft object, and a later edit to it would rewrite the thing we're
+ * comparing against.
+ */
+export function cloneDraft(value: unknown, depth = 0): unknown {
+  if (depth >= DRAFT_DEPTH_LIMIT || typeof value !== 'object' || value === null) return value
+  if (Array.isArray(value)) return value.map((item) => cloneDraft(item, depth + 1))
+  const copy: Record<string, unknown> = {}
+  for (const key of Object.keys(value)) {
+    copy[key] = cloneDraft((value as Record<string, unknown>)[key], depth + 1)
+  }
+  return copy
+}
+
+/**
+ * Whether two reads of a section's draft are the same edit.
+ *
+ * Compares key *presence*, so `{ k: undefined }` and `{}` differ — unlike
+ * `JSON.stringify` equality, which drops `undefined`-valued keys. That
+ * difference is currently invisible, because `updateStorySettings` strips
+ * `undefined` the same way, so a stringify-equal pair also writes equal. This
+ * exists so the reset decision stops depending on that coincidence: nothing
+ * enforces that the two modules keep agreeing on what `undefined` means.
+ */
+export function sameDraft(a: unknown, b: unknown, depth = 0): boolean {
+  // Only reached by a cycle or a draft deeper than the cap; both fall to
+  // "changed", which skips a reset rather than discarding an edit.
+  if (depth >= DRAFT_DEPTH_LIMIT) return false
+  if (Object.is(a, b)) return true
+  if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) return false
+  if (Array.isArray(a) !== Array.isArray(b)) return false
+  const aKeys = Object.keys(a)
+  if (aKeys.length !== Object.keys(b).length) return false
+  return aKeys.every(
+    (key) =>
+      Object.hasOwn(b, key) &&
+      sameDraft(
+        (a as Record<string, unknown>)[key],
+        (b as Record<string, unknown>)[key],
+        depth + 1,
+      ),
+  )
+}

--- a/components/story-settings/save-session-state.ts
+++ b/components/story-settings/save-session-state.ts
@@ -1,0 +1,56 @@
+export type SectionDirtyState = {
+  id: string
+  order: number
+  dirtyFields: readonly string[]
+}
+
+export type SaveSessionSnapshot = {
+  isDirty: boolean
+  dirtyFields: readonly string[]
+  dirtyCount: number
+}
+
+export const CLEAN_SNAPSHOT: SaveSessionSnapshot = {
+  isDirty: false,
+  dirtyFields: [],
+  dirtyCount: 0,
+}
+
+function sameFields(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((field, i) => field === b[i])
+}
+
+// Rail order drives the label order in the save bar, so the user reads dirty
+// fields in the same sequence the tabs present them.
+export function computeSnapshot(sections: readonly SectionDirtyState[]): SaveSessionSnapshot {
+  const dirtyFields = [...sections]
+    .sort((a, b) => a.order - b.order || a.id.localeCompare(b.id))
+    .flatMap((section) => section.dirtyFields)
+  if (dirtyFields.length === 0) return CLEAN_SNAPSHOT
+  return { isDirty: true, dirtyFields, dirtyCount: dirtyFields.length }
+}
+
+// Returns the SAME array reference when nothing changed, so the provider's
+// setState is a no-op and a section republishing an unchanged list can't loop.
+export function upsertSection(
+  sections: readonly SectionDirtyState[],
+  next: SectionDirtyState,
+): readonly SectionDirtyState[] {
+  const index = sections.findIndex((s) => s.id === next.id)
+  if (index === -1) return [...sections, next]
+  const current = sections[index]
+  if (current.order === next.order && sameFields(current.dirtyFields, next.dirtyFields)) {
+    return sections
+  }
+  const copy = [...sections]
+  copy[index] = next
+  return copy
+}
+
+export function removeSection(
+  sections: readonly SectionDirtyState[],
+  id: string,
+): readonly SectionDirtyState[] {
+  if (!sections.some((s) => s.id === id)) return sections
+  return sections.filter((s) => s.id !== id)
+}

--- a/components/story-settings/save-session-state.ts
+++ b/components/story-settings/save-session-state.ts
@@ -5,12 +5,12 @@ export type SectionDirtyState = {
 }
 
 export type SaveSessionSnapshot = {
-  isDirty: boolean
-  dirtyFields: readonly string[]
-  dirtyCount: number
+  readonly isDirty: boolean
+  readonly dirtyFields: readonly string[]
+  readonly dirtyCount: number
 }
 
-export const CLEAN_SNAPSHOT: SaveSessionSnapshot = {
+const CLEAN_SNAPSHOT: SaveSessionSnapshot = {
   isDirty: false,
   dirtyFields: [],
   dirtyCount: 0,
@@ -20,6 +20,7 @@ function sameFields(a: readonly string[], b: readonly string[]): boolean {
   return a.length === b.length && a.every((field, i) => field === b[i])
 }
 
+/** Returns a fresh snapshot per dirty call — derive it (useMemo), never store it in state. */
 // Rail order drives the label order in the save bar, so the user reads dirty
 // fields in the same sequence the tabs present them.
 export function computeSnapshot(sections: readonly SectionDirtyState[]): SaveSessionSnapshot {

--- a/components/story-settings/save-session-state.ts
+++ b/components/story-settings/save-session-state.ts
@@ -1,20 +1,20 @@
+import { storySettingsTabOrder, type StorySettingsTabId } from './tabs'
+
 export type SectionDirtyState = {
   id: string
-  order: number
+  tab: StorySettingsTabId
   dirtyFields: readonly string[]
 }
 
+/**
+ * The surface's dirty fields in rail order. One field, so "clean" and "which
+ * fields" can never disagree — read `dirtyFields.length` for both.
+ */
 export type SaveSessionSnapshot = {
-  readonly isDirty: boolean
   readonly dirtyFields: readonly string[]
-  readonly dirtyCount: number
 }
 
-const CLEAN_SNAPSHOT: SaveSessionSnapshot = {
-  isDirty: false,
-  dirtyFields: [],
-  dirtyCount: 0,
-}
+const CLEAN_SNAPSHOT: SaveSessionSnapshot = { dirtyFields: [] }
 
 function sameFields(a: readonly string[], b: readonly string[]): boolean {
   return a.length === b.length && a.every((field, i) => field === b[i])
@@ -22,13 +22,17 @@ function sameFields(a: readonly string[], b: readonly string[]): boolean {
 
 /** Returns a fresh snapshot per dirty call — derive it (useMemo), never store it in state. */
 // Rail order drives the label order in the save bar, so the user reads dirty
-// fields in the same sequence the tabs present them.
+// fields in the same sequence the tabs present them. Sections sharing a tab tie
+// on order and fall back to id, so the sequence stays stable across mounts.
 export function computeSnapshot(sections: readonly SectionDirtyState[]): SaveSessionSnapshot {
   const dirtyFields = [...sections]
-    .sort((a, b) => a.order - b.order || a.id.localeCompare(b.id))
+    .sort(
+      (a, b) =>
+        storySettingsTabOrder(a.tab) - storySettingsTabOrder(b.tab) || a.id.localeCompare(b.id),
+    )
     .flatMap((section) => section.dirtyFields)
   if (dirtyFields.length === 0) return CLEAN_SNAPSHOT
-  return { isDirty: true, dirtyFields, dirtyCount: dirtyFields.length }
+  return { dirtyFields }
 }
 
 // Returns the SAME array reference when nothing changed, so the provider's
@@ -40,7 +44,7 @@ export function upsertSection(
   const index = sections.findIndex((s) => s.id === next.id)
   if (index === -1) return [...sections, next]
   const current = sections[index]
-  if (current.order === next.order && sameFields(current.dirtyFields, next.dirtyFields)) {
+  if (current.tab === next.tab && sameFields(current.dirtyFields, next.dirtyFields)) {
     return sections
   }
   const copy = [...sections]

--- a/components/story-settings/save-session.test.tsx
+++ b/components/story-settings/save-session.test.tsx
@@ -483,6 +483,36 @@ describe('StorySettingsSaveSessionProvider — leave guard', () => {
     expect(session.onSaveFailed).toHaveBeenCalledTimes(1)
     expect(proceed).not.toHaveBeenCalled()
     expect(aids.reset).not.toHaveBeenCalled()
+    // The guard stays up so the failure leaves the user on the same choice
+    // instead of stranding the navigation they asked for.
+    expect(session.api().pendingLeave).toBe(true)
+  })
+
+  it('holds the guard open and saving while its own save is in flight', async () => {
+    const releases: (() => void)[] = []
+    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
+    const session = mountSession({
+      children: sectionsOf(aids),
+      onCommit: vi.fn(() => new Promise<void>((resolve) => releases.push(resolve))),
+    })
+    const proceed = vi.fn()
+
+    act(() => session.api().requestLeave(proceed))
+    await act(async () => {
+      session.api().resolveLeave('save')
+    })
+
+    expect(session.api().pendingLeave).toBe(true)
+    expect(session.api().saving).toBe(true)
+    expect(proceed).not.toHaveBeenCalled()
+
+    await act(async () => {
+      for (const release of releases) release()
+    })
+
+    expect(session.api().pendingLeave).toBe(false)
+    expect(session.api().saving).toBe(false)
+    expect(proceed).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/components/story-settings/save-session.test.tsx
+++ b/components/story-settings/save-session.test.tsx
@@ -3,7 +3,7 @@ import { act, cleanup, render } from '@testing-library/react'
 import { type ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi, type Mock } from 'vitest'
 
-import type { StorySettings } from '@/lib/db'
+import { STORY_SETTINGS_DEFAULTS, type StorySettings } from '@/lib/db'
 
 import {
   StorySettingsSaveSessionProvider,
@@ -38,7 +38,10 @@ vi.mock('./save-session-state', async (importOriginal) => {
 afterEach(() => {
   guard.breakArrayIdentity = false
   cleanup()
+  vi.restoreAllMocks()
 })
+
+const COLLISION = 'both patch the top-level key'
 
 type SectionFixture = {
   id: string
@@ -192,6 +195,65 @@ describe('StorySettingsSaveSessionProvider — save', () => {
     expect(session.onSaved).not.toHaveBeenCalled()
     expect(aids.reset).not.toHaveBeenCalled()
     expect(memory.reset).not.toHaveBeenCalled()
+  })
+
+  it('turns away a second save while one is already in flight', async () => {
+    // Every commit gets released, not just the last: a regression must fail on
+    // the call-count assertion rather than deadlocking on an orphaned promise.
+    const releases: (() => void)[] = []
+    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
+    const session = mountSession({
+      children: sectionsOf(aids),
+      onCommit: vi.fn(() => new Promise<void>((resolve) => releases.push(resolve))),
+    })
+
+    let outcomes: boolean[] = []
+    await act(async () => {
+      const inFlight = session.api().save()
+      const second = session.api().save()
+      for (const release of releases) release()
+      outcomes = await Promise.all([inFlight, second])
+    })
+
+    expect(session.onCommit).toHaveBeenCalledTimes(1)
+    expect(outcomes).toEqual([true, false])
+    expect(aids.reset).toHaveBeenCalledTimes(1)
+    expect(session.onSaved).toHaveBeenCalledTimes(1)
+  })
+
+  it('warns when two sections patch the same top-level key', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const composer = makeSection('composer', 10, ['translation'], {
+      translation: { ...STORY_SETTINGS_DEFAULTS.translation, enabled: true },
+    })
+    const languages = makeSection('languages', 20, ['granular toggles'], {
+      translation: { ...STORY_SETTINGS_DEFAULTS.translation, targetLanguage: 'cs' },
+    })
+    const session = mountSession({ children: sectionsOf(composer, languages) })
+
+    await act(async () => {
+      await session.api().save()
+    })
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(COLLISION))
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('"composer" and "languages"'))
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('"translation"'))
+  })
+
+  it('stays quiet when every section patches a distinct top-level key', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const aids = makeSection('authoring-aids', 10, ['suggestions'], {
+      suggestionsEnabled: true,
+      suggestionCount: 5,
+    })
+    const memory = makeSection('embedding-status', 20, ['embedder'], { embeddingBackend: 'local' })
+    const session = mountSession({ children: sectionsOf(aids, memory) })
+
+    await act(async () => {
+      await session.api().save()
+    })
+
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining(COLLISION))
   })
 
   it('leaves the session clean again after a successful save', async () => {

--- a/components/story-settings/save-session.test.tsx
+++ b/components/story-settings/save-session.test.tsx
@@ -197,6 +197,47 @@ describe('StorySettingsSaveSessionProvider — save', () => {
     expect(memory.reset).not.toHaveBeenCalled()
   })
 
+  it('skips a clean section rather than trusting it to return an empty patch', async () => {
+    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
+    const memory = makeSection('embedding-status', 20, [], {
+      embedding_model_id: 'Xenova/all-MiniLM-L6-v2',
+    })
+    const session = mountSession({ children: sectionsOf(aids, memory) })
+
+    await act(async () => {
+      await session.api().save()
+    })
+
+    expect(memory.getPatch).not.toHaveBeenCalled()
+    expect(session.onCommit).toHaveBeenCalledExactlyOnceWith({ suggestionsEnabled: true })
+  })
+
+  it('commits the newest getPatch and reset closures, not the ones from mount', async () => {
+    const resets: number[] = []
+    function CountSection({ count }: { count: number }) {
+      useStorySettingsSection({
+        id: 'authoring-aids',
+        order: 10,
+        dirtyFields: ['suggestion count'],
+        getPatch: () => ({ suggestionCount: count }),
+        reset: () => resets.push(count),
+      })
+      return null
+    }
+
+    const session = mountSession({ children: <CountSection count={3} /> })
+    act(() => {
+      session.rerenderWith(<CountSection count={5} />)
+    })
+
+    await act(async () => {
+      await session.api().save()
+    })
+
+    expect(session.onCommit).toHaveBeenCalledExactlyOnceWith({ suggestionCount: 5 })
+    expect(resets).toEqual([5])
+  })
+
   it('turns away a second save while one is already in flight', async () => {
     // Every commit gets released, not just the last: a regression must fail on
     // the call-count assertion rather than deadlocking on an orphaned promise.

--- a/components/story-settings/save-session.test.tsx
+++ b/components/story-settings/save-session.test.tsx
@@ -207,12 +207,19 @@ describe('StorySettingsSaveSessionProvider — save', () => {
       onCommit: vi.fn(() => new Promise<void>((resolve) => releases.push(resolve))),
     })
 
+    let inFlight: Promise<boolean> | undefined
+    let second: Promise<boolean> | undefined
+    await act(async () => {
+      inFlight = session.api().save()
+      second = session.api().save()
+    })
+
+    expect(session.api().saving).toBe(true)
+
     let outcomes: boolean[] = []
     await act(async () => {
-      const inFlight = session.api().save()
-      const second = session.api().save()
       for (const release of releases) release()
-      outcomes = await Promise.all([inFlight, second])
+      outcomes = await Promise.all([inFlight!, second!])
     })
 
     expect(session.onCommit).toHaveBeenCalledTimes(1)
@@ -256,7 +263,7 @@ describe('StorySettingsSaveSessionProvider — save', () => {
     expect(warn).not.toHaveBeenCalledWith(expect.stringContaining(COLLISION))
   })
 
-  it('leaves the session clean again after a successful save', async () => {
+  it('clears the saving flag after a successful save', async () => {
     const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
     const session = mountSession({ children: sectionsOf(aids) })
     expect(session.api().saving).toBe(false)

--- a/components/story-settings/save-session.test.tsx
+++ b/components/story-settings/save-session.test.tsx
@@ -1,0 +1,416 @@
+// @vitest-environment jsdom
+import { act, cleanup, render } from '@testing-library/react'
+import { type ReactNode } from 'react'
+import { afterEach, describe, expect, it, vi, type Mock } from 'vitest'
+
+import type { StorySettings } from '@/lib/db'
+
+import {
+  StorySettingsSaveSessionProvider,
+  useStorySettingsSaveSession,
+  useStorySettingsSection,
+  type SaveSessionApi,
+} from './save-session'
+import { type SectionDirtyState } from './save-session-state'
+
+// The publish loop has two independent guards: the effect's serialized dirty
+// key, and upsertSection returning the same array reference for an unchanged
+// republish. The second alone stops the loop, which makes the first
+// unfalsifiable — so one test neutralizes it to exercise the first in isolation.
+const guard = vi.hoisted(() => ({ breakArrayIdentity: false }))
+
+type UpsertSection = (
+  sections: readonly SectionDirtyState[],
+  next: SectionDirtyState,
+) => readonly SectionDirtyState[]
+
+vi.mock('./save-session-state', async (importOriginal) => {
+  const actual = (await importOriginal()) as { upsertSection: UpsertSection }
+  return {
+    ...actual,
+    upsertSection: (sections: readonly SectionDirtyState[], next: SectionDirtyState) => {
+      const result = actual.upsertSection(sections, next)
+      return guard.breakArrayIdentity && result === sections ? [...sections] : result
+    },
+  }
+})
+
+afterEach(() => {
+  guard.breakArrayIdentity = false
+  cleanup()
+})
+
+type SectionFixture = {
+  id: string
+  order: number
+  dirtyFields: readonly string[]
+  getPatch: Mock<() => Partial<StorySettings>>
+  reset: Mock<() => void>
+}
+
+function makeSection(
+  id: string,
+  order: number,
+  dirtyFields: readonly string[],
+  patch: Partial<StorySettings> = {},
+): SectionFixture {
+  return { id, order, dirtyFields, getPatch: vi.fn(() => patch), reset: vi.fn() }
+}
+
+function Section({ fixture }: { fixture: SectionFixture }) {
+  useStorySettingsSection({
+    id: fixture.id,
+    order: fixture.order,
+    dirtyFields: fixture.dirtyFields,
+    getPatch: fixture.getPatch,
+    reset: fixture.reset,
+  })
+  return null
+}
+
+function Capture({ held }: { held: { current: SaveSessionApi | null } }) {
+  held.current = useStorySettingsSaveSession()
+  return null
+}
+
+type MountOptions = {
+  children?: ReactNode
+  onCommit?: Mock<() => Promise<unknown>>
+  onSaved?: Mock<() => void>
+  onSaveFailed?: Mock<(error: unknown) => void>
+}
+
+function mountSession(options: MountOptions = {}) {
+  const onCommit = options.onCommit ?? vi.fn(() => Promise.resolve())
+  const onSaved = options.onSaved ?? vi.fn()
+  const onSaveFailed = options.onSaveFailed ?? vi.fn()
+  const held: { current: SaveSessionApi | null } = { current: null }
+
+  const tree = (children: ReactNode) => (
+    <StorySettingsSaveSessionProvider
+      onCommit={onCommit}
+      onSaved={onSaved}
+      onSaveFailed={onSaveFailed}
+    >
+      {children}
+      <Capture held={held} />
+    </StorySettingsSaveSessionProvider>
+  )
+
+  const view = render(tree(options.children))
+
+  return {
+    onCommit,
+    onSaved,
+    onSaveFailed,
+    api: () => held.current!,
+    rerenderWith: (children: ReactNode) => view.rerender(tree(children)),
+  }
+}
+
+function sectionsOf(...fixtures: SectionFixture[]) {
+  return fixtures.map((fixture) => <Section key={fixture.id} fixture={fixture} />)
+}
+
+/**
+ * A section handing the hook a brand-new `dirtyFields` array on every render —
+ * the shape that would re-fire the publish effect forever if the guards broke.
+ * Throws past a render ceiling so a regression fails loudly instead of hanging
+ * the run: an unguarded publish loop never yields to the test timeout.
+ */
+function churningSection(renders: { count: number }) {
+  return function ChurningSection() {
+    renders.count += 1
+    useStorySettingsSection({
+      id: 'authoring-aids',
+      order: 10,
+      dirtyFields: ['suggestions', 'suggestion count'].slice(),
+      getPatch: () => ({ suggestionsEnabled: true }),
+      reset: () => {},
+    })
+    if (renders.count > 25) throw new Error(`publish loop: ${renders.count} renders`)
+    return null
+  }
+}
+
+describe('StorySettingsSaveSessionProvider — save', () => {
+  it('commits every registered section as ONE merged write', async () => {
+    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
+    const memory = makeSection('embedding-status', 20, ['embedder'], {
+      embedding_model_id: 'Xenova/all-MiniLM-L6-v2',
+    })
+    const chapters = makeSection('chapters', 30, ['chapter threshold'], {
+      chapterTokenThreshold: 9000,
+    })
+    const session = mountSession({ children: sectionsOf(aids, memory, chapters) })
+
+    await act(async () => {
+      await session.api().save()
+    })
+
+    expect(session.onCommit).toHaveBeenCalledTimes(1)
+    expect(session.onCommit).toHaveBeenCalledWith({
+      suggestionsEnabled: true,
+      embedding_model_id: 'Xenova/all-MiniLM-L6-v2',
+      chapterTokenThreshold: 9000,
+    })
+  })
+
+  it('resolves true and resets every section after a successful save', async () => {
+    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
+    const memory = makeSection('embedding-status', 20, ['embedder'], { embeddingBackend: 'local' })
+    const session = mountSession({ children: sectionsOf(aids, memory) })
+
+    let outcome: boolean | undefined
+    await act(async () => {
+      outcome = await session.api().save()
+    })
+
+    expect(outcome).toBe(true)
+    expect(aids.reset).toHaveBeenCalledTimes(1)
+    expect(memory.reset).toHaveBeenCalledTimes(1)
+    expect(session.onSaved).toHaveBeenCalledTimes(1)
+    expect(session.onSaveFailed).not.toHaveBeenCalled()
+  })
+
+  it('keeps every draft intact when the commit rejects', async () => {
+    const failure = new Error('write failed')
+    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
+    const memory = makeSection('embedding-status', 20, ['embedder'], { embeddingBackend: 'local' })
+    const session = mountSession({
+      children: sectionsOf(aids, memory),
+      onCommit: vi.fn(() => Promise.reject(failure)),
+    })
+
+    let outcome: boolean | undefined
+    await act(async () => {
+      outcome = await session.api().save()
+    })
+
+    expect(outcome).toBe(false)
+    expect(session.onSaveFailed).toHaveBeenCalledWith(failure)
+    expect(session.onSaved).not.toHaveBeenCalled()
+    expect(aids.reset).not.toHaveBeenCalled()
+    expect(memory.reset).not.toHaveBeenCalled()
+  })
+
+  it('leaves the session clean again after a successful save', async () => {
+    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
+    const session = mountSession({ children: sectionsOf(aids) })
+    expect(session.api().saving).toBe(false)
+
+    await act(async () => {
+      await session.api().save()
+    })
+
+    expect(session.api().saving).toBe(false)
+  })
+})
+
+describe('StorySettingsSaveSessionProvider — discard', () => {
+  it('resets every section without writing', () => {
+    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
+    const memory = makeSection('embedding-status', 20, ['embedder'], { embeddingBackend: 'local' })
+    const session = mountSession({ children: sectionsOf(aids, memory) })
+
+    act(() => session.api().discard())
+
+    expect(aids.reset).toHaveBeenCalledTimes(1)
+    expect(memory.reset).toHaveBeenCalledTimes(1)
+    expect(session.onCommit).not.toHaveBeenCalled()
+  })
+})
+
+describe('StorySettingsSaveSessionProvider — snapshot', () => {
+  it('is clean with no registered sections', () => {
+    const session = mountSession()
+    expect(session.api().snapshot).toEqual({ isDirty: false, dirtyFields: [], dirtyCount: 0 })
+  })
+
+  it('is clean while every registered section is clean', () => {
+    const aids = makeSection('authoring-aids', 10, [])
+    const memory = makeSection('embedding-status', 20, [])
+    const session = mountSession({ children: sectionsOf(aids, memory) })
+
+    expect(session.api().snapshot).toEqual({ isDirty: false, dirtyFields: [], dirtyCount: 0 })
+  })
+
+  it('aggregates dirty fields across sections in rail order, not mount order', () => {
+    const memory = makeSection('embedding-status', 20, ['embedder'])
+    const aids = makeSection('authoring-aids', 10, ['suggestions', 'suggestion count'])
+    const session = mountSession({ children: sectionsOf(memory, aids) })
+
+    expect(session.api().snapshot).toEqual({
+      isDirty: true,
+      dirtyFields: ['suggestions', 'suggestion count', 'embedder'],
+      dirtyCount: 3,
+    })
+  })
+
+  it('tracks a section that goes dirty after mount', () => {
+    const aids = makeSection('authoring-aids', 10, [])
+    const session = mountSession({ children: sectionsOf(aids) })
+    expect(session.api().snapshot.isDirty).toBe(false)
+
+    act(() => {
+      session.rerenderWith(sectionsOf({ ...aids, dirtyFields: ['suggestions'] }))
+    })
+
+    expect(session.api().snapshot).toEqual({
+      isDirty: true,
+      dirtyFields: ['suggestions'],
+      dirtyCount: 1,
+    })
+  })
+})
+
+describe('StorySettingsSaveSessionProvider — unmount', () => {
+  it('drops an unmounted section from the snapshot and from the merged write', async () => {
+    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
+    const memory = makeSection('embedding-status', 20, ['embedder'], { embeddingBackend: 'local' })
+    const session = mountSession({ children: sectionsOf(aids, memory) })
+    expect(session.api().snapshot.dirtyCount).toBe(2)
+
+    act(() => {
+      session.rerenderWith(sectionsOf(aids))
+    })
+
+    expect(session.api().snapshot).toEqual({
+      isDirty: true,
+      dirtyFields: ['suggestions'],
+      dirtyCount: 1,
+    })
+
+    await act(async () => {
+      await session.api().save()
+    })
+
+    expect(memory.getPatch).not.toHaveBeenCalled()
+    expect(memory.reset).not.toHaveBeenCalled()
+    expect(session.onCommit).toHaveBeenCalledExactlyOnceWith({ suggestionsEnabled: true })
+  })
+})
+
+describe('StorySettingsSaveSessionProvider — leave guard', () => {
+  it('lets a clean session leave immediately', () => {
+    const aids = makeSection('authoring-aids', 10, [])
+    const session = mountSession({ children: sectionsOf(aids) })
+    const proceed = vi.fn()
+
+    act(() => session.api().requestLeave(proceed))
+
+    expect(proceed).toHaveBeenCalledTimes(1)
+    expect(session.api().pendingLeave).toBe(false)
+  })
+
+  it('holds a dirty session at the prompt', () => {
+    const aids = makeSection('authoring-aids', 10, ['suggestions'])
+    const session = mountSession({ children: sectionsOf(aids) })
+    const proceed = vi.fn()
+
+    act(() => session.api().requestLeave(proceed))
+
+    expect(proceed).not.toHaveBeenCalled()
+    expect(session.api().pendingLeave).toBe(true)
+  })
+
+  it('cancel keeps the session and stays put', () => {
+    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
+    const session = mountSession({ children: sectionsOf(aids) })
+    const proceed = vi.fn()
+
+    act(() => session.api().requestLeave(proceed))
+    act(() => session.api().resolveLeave('cancel'))
+
+    expect(proceed).not.toHaveBeenCalled()
+    expect(session.api().pendingLeave).toBe(false)
+    expect(session.onCommit).not.toHaveBeenCalled()
+    expect(aids.reset).not.toHaveBeenCalled()
+  })
+
+  it('discard throws the drafts away and proceeds', () => {
+    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
+    const session = mountSession({ children: sectionsOf(aids) })
+    const proceed = vi.fn()
+
+    act(() => session.api().requestLeave(proceed))
+    act(() => session.api().resolveLeave('discard'))
+
+    expect(aids.reset).toHaveBeenCalledTimes(1)
+    expect(proceed).toHaveBeenCalledTimes(1)
+    expect(session.onCommit).not.toHaveBeenCalled()
+    expect(session.api().pendingLeave).toBe(false)
+  })
+
+  it('save commits once and then proceeds', async () => {
+    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
+    const session = mountSession({ children: sectionsOf(aids) })
+    const proceed = vi.fn()
+
+    act(() => session.api().requestLeave(proceed))
+    await act(async () => {
+      session.api().resolveLeave('save')
+    })
+
+    expect(session.onCommit).toHaveBeenCalledExactlyOnceWith({ suggestionsEnabled: true })
+    expect(proceed).toHaveBeenCalledTimes(1)
+    expect(session.api().pendingLeave).toBe(false)
+  })
+
+  it('does NOT proceed when the save it was asked for fails', async () => {
+    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
+    const session = mountSession({
+      children: sectionsOf(aids),
+      onCommit: vi.fn(() => Promise.reject(new Error('write failed'))),
+    })
+    const proceed = vi.fn()
+
+    act(() => session.api().requestLeave(proceed))
+    await act(async () => {
+      session.api().resolveLeave('save')
+    })
+
+    expect(session.onSaveFailed).toHaveBeenCalledTimes(1)
+    expect(proceed).not.toHaveBeenCalled()
+    expect(aids.reset).not.toHaveBeenCalled()
+  })
+})
+
+describe('useStorySettingsSection', () => {
+  it('throws outside a provider', () => {
+    const aids = makeSection('authoring-aids', 10, [])
+    expect(() => render(<Section fixture={aids} />)).toThrow(
+      /must be used inside StorySettingsSaveSessionProvider/,
+    )
+  })
+
+  it('settles instead of looping when a section republishes a fresh array', async () => {
+    const renders = { count: 0 }
+    const ChurningSection = churningSection(renders)
+
+    const session = mountSession({ children: <ChurningSection /> })
+
+    const settled = renders.count
+    expect(settled).toBeLessThanOrEqual(3)
+    expect(session.api().snapshot.dirtyCount).toBe(2)
+
+    await act(async () => {})
+    expect(renders.count).toBe(settled)
+
+    act(() => {
+      session.rerenderWith(<ChurningSection />)
+    })
+    expect(renders.count).toBe(settled + 1)
+  })
+
+  it('settles on the dirty key alone when array identity no longer guards', () => {
+    guard.breakArrayIdentity = true
+    const renders = { count: 0 }
+    const ChurningSection = churningSection(renders)
+
+    const session = mountSession({ children: <ChurningSection /> })
+
+    expect(renders.count).toBeLessThanOrEqual(3)
+    expect(session.api().snapshot.dirtyCount).toBe(2)
+  })
+})

--- a/components/story-settings/save-session.test.tsx
+++ b/components/story-settings/save-session.test.tsx
@@ -514,6 +514,86 @@ describe('StorySettingsSaveSessionProvider — leave guard', () => {
     expect(session.api().saving).toBe(false)
     expect(proceed).toHaveBeenCalledTimes(1)
   })
+
+  // The in-flight refusal below reads the same ref that gates save() re-entry,
+  // so a flag left raised would silently make every later leave inert.
+  it('accepts a save-and-leave after an earlier commit has settled', async () => {
+    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
+    const session = mountSession({ children: sectionsOf(aids) })
+
+    await act(async () => {
+      await session.api().save()
+    })
+
+    const proceed = vi.fn()
+    act(() => session.api().requestLeave(proceed))
+    await act(async () => {
+      session.api().resolveLeave('save')
+    })
+
+    expect(session.onCommit).toHaveBeenCalledTimes(2)
+    expect(proceed).toHaveBeenCalledTimes(1)
+    expect(session.api().pendingLeave).toBe(false)
+  })
+
+  // The dialog disables itself mid-commit, but window-close and other non-modal
+  // intercepts reach resolveLeave directly, so the refusal lives here too.
+  it('refuses a cancel that arrives while its own save is in flight', async () => {
+    const releases: (() => void)[] = []
+    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
+    const session = mountSession({
+      children: sectionsOf(aids),
+      onCommit: vi.fn(() => new Promise<void>((resolve) => releases.push(resolve))),
+    })
+    const proceed = vi.fn()
+
+    act(() => session.api().requestLeave(proceed))
+    await act(async () => {
+      session.api().resolveLeave('save')
+    })
+    await act(async () => {
+      session.api().resolveLeave('cancel')
+    })
+
+    expect(session.api().pendingLeave).toBe(true)
+
+    await act(async () => {
+      for (const release of releases) release()
+    })
+
+    // Refused, not queued: the save the user asked for still lands and leaves.
+    expect(proceed).toHaveBeenCalledTimes(1)
+    expect(session.api().pendingLeave).toBe(false)
+  })
+
+  it('refuses a discard that arrives while its own save is in flight', async () => {
+    const releases: (() => void)[] = []
+    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
+    const session = mountSession({
+      children: sectionsOf(aids),
+      onCommit: vi.fn(() => new Promise<void>((resolve) => releases.push(resolve))),
+    })
+    const proceed = vi.fn()
+
+    act(() => session.api().requestLeave(proceed))
+    await act(async () => {
+      session.api().resolveLeave('save')
+    })
+    await act(async () => {
+      session.api().resolveLeave('discard')
+    })
+
+    expect(aids.reset).not.toHaveBeenCalled()
+    expect(proceed).not.toHaveBeenCalled()
+    expect(session.api().pendingLeave).toBe(true)
+
+    await act(async () => {
+      for (const release of releases) release()
+    })
+
+    expect(aids.reset).toHaveBeenCalledTimes(1)
+    expect(proceed).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('useStorySettingsSection', () => {

--- a/components/story-settings/save-session.test.tsx
+++ b/components/story-settings/save-session.test.tsx
@@ -12,6 +12,7 @@ import {
   type SaveSessionApi,
 } from './save-session'
 import { type SectionDirtyState } from './save-session-state'
+import { type StorySettingsTabId } from './tabs'
 
 // The publish loop has two independent guards: the effect's serialized dirty
 // key, and upsertSection returning the same array reference for an unchanged
@@ -45,7 +46,7 @@ const COLLISION = 'both patch the top-level key'
 
 type SectionFixture = {
   id: string
-  order: number
+  tab: StorySettingsTabId
   dirtyFields: readonly string[]
   getPatch: Mock<() => Partial<StorySettings>>
   reset: Mock<() => void>
@@ -53,17 +54,17 @@ type SectionFixture = {
 
 function makeSection(
   id: string,
-  order: number,
+  tab: StorySettingsTabId,
   dirtyFields: readonly string[],
   patch: Partial<StorySettings> = {},
 ): SectionFixture {
-  return { id, order, dirtyFields, getPatch: vi.fn(() => patch), reset: vi.fn() }
+  return { id, tab, dirtyFields, getPatch: vi.fn(() => patch), reset: vi.fn() }
 }
 
 function Section({ fixture }: { fixture: SectionFixture }) {
   useStorySettingsSection({
     id: fixture.id,
-    order: fixture.order,
+    tab: fixture.tab,
     dirtyFields: fixture.dirtyFields,
     getPatch: fixture.getPatch,
     reset: fixture.reset,
@@ -126,7 +127,7 @@ function churningSection(renders: { count: number }) {
     renders.count += 1
     useStorySettingsSection({
       id: 'authoring-aids',
-      order: 10,
+      tab: 'generation',
       dirtyFields: ['suggestions', 'suggestion count'].slice(),
       getPatch: () => ({ suggestionsEnabled: true }),
       reset: () => {},
@@ -138,11 +139,13 @@ function churningSection(renders: { count: number }) {
 
 describe('StorySettingsSaveSessionProvider — save', () => {
   it('commits every registered section as ONE merged write', async () => {
-    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
-    const memory = makeSection('embedding-status', 20, ['embedder'], {
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
+      suggestionsEnabled: true,
+    })
+    const memory = makeSection('embedding-status', 'memory', ['embedder'], {
       embedding_model_id: 'Xenova/all-MiniLM-L6-v2',
     })
-    const chapters = makeSection('chapters', 30, ['chapter threshold'], {
+    const chapters = makeSection('chapters', 'advanced', ['chapter threshold'], {
       chapterTokenThreshold: 9000,
     })
     const session = mountSession({ children: sectionsOf(aids, memory, chapters) })
@@ -160,8 +163,12 @@ describe('StorySettingsSaveSessionProvider — save', () => {
   })
 
   it('resolves true and resets every section after a successful save', async () => {
-    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
-    const memory = makeSection('embedding-status', 20, ['embedder'], { embeddingBackend: 'local' })
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
+      suggestionsEnabled: true,
+    })
+    const memory = makeSection('embedding-status', 'memory', ['embedder'], {
+      embeddingBackend: 'local',
+    })
     const session = mountSession({ children: sectionsOf(aids, memory) })
 
     let outcome: boolean | undefined
@@ -178,8 +185,12 @@ describe('StorySettingsSaveSessionProvider — save', () => {
 
   it('keeps every draft intact when the commit rejects', async () => {
     const failure = new Error('write failed')
-    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
-    const memory = makeSection('embedding-status', 20, ['embedder'], { embeddingBackend: 'local' })
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
+      suggestionsEnabled: true,
+    })
+    const memory = makeSection('embedding-status', 'memory', ['embedder'], {
+      embeddingBackend: 'local',
+    })
     const session = mountSession({
       children: sectionsOf(aids, memory),
       onCommit: vi.fn(() => Promise.reject(failure)),
@@ -198,8 +209,10 @@ describe('StorySettingsSaveSessionProvider — save', () => {
   })
 
   it('skips a clean section rather than trusting it to return an empty patch', async () => {
-    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
-    const memory = makeSection('embedding-status', 20, [], {
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
+      suggestionsEnabled: true,
+    })
+    const memory = makeSection('embedding-status', 'memory', [], {
       embedding_model_id: 'Xenova/all-MiniLM-L6-v2',
     })
     const session = mountSession({ children: sectionsOf(aids, memory) })
@@ -217,7 +230,7 @@ describe('StorySettingsSaveSessionProvider — save', () => {
     function CountSection({ count }: { count: number }) {
       useStorySettingsSection({
         id: 'authoring-aids',
-        order: 10,
+        tab: 'generation',
         dirtyFields: ['suggestion count'],
         getPatch: () => ({ suggestionCount: count }),
         reset: () => resets.push(count),
@@ -242,7 +255,9 @@ describe('StorySettingsSaveSessionProvider — save', () => {
     // Every commit gets released, not just the last: a regression must fail on
     // the call-count assertion rather than deadlocking on an orphaned promise.
     const releases: (() => void)[] = []
-    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
+      suggestionsEnabled: true,
+    })
     const session = mountSession({
       children: sectionsOf(aids),
       onCommit: vi.fn(() => new Promise<void>((resolve) => releases.push(resolve))),
@@ -271,10 +286,10 @@ describe('StorySettingsSaveSessionProvider — save', () => {
 
   it('warns when two sections patch the same top-level key', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    const composer = makeSection('composer', 10, ['translation'], {
+    const composer = makeSection('composer', 'generation', ['translation'], {
       translation: { ...STORY_SETTINGS_DEFAULTS.translation, enabled: true },
     })
-    const languages = makeSection('languages', 20, ['granular toggles'], {
+    const languages = makeSection('languages', 'translation', ['granular toggles'], {
       translation: { ...STORY_SETTINGS_DEFAULTS.translation, targetLanguage: 'cs' },
     })
     const session = mountSession({ children: sectionsOf(composer, languages) })
@@ -290,11 +305,13 @@ describe('StorySettingsSaveSessionProvider — save', () => {
 
   it('stays quiet when every section patches a distinct top-level key', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    const aids = makeSection('authoring-aids', 10, ['suggestions'], {
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
       suggestionsEnabled: true,
       suggestionCount: 5,
     })
-    const memory = makeSection('embedding-status', 20, ['embedder'], { embeddingBackend: 'local' })
+    const memory = makeSection('embedding-status', 'memory', ['embedder'], {
+      embeddingBackend: 'local',
+    })
     const session = mountSession({ children: sectionsOf(aids, memory) })
 
     await act(async () => {
@@ -305,7 +322,9 @@ describe('StorySettingsSaveSessionProvider — save', () => {
   })
 
   it('clears the saving flag after a successful save', async () => {
-    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
+      suggestionsEnabled: true,
+    })
     const session = mountSession({ children: sectionsOf(aids) })
     expect(session.api().saving).toBe(false)
 
@@ -319,8 +338,12 @@ describe('StorySettingsSaveSessionProvider — save', () => {
 
 describe('StorySettingsSaveSessionProvider — discard', () => {
   it('resets every section without writing', () => {
-    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
-    const memory = makeSection('embedding-status', 20, ['embedder'], { embeddingBackend: 'local' })
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
+      suggestionsEnabled: true,
+    })
+    const memory = makeSection('embedding-status', 'memory', ['embedder'], {
+      embeddingBackend: 'local',
+    })
     const session = mountSession({ children: sectionsOf(aids, memory) })
 
     act(() => session.api().discard())
@@ -338,16 +361,16 @@ describe('StorySettingsSaveSessionProvider — snapshot', () => {
   })
 
   it('is clean while every registered section is clean', () => {
-    const aids = makeSection('authoring-aids', 10, [])
-    const memory = makeSection('embedding-status', 20, [])
+    const aids = makeSection('authoring-aids', 'generation', [])
+    const memory = makeSection('embedding-status', 'memory', [])
     const session = mountSession({ children: sectionsOf(aids, memory) })
 
     expect(session.api().snapshot).toEqual({ isDirty: false, dirtyFields: [], dirtyCount: 0 })
   })
 
   it('aggregates dirty fields across sections in rail order, not mount order', () => {
-    const memory = makeSection('embedding-status', 20, ['embedder'])
-    const aids = makeSection('authoring-aids', 10, ['suggestions', 'suggestion count'])
+    const memory = makeSection('embedding-status', 'memory', ['embedder'])
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions', 'suggestion count'])
     const session = mountSession({ children: sectionsOf(memory, aids) })
 
     expect(session.api().snapshot).toEqual({
@@ -358,7 +381,7 @@ describe('StorySettingsSaveSessionProvider — snapshot', () => {
   })
 
   it('tracks a section that goes dirty after mount', () => {
-    const aids = makeSection('authoring-aids', 10, [])
+    const aids = makeSection('authoring-aids', 'generation', [])
     const session = mountSession({ children: sectionsOf(aids) })
     expect(session.api().snapshot.isDirty).toBe(false)
 
@@ -376,8 +399,12 @@ describe('StorySettingsSaveSessionProvider — snapshot', () => {
 
 describe('StorySettingsSaveSessionProvider — unmount', () => {
   it('drops an unmounted section from the snapshot and from the merged write', async () => {
-    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
-    const memory = makeSection('embedding-status', 20, ['embedder'], { embeddingBackend: 'local' })
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
+      suggestionsEnabled: true,
+    })
+    const memory = makeSection('embedding-status', 'memory', ['embedder'], {
+      embeddingBackend: 'local',
+    })
     const session = mountSession({ children: sectionsOf(aids, memory) })
     expect(session.api().snapshot.dirtyCount).toBe(2)
 
@@ -403,7 +430,7 @@ describe('StorySettingsSaveSessionProvider — unmount', () => {
 
 describe('StorySettingsSaveSessionProvider — leave guard', () => {
   it('lets a clean session leave immediately', () => {
-    const aids = makeSection('authoring-aids', 10, [])
+    const aids = makeSection('authoring-aids', 'generation', [])
     const session = mountSession({ children: sectionsOf(aids) })
     const proceed = vi.fn()
 
@@ -414,7 +441,7 @@ describe('StorySettingsSaveSessionProvider — leave guard', () => {
   })
 
   it('holds a dirty session at the prompt', () => {
-    const aids = makeSection('authoring-aids', 10, ['suggestions'])
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'])
     const session = mountSession({ children: sectionsOf(aids) })
     const proceed = vi.fn()
 
@@ -425,7 +452,9 @@ describe('StorySettingsSaveSessionProvider — leave guard', () => {
   })
 
   it('cancel keeps the session and stays put', () => {
-    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
+      suggestionsEnabled: true,
+    })
     const session = mountSession({ children: sectionsOf(aids) })
     const proceed = vi.fn()
 
@@ -439,7 +468,9 @@ describe('StorySettingsSaveSessionProvider — leave guard', () => {
   })
 
   it('discard throws the drafts away and proceeds', () => {
-    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
+      suggestionsEnabled: true,
+    })
     const session = mountSession({ children: sectionsOf(aids) })
     const proceed = vi.fn()
 
@@ -453,7 +484,9 @@ describe('StorySettingsSaveSessionProvider — leave guard', () => {
   })
 
   it('save commits once and then proceeds', async () => {
-    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
+      suggestionsEnabled: true,
+    })
     const session = mountSession({ children: sectionsOf(aids) })
     const proceed = vi.fn()
 
@@ -468,7 +501,9 @@ describe('StorySettingsSaveSessionProvider — leave guard', () => {
   })
 
   it('does NOT proceed when the save it was asked for fails', async () => {
-    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
+      suggestionsEnabled: true,
+    })
     const session = mountSession({
       children: sectionsOf(aids),
       onCommit: vi.fn(() => Promise.reject(new Error('write failed'))),
@@ -490,7 +525,9 @@ describe('StorySettingsSaveSessionProvider — leave guard', () => {
 
   it('holds the guard open and saving while its own save is in flight', async () => {
     const releases: (() => void)[] = []
-    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
+      suggestionsEnabled: true,
+    })
     const session = mountSession({
       children: sectionsOf(aids),
       onCommit: vi.fn(() => new Promise<void>((resolve) => releases.push(resolve))),
@@ -518,7 +555,9 @@ describe('StorySettingsSaveSessionProvider — leave guard', () => {
   // The in-flight refusal below reads the same ref that gates save() re-entry,
   // so a flag left raised would silently make every later leave inert.
   it('accepts a save-and-leave after an earlier commit has settled', async () => {
-    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
+      suggestionsEnabled: true,
+    })
     const session = mountSession({ children: sectionsOf(aids) })
 
     await act(async () => {
@@ -540,7 +579,9 @@ describe('StorySettingsSaveSessionProvider — leave guard', () => {
   // intercepts reach resolveLeave directly, so the refusal lives here too.
   it('refuses a cancel that arrives while its own save is in flight', async () => {
     const releases: (() => void)[] = []
-    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
+      suggestionsEnabled: true,
+    })
     const session = mountSession({
       children: sectionsOf(aids),
       onCommit: vi.fn(() => new Promise<void>((resolve) => releases.push(resolve))),
@@ -568,7 +609,9 @@ describe('StorySettingsSaveSessionProvider — leave guard', () => {
 
   it('refuses a discard that arrives while its own save is in flight', async () => {
     const releases: (() => void)[] = []
-    const aids = makeSection('authoring-aids', 10, ['suggestions'], { suggestionsEnabled: true })
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
+      suggestionsEnabled: true,
+    })
     const session = mountSession({
       children: sectionsOf(aids),
       onCommit: vi.fn(() => new Promise<void>((resolve) => releases.push(resolve))),
@@ -598,7 +641,7 @@ describe('StorySettingsSaveSessionProvider — leave guard', () => {
 
 describe('useStorySettingsSection', () => {
   it('throws outside a provider', () => {
-    const aids = makeSection('authoring-aids', 10, [])
+    const aids = makeSection('authoring-aids', 'generation', [])
     expect(() => render(<Section fixture={aids} />)).toThrow(
       /must be used inside StorySettingsSaveSessionProvider/,
     )

--- a/components/story-settings/save-session.test.tsx
+++ b/components/story-settings/save-session.test.tsx
@@ -3,6 +3,7 @@ import { act, cleanup, render } from '@testing-library/react'
 import { type ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi, type Mock } from 'vitest'
 
+import { StorySettingsStaleStoreError } from '@/lib/actions'
 import { STORY_SETTINGS_DEFAULTS, type StorySettings } from '@/lib/db'
 
 import {
@@ -208,6 +209,33 @@ describe('StorySettingsSaveSessionProvider — save', () => {
     expect(memory.reset).not.toHaveBeenCalled()
   })
 
+  // The write is on disk; only the store re-read failed. Reporting `false`
+  // would break save()'s own contract and, worse, strand a leave waiting on it
+  // — the user would be told to Save/Discard changes already persisted.
+  it('treats a stale store as a landed write and settles a waiting leave', async () => {
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
+      suggestionsEnabled: true,
+    })
+    const stale = new StorySettingsStaleStoreError()
+    const session = mountSession({
+      children: sectionsOf(aids),
+      onCommit: vi.fn(() => Promise.reject(stale)),
+    })
+    const proceed = vi.fn()
+
+    act(() => session.api().requestLeave(proceed))
+    await act(async () => {
+      await expect(session.api().save()).resolves.toBe(true)
+    })
+
+    expect(session.onSaveFailed).toHaveBeenCalledWith(stale)
+    expect(proceed).toHaveBeenCalledTimes(1)
+    expect(session.api().pendingLeave).toBe(false)
+    // Re-deriving would read the store's pre-save values, so the draft stands.
+    expect(aids.reset).not.toHaveBeenCalled()
+    expect(session.onSaved).not.toHaveBeenCalled()
+  })
+
   it('skips a clean section rather than trusting it to return an empty patch', async () => {
     const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
       suggestionsEnabled: true,
@@ -284,8 +312,9 @@ describe('StorySettingsSaveSessionProvider — save', () => {
     expect(session.onSaved).toHaveBeenCalledTimes(1)
   })
 
-  it('warns when two sections patch the same top-level key', async () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  // The merge is shallow, so the loser's slice is gone and `stories` has no
+  // delta to recover it. Refusing the save is the only outcome that keeps both.
+  it('refuses the save when two sections patch the same top-level key', async () => {
     const composer = makeSection('composer', 'generation', ['translation'], {
       translation: { ...STORY_SETTINGS_DEFAULTS.translation, enabled: true },
     })
@@ -295,12 +324,16 @@ describe('StorySettingsSaveSessionProvider — save', () => {
     const session = mountSession({ children: sectionsOf(composer, languages) })
 
     await act(async () => {
-      await session.api().save()
+      await expect(session.api().save()).resolves.toBe(false)
     })
 
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining(COLLISION))
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('"composer" and "languages"'))
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('"translation"'))
+    expect(session.onCommit).not.toHaveBeenCalled()
+    expect(composer.reset).not.toHaveBeenCalled()
+    expect(languages.reset).not.toHaveBeenCalled()
+    const [error] = session.onSaveFailed.mock.calls[0] as [Error]
+    expect(error.message).toContain(COLLISION)
+    expect(error.message).toContain('"composer" and "languages"')
+    expect(error.message).toContain('"translation"')
   })
 
   it('stays quiet when every section patches a distinct top-level key', async () => {
@@ -586,30 +619,38 @@ describe('StorySettingsSaveSessionProvider — unmount', () => {
     expect(session.onCommit).toHaveBeenCalledExactlyOnceWith({ suggestionsEnabled: true })
   })
 
-  it('keeps the survivor wired when a section sharing its id unmounts', async () => {
+  it('refuses two live sections registering the same id', () => {
     // Two slices can independently pick the same free-form id on a seam built
-    // for independent extension; the first to unmount must not evict the other.
-    const first = makeSection('authoring-aids', 'generation', ['suggestions'], {
+    // for independent extension. Every registry is id-keyed, so the loser is
+    // unreconstructable — the surface has to fail loudly instead of dropping it.
+    const first = makeSection('authoring-aids', 'generation', ['suggestions'])
+    const second = makeSection('authoring-aids', 'generation', ['suggestions'])
+
+    expect(() =>
+      mountSession({
+        children: [
+          <Section key="first" fixture={first} />,
+          <Section key="second" fixture={second} />,
+        ],
+      }),
+    ).toThrow(/registered the id "authoring-aids"/)
+  })
+
+  it('lets a remount reuse the id of the section it replaces', () => {
+    // The duplicate check must not fire on a tab panel remounting, which is a
+    // detach followed by an attach on the same id rather than two live claims.
+    const first = makeSection('authoring-aids', 'generation', ['suggestions'])
+    const replacement = makeSection('authoring-aids', 'generation', ['suggestions'], {
       suggestionsEnabled: true,
     })
-    const second = makeSection('authoring-aids', 'generation', ['suggestions'])
-    const session = mountSession({
-      children: [
-        <Section key="first" fixture={first} />,
-        <Section key="second" fixture={second} />,
-      ],
-    })
+    const session = mountSession({ children: sectionsOf(first) })
 
-    act(() => {
-      session.rerenderWith(<Section key="first" fixture={first} />)
-    })
+    expect(() => {
+      act(() => session.rerenderWith(null))
+      act(() => session.rerenderWith(sectionsOf(replacement)))
+    }).not.toThrow()
 
-    await act(async () => {
-      await session.api().save()
-    })
-
-    expect(session.onCommit).toHaveBeenCalledExactlyOnceWith({ suggestionsEnabled: true })
-    expect(first.reset).toHaveBeenCalledTimes(1)
+    expect(session.api().snapshot.dirtyFields).toEqual(['suggestions'])
   })
 })
 
@@ -885,6 +926,34 @@ describe('StorySettingsSaveSessionProvider — leave guard', () => {
 
     expect(aids.reset).toHaveBeenCalledTimes(1)
     expect(proceed).toHaveBeenCalledTimes(1)
+  })
+
+  // The SaveBar's Discard button is `disabled={saving}`, but that is
+  // presentation: the write lands regardless, so a discard let through here
+  // would revert the drafts and leave the session clean showing the values the
+  // user asked to throw away, under a "Saved." toast.
+  it('refuses a bare discard that arrives while a save is in flight', async () => {
+    const releases: (() => void)[] = []
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
+      suggestionsEnabled: true,
+    })
+    const session = mountSession({
+      children: sectionsOf(aids),
+      onCommit: vi.fn(() => new Promise<void>((resolve) => releases.push(resolve))),
+    })
+
+    await act(async () => {
+      void session.api().save()
+    })
+    act(() => session.api().discard())
+
+    expect(aids.reset).not.toHaveBeenCalled()
+
+    await act(async () => {
+      for (const release of releases) release()
+    })
+
+    expect(session.onCommit).toHaveBeenCalledExactlyOnceWith({ suggestionsEnabled: true })
   })
 })
 

--- a/components/story-settings/save-session.test.tsx
+++ b/components/story-settings/save-session.test.tsx
@@ -10,6 +10,7 @@ import {
   StorySettingsSaveSessionProvider,
   useStorySettingsSaveSession,
   useStorySettingsSection,
+  type SaveOutcome,
   type SaveSessionApi,
 } from './save-session'
 import { type SectionDirtyState } from './save-session-state'
@@ -172,12 +173,12 @@ describe('StorySettingsSaveSessionProvider — save', () => {
     })
     const session = mountSession({ children: sectionsOf(aids, memory) })
 
-    let outcome: boolean | undefined
+    let outcome: SaveOutcome | undefined
     await act(async () => {
       outcome = await session.api().save()
     })
 
-    expect(outcome).toBe(true)
+    expect(outcome?.status).toBe('committed')
     expect(aids.reset).toHaveBeenCalledTimes(1)
     expect(memory.reset).toHaveBeenCalledTimes(1)
     expect(session.onSaved).toHaveBeenCalledTimes(1)
@@ -197,12 +198,12 @@ describe('StorySettingsSaveSessionProvider — save', () => {
       onCommit: vi.fn(() => Promise.reject(failure)),
     })
 
-    let outcome: boolean | undefined
+    let outcome: SaveOutcome | undefined
     await act(async () => {
       outcome = await session.api().save()
     })
 
-    expect(outcome).toBe(false)
+    expect(outcome?.status).toBe('rejected')
     expect(session.onSaveFailed).toHaveBeenCalledWith(failure)
     expect(session.onSaved).not.toHaveBeenCalled()
     expect(aids.reset).not.toHaveBeenCalled()
@@ -225,7 +226,10 @@ describe('StorySettingsSaveSessionProvider — save', () => {
 
     act(() => session.api().requestLeave(proceed))
     await act(async () => {
-      await expect(session.api().save()).resolves.toBe(true)
+      await expect(session.api().save()).resolves.toMatchObject({
+        status: 'committed',
+        storeStale: true,
+      })
     })
 
     expect(session.onSaveFailed).toHaveBeenCalledWith(stale)
@@ -291,8 +295,8 @@ describe('StorySettingsSaveSessionProvider — save', () => {
       onCommit: vi.fn(() => new Promise<void>((resolve) => releases.push(resolve))),
     })
 
-    let inFlight: Promise<boolean> | undefined
-    let second: Promise<boolean> | undefined
+    let inFlight: Promise<SaveOutcome> | undefined
+    let second: Promise<SaveOutcome> | undefined
     await act(async () => {
       inFlight = session.api().save()
       second = session.api().save()
@@ -300,14 +304,14 @@ describe('StorySettingsSaveSessionProvider — save', () => {
 
     expect(session.api().saving).toBe(true)
 
-    let outcomes: boolean[] = []
+    let outcomes: SaveOutcome[] = []
     await act(async () => {
       for (const release of releases) release()
       outcomes = await Promise.all([inFlight!, second!])
     })
 
     expect(session.onCommit).toHaveBeenCalledTimes(1)
-    expect(outcomes).toEqual([true, false])
+    expect(outcomes.map((o) => o.status)).toEqual(['committed', 'busy'])
     expect(aids.reset).toHaveBeenCalledTimes(1)
     expect(session.onSaved).toHaveBeenCalledTimes(1)
   })
@@ -324,7 +328,7 @@ describe('StorySettingsSaveSessionProvider — save', () => {
     const session = mountSession({ children: sectionsOf(composer, languages) })
 
     await act(async () => {
-      await expect(session.api().save()).resolves.toBe(false)
+      await expect(session.api().save()).resolves.toMatchObject({ status: 'rejected' })
     })
 
     expect(session.onCommit).not.toHaveBeenCalled()
@@ -372,12 +376,12 @@ describe('StorySettingsSaveSessionProvider — save', () => {
     const aids = makeSection('authoring-aids', 'generation', [])
     const session = mountSession({ children: sectionsOf(aids) })
 
-    let outcome: boolean | undefined
+    let outcome: SaveOutcome | undefined
     await act(async () => {
       outcome = await session.api().save()
     })
 
-    expect(outcome).toBe(true)
+    expect(outcome?.status).toBe('noop')
     expect(session.onCommit).not.toHaveBeenCalled()
     expect(session.onSaved).not.toHaveBeenCalled()
     expect(aids.reset).not.toHaveBeenCalled()
@@ -394,7 +398,7 @@ describe('StorySettingsSaveSessionProvider — save', () => {
       onCommit: vi.fn(() => new Promise<void>((resolve) => releases.push(resolve))),
     })
 
-    let inFlight: Promise<boolean> | undefined
+    let inFlight: Promise<SaveOutcome> | undefined
     await act(async () => {
       inFlight = session.api().save()
     })
@@ -442,7 +446,7 @@ describe('StorySettingsSaveSessionProvider — save', () => {
       onCommit: vi.fn(() => new Promise<void>((resolve) => releases.push(resolve))),
     })
 
-    let inFlight: Promise<boolean> | undefined
+    let inFlight: Promise<SaveOutcome> | undefined
     await act(async () => {
       inFlight = session.api().save()
     })
@@ -472,13 +476,13 @@ describe('StorySettingsSaveSessionProvider — save', () => {
     })
     const session = mountSession({ children: sectionsOf(aids), onSaved })
 
-    let outcome: boolean | undefined
+    let outcome: SaveOutcome | undefined
     await act(async () => {
       outcome = await session.api().save()
     })
 
     expect(session.onCommit).toHaveBeenCalledTimes(1)
-    expect(outcome).toBe(true)
+    expect(outcome?.status).toBe('committed')
     expect(session.onSaveFailed).not.toHaveBeenCalled()
   })
 
@@ -494,13 +498,13 @@ describe('StorySettingsSaveSessionProvider — save', () => {
     })
     const session = mountSession({ children: sectionsOf(aids, memory) })
 
-    let outcome: boolean | undefined
+    let outcome: SaveOutcome | undefined
     await act(async () => {
       outcome = await session.api().save()
     })
 
     expect(memory.reset).toHaveBeenCalledTimes(1)
-    expect(outcome).toBe(true)
+    expect(outcome?.status).toBe('committed')
     expect(session.onSaveFailed).not.toHaveBeenCalled()
   })
 
@@ -511,12 +515,12 @@ describe('StorySettingsSaveSessionProvider — save', () => {
     })
     const session = mountSession({ children: sectionsOf(aids) })
 
-    let outcome: boolean | undefined
+    let outcome: SaveOutcome | undefined
     await act(async () => {
       outcome = await session.api().save()
     })
 
-    expect(outcome).toBe(false)
+    expect(outcome?.status).toBe('rejected')
     expect(session.onCommit).not.toHaveBeenCalled()
     expect(session.onSaveFailed).toHaveBeenCalledOnce()
     expect(String(session.onSaveFailed.mock.calls[0]?.[0])).toContain('authoring-aids')
@@ -655,6 +659,54 @@ describe('StorySettingsSaveSessionProvider — unmount', () => {
 })
 
 describe('StorySettingsSaveSessionProvider — leave guard', () => {
+  // Electron queues a window close, then the user hits the back arrow before
+  // answering. Holding one slot dropped the close, so the main process kept
+  // holding a prevented close nobody could ever confirm.
+  it('runs every queued leave intent, not just the newest', async () => {
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
+      suggestionsEnabled: true,
+    })
+    const session = mountSession({ children: sectionsOf(aids) })
+    const closeWindow = vi.fn()
+    const goBack = vi.fn()
+
+    act(() => session.api().requestLeave(closeWindow))
+    act(() => session.api().requestLeave(goBack))
+    expect(session.api().pendingLeave).toBe(true)
+
+    await act(async () => {
+      session.api().resolveLeave('save')
+    })
+
+    expect(closeWindow).toHaveBeenCalledTimes(1)
+    expect(goBack).toHaveBeenCalledTimes(1)
+    expect(session.api().pendingLeave).toBe(false)
+  })
+
+  it('drops every queued intent on cancel, not just the newest', async () => {
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
+      suggestionsEnabled: true,
+    })
+    const session = mountSession({ children: sectionsOf(aids) })
+    const closeWindow = vi.fn()
+    const goBack = vi.fn()
+
+    act(() => session.api().requestLeave(closeWindow))
+    act(() => session.api().requestLeave(goBack))
+    act(() => session.api().resolveLeave('cancel'))
+
+    expect(session.api().pendingLeave).toBe(false)
+    expect(closeWindow).not.toHaveBeenCalled()
+    expect(goBack).not.toHaveBeenCalled()
+
+    // A later save must not resurrect them.
+    await act(async () => {
+      await session.api().save()
+    })
+    expect(closeWindow).not.toHaveBeenCalled()
+    expect(goBack).not.toHaveBeenCalled()
+  })
+
   // A window-close intercept can reach resolveLeave without going through the
   // dialog; requestLeave first is the precondition, not an optimization.
   it('does nothing when resolved without a pending leave', async () => {

--- a/components/story-settings/save-session.test.tsx
+++ b/components/story-settings/save-session.test.tsx
@@ -380,6 +380,17 @@ describe('StorySettingsSaveSessionProvider — snapshot', () => {
     })
   })
 
+  // Ids run reverse-alphabetical to rail order on purpose: with equal ranks the
+  // id tie-break would order these the other way, so a tab that stopped driving
+  // the rank can't hide behind the test above.
+  it('ranks a section by its tab, not by its id', () => {
+    const later = makeSection('aaa-embedder', 'memory', ['embedder'])
+    const earlier = makeSection('zzz-suggestions', 'generation', ['suggestions'])
+    const session = mountSession({ children: sectionsOf(later, earlier) })
+
+    expect(session.api().snapshot.dirtyFields).toEqual(['suggestions', 'embedder'])
+  })
+
   it('tracks a section that goes dirty after mount', () => {
     const aids = makeSection('authoring-aids', 'generation', [])
     const session = mountSession({ children: sectionsOf(aids) })

--- a/components/story-settings/save-session.test.tsx
+++ b/components/story-settings/save-session.test.tsx
@@ -386,6 +386,50 @@ describe('StorySettingsSaveSessionProvider — save', () => {
     expect(session.api().snapshot.dirtyFields).toContain('embedder')
   })
 
+  it('leaves a section the user kept editing during its own commit dirty', async () => {
+    // The section is dirty at save time, so it IS committed — and then edited
+    // again before the write lands. Resetting it would re-derive the draft back
+    // to the values just written and drop the newer edit.
+    const releases: (() => void)[] = []
+    const draft = { current: 3 }
+    const reset = vi.fn()
+    function CountSection() {
+      useStorySettingsSection({
+        id: 'authoring-aids',
+        tab: 'generation',
+        dirtyFields: ['suggestion count'],
+        getPatch: () => ({ suggestionCount: draft.current }),
+        reset,
+      })
+      return null
+    }
+
+    const session = mountSession({
+      children: <CountSection />,
+      onCommit: vi.fn(() => new Promise<void>((resolve) => releases.push(resolve))),
+    })
+
+    let inFlight: Promise<boolean> | undefined
+    await act(async () => {
+      inFlight = session.api().save()
+    })
+
+    draft.current = 5
+    const proceed = vi.fn()
+    act(() => session.api().requestLeave(proceed))
+
+    await act(async () => {
+      releases.forEach((release) => release())
+      await inFlight
+    })
+
+    expect(session.onCommit).toHaveBeenCalledExactlyOnceWith({ suggestionCount: 3 })
+    expect(reset).not.toHaveBeenCalled()
+    // The session is not clean, so a leave waiting on this save must not run.
+    expect(proceed).not.toHaveBeenCalled()
+    expect(session.api().pendingLeave).toBe(true)
+  })
+
   it('reports a committed write as saved even when a post-commit step throws', async () => {
     const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
       suggestionsEnabled: true,

--- a/components/story-settings/save-session.test.tsx
+++ b/components/story-settings/save-session.test.tsx
@@ -552,6 +552,53 @@ describe('StorySettingsSaveSessionProvider — leave guard', () => {
     expect(proceed).toHaveBeenCalledTimes(1)
   })
 
+  // The SaveBar and the header back arrow both stay live during a commit, so a
+  // leave can be requested after the save that will satisfy it already started.
+  it('honours a leave requested while an earlier save was already running', async () => {
+    const releases: (() => void)[] = []
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
+      suggestionsEnabled: true,
+    })
+    const session = mountSession({
+      children: sectionsOf(aids),
+      onCommit: vi.fn(() => new Promise<void>((resolve) => releases.push(resolve))),
+    })
+    const proceed = vi.fn()
+
+    await act(async () => {
+      void session.api().save()
+    })
+    expect(session.api().saving).toBe(true)
+
+    act(() => session.api().requestLeave(proceed))
+    expect(session.api().pendingLeave).toBe(true)
+
+    await act(async () => {
+      for (const release of releases) release()
+    })
+
+    expect(proceed).toHaveBeenCalledTimes(1)
+    expect(session.api().pendingLeave).toBe(false)
+  })
+
+  it('does not navigate on a save once the pending leave was cancelled', async () => {
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
+      suggestionsEnabled: true,
+    })
+    const session = mountSession({ children: sectionsOf(aids) })
+    const proceed = vi.fn()
+
+    act(() => session.api().requestLeave(proceed))
+    act(() => session.api().resolveLeave('cancel'))
+
+    await act(async () => {
+      await session.api().save()
+    })
+
+    expect(proceed).not.toHaveBeenCalled()
+    expect(session.api().pendingLeave).toBe(false)
+  })
+
   // The in-flight refusal below reads the same ref that gates save() re-entry,
   // so a flag left raised would silently make every later leave inert.
   it('accepts a save-and-leave after an earlier commit has settled', async () => {

--- a/components/story-settings/save-session.test.tsx
+++ b/components/story-settings/save-session.test.tsx
@@ -334,6 +334,116 @@ describe('StorySettingsSaveSessionProvider — save', () => {
 
     expect(session.api().saving).toBe(false)
   })
+
+  it('does not write, or claim a save, when the session is clean', async () => {
+    const aids = makeSection('authoring-aids', 'generation', [])
+    const session = mountSession({ children: sectionsOf(aids) })
+
+    let outcome: boolean | undefined
+    await act(async () => {
+      outcome = await session.api().save()
+    })
+
+    expect(outcome).toBe(true)
+    expect(session.onCommit).not.toHaveBeenCalled()
+    expect(session.onSaved).not.toHaveBeenCalled()
+    expect(aids.reset).not.toHaveBeenCalled()
+  })
+
+  it('leaves an edit made during the commit dirty instead of resetting it away', async () => {
+    const releases: (() => void)[] = []
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
+      suggestionsEnabled: true,
+    })
+    const late = makeSection('embedding-status', 'memory', [], { embeddingBackend: 'local' })
+    const session = mountSession({
+      children: sectionsOf(aids, late),
+      onCommit: vi.fn(() => new Promise<void>((resolve) => releases.push(resolve))),
+    })
+
+    let inFlight: Promise<boolean> | undefined
+    await act(async () => {
+      inFlight = session.api().save()
+    })
+
+    // The user keeps typing in a second section while the write is in flight.
+    const lateDirty = { ...late, dirtyFields: ['embedder'] }
+    act(() => {
+      session.rerenderWith(sectionsOf(aids, lateDirty))
+    })
+
+    await act(async () => {
+      releases.forEach((release) => release())
+      await inFlight
+    })
+
+    expect(session.onCommit).toHaveBeenCalledExactlyOnceWith({ suggestionsEnabled: true })
+    expect(aids.reset).toHaveBeenCalledTimes(1)
+    // Neither committed nor reset: the edit landed after getPatch ran, so it
+    // survives to the next save instead of being re-derived away.
+    expect(late.getPatch).not.toHaveBeenCalled()
+    expect(late.reset).not.toHaveBeenCalled()
+    expect(session.api().snapshot.dirtyFields).toContain('embedder')
+  })
+
+  it('reports a committed write as saved even when a post-commit step throws', async () => {
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
+      suggestionsEnabled: true,
+    })
+    const onSaved = vi.fn(() => {
+      throw new Error('toast blew up')
+    })
+    const session = mountSession({ children: sectionsOf(aids), onSaved })
+
+    let outcome: boolean | undefined
+    await act(async () => {
+      outcome = await session.api().save()
+    })
+
+    expect(session.onCommit).toHaveBeenCalledTimes(1)
+    expect(outcome).toBe(true)
+    expect(session.onSaveFailed).not.toHaveBeenCalled()
+  })
+
+  it('resets the remaining sections when one section’s reset throws', async () => {
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
+      suggestionsEnabled: true,
+    })
+    aids.reset.mockImplementation(() => {
+      throw new Error('reset blew up')
+    })
+    const memory = makeSection('embedding-status', 'memory', ['embedder'], {
+      embeddingBackend: 'local',
+    })
+    const session = mountSession({ children: sectionsOf(aids, memory) })
+
+    let outcome: boolean | undefined
+    await act(async () => {
+      outcome = await session.api().save()
+    })
+
+    expect(memory.reset).toHaveBeenCalledTimes(1)
+    expect(outcome).toBe(true)
+    expect(session.onSaveFailed).not.toHaveBeenCalled()
+  })
+
+  it('names the section whose getPatch throws', async () => {
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'])
+    aids.getPatch.mockImplementation(() => {
+      throw new Error('draft is malformed')
+    })
+    const session = mountSession({ children: sectionsOf(aids) })
+
+    let outcome: boolean | undefined
+    await act(async () => {
+      outcome = await session.api().save()
+    })
+
+    expect(outcome).toBe(false)
+    expect(session.onCommit).not.toHaveBeenCalled()
+    expect(session.onSaveFailed).toHaveBeenCalledOnce()
+    expect(String(session.onSaveFailed.mock.calls[0]?.[0])).toContain('authoring-aids')
+  })
 })
 
 describe('StorySettingsSaveSessionProvider — discard', () => {
@@ -357,7 +467,7 @@ describe('StorySettingsSaveSessionProvider — discard', () => {
 describe('StorySettingsSaveSessionProvider — snapshot', () => {
   it('is clean with no registered sections', () => {
     const session = mountSession()
-    expect(session.api().snapshot).toEqual({ isDirty: false, dirtyFields: [], dirtyCount: 0 })
+    expect(session.api().snapshot).toEqual({ dirtyFields: [] })
   })
 
   it('is clean while every registered section is clean', () => {
@@ -365,7 +475,7 @@ describe('StorySettingsSaveSessionProvider — snapshot', () => {
     const memory = makeSection('embedding-status', 'memory', [])
     const session = mountSession({ children: sectionsOf(aids, memory) })
 
-    expect(session.api().snapshot).toEqual({ isDirty: false, dirtyFields: [], dirtyCount: 0 })
+    expect(session.api().snapshot).toEqual({ dirtyFields: [] })
   })
 
   it('aggregates dirty fields across sections in rail order, not mount order', () => {
@@ -374,9 +484,7 @@ describe('StorySettingsSaveSessionProvider — snapshot', () => {
     const session = mountSession({ children: sectionsOf(memory, aids) })
 
     expect(session.api().snapshot).toEqual({
-      isDirty: true,
       dirtyFields: ['suggestions', 'suggestion count', 'embedder'],
-      dirtyCount: 3,
     })
   })
 
@@ -394,16 +502,14 @@ describe('StorySettingsSaveSessionProvider — snapshot', () => {
   it('tracks a section that goes dirty after mount', () => {
     const aids = makeSection('authoring-aids', 'generation', [])
     const session = mountSession({ children: sectionsOf(aids) })
-    expect(session.api().snapshot.isDirty).toBe(false)
+    expect(session.api().snapshot.dirtyFields).toEqual([])
 
     act(() => {
       session.rerenderWith(sectionsOf({ ...aids, dirtyFields: ['suggestions'] }))
     })
 
     expect(session.api().snapshot).toEqual({
-      isDirty: true,
       dirtyFields: ['suggestions'],
-      dirtyCount: 1,
     })
   })
 })
@@ -417,16 +523,14 @@ describe('StorySettingsSaveSessionProvider — unmount', () => {
       embeddingBackend: 'local',
     })
     const session = mountSession({ children: sectionsOf(aids, memory) })
-    expect(session.api().snapshot.dirtyCount).toBe(2)
+    expect(session.api().snapshot.dirtyFields).toHaveLength(2)
 
     act(() => {
       session.rerenderWith(sectionsOf(aids))
     })
 
     expect(session.api().snapshot).toEqual({
-      isDirty: true,
       dirtyFields: ['suggestions'],
-      dirtyCount: 1,
     })
 
     await act(async () => {
@@ -437,9 +541,52 @@ describe('StorySettingsSaveSessionProvider — unmount', () => {
     expect(memory.reset).not.toHaveBeenCalled()
     expect(session.onCommit).toHaveBeenCalledExactlyOnceWith({ suggestionsEnabled: true })
   })
+
+  it('keeps the survivor wired when a section sharing its id unmounts', async () => {
+    // Two slices can independently pick the same free-form id on a seam built
+    // for independent extension; the first to unmount must not evict the other.
+    const first = makeSection('authoring-aids', 'generation', ['suggestions'], {
+      suggestionsEnabled: true,
+    })
+    const second = makeSection('authoring-aids', 'generation', ['suggestions'])
+    const session = mountSession({
+      children: [
+        <Section key="first" fixture={first} />,
+        <Section key="second" fixture={second} />,
+      ],
+    })
+
+    act(() => {
+      session.rerenderWith(<Section key="first" fixture={first} />)
+    })
+
+    await act(async () => {
+      await session.api().save()
+    })
+
+    expect(session.onCommit).toHaveBeenCalledExactlyOnceWith({ suggestionsEnabled: true })
+    expect(first.reset).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('StorySettingsSaveSessionProvider — leave guard', () => {
+  // A window-close intercept can reach resolveLeave without going through the
+  // dialog; requestLeave first is the precondition, not an optimization.
+  it('does nothing when resolved without a pending leave', async () => {
+    const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
+      suggestionsEnabled: true,
+    })
+    const session = mountSession({ children: sectionsOf(aids) })
+
+    await act(async () => {
+      session.api().resolveLeave('save')
+      session.api().resolveLeave('discard')
+    })
+
+    expect(session.onCommit).not.toHaveBeenCalled()
+    expect(aids.reset).not.toHaveBeenCalled()
+  })
+
   it('lets a clean session leave immediately', () => {
     const aids = makeSection('authoring-aids', 'generation', [])
     const session = mountSession({ children: sectionsOf(aids) })
@@ -713,7 +860,7 @@ describe('useStorySettingsSection', () => {
 
     const settled = renders.count
     expect(settled).toBeLessThanOrEqual(3)
-    expect(session.api().snapshot.dirtyCount).toBe(2)
+    expect(session.api().snapshot.dirtyFields).toHaveLength(2)
 
     await act(async () => {})
     expect(renders.count).toBe(settled)
@@ -732,6 +879,6 @@ describe('useStorySettingsSection', () => {
     const session = mountSession({ children: <ChurningSection /> })
 
     expect(renders.count).toBeLessThanOrEqual(3)
-    expect(session.api().snapshot.dirtyCount).toBe(2)
+    expect(session.api().snapshot.dirtyFields).toHaveLength(2)
   })
 })

--- a/components/story-settings/save-session.test.tsx
+++ b/components/story-settings/save-session.test.tsx
@@ -164,7 +164,7 @@ describe('StorySettingsSaveSessionProvider — save', () => {
     })
   })
 
-  it('resolves true and resets every section after a successful save', async () => {
+  it('reports a committed write and resets every section after a successful save', async () => {
     const aids = makeSection('authoring-aids', 'generation', ['suggestions'], {
       suggestionsEnabled: true,
     })

--- a/components/story-settings/save-session.tsx
+++ b/components/story-settings/save-session.tsx
@@ -1,0 +1,228 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
+
+import type { StorySettings } from '@/lib/db'
+
+import {
+  computeSnapshot,
+  removeSection,
+  upsertSection,
+  type SaveSessionSnapshot,
+  type SectionDirtyState,
+} from './save-session-state'
+
+type SectionCallbacks = {
+  getPatch: () => Partial<StorySettings>
+  reset: () => void
+}
+
+type SaveSessionApi = {
+  snapshot: SaveSessionSnapshot
+  saving: boolean
+  publish: (state: SectionDirtyState) => void
+  unpublish: (id: string) => void
+  attach: (id: string, callbacks: { current: SectionCallbacks }) => () => void
+  save: () => Promise<boolean>
+  discard: () => void
+  requestLeave: (proceed: () => void) => void
+  pendingLeave: boolean
+  resolveLeave: (outcome: 'save' | 'discard' | 'cancel') => void
+}
+
+const SaveSessionContext = createContext<SaveSessionApi | null>(null)
+
+type ProviderProps = {
+  /**
+   * Commits the merged patch from every section as ONE write. The provider
+   * never calls this more than once per save.
+   */
+  onCommit: (patch: Partial<StorySettings>) => Promise<unknown>
+  onSaved?: () => void
+  onSaveFailed?: (error: unknown) => void
+  children: ReactNode
+}
+
+export function StorySettingsSaveSessionProvider({
+  onCommit,
+  onSaved,
+  onSaveFailed,
+  children,
+}: ProviderProps) {
+  const [sections, setSections] = useState<readonly SectionDirtyState[]>([])
+  const [saving, setSaving] = useState(false)
+  const [pendingLeave, setPendingLeave] = useState<(() => void) | null>(null)
+
+  // Callbacks live in refs, never in state: sections hand us fresh closures on
+  // every render and storing them would re-render the whole surface each time.
+  const callbacksRef = useRef(new Map<string, { current: SectionCallbacks }>())
+
+  const publish = useCallback((state: SectionDirtyState) => {
+    setSections((prev) => upsertSection(prev, state))
+  }, [])
+
+  const unpublish = useCallback((id: string) => {
+    setSections((prev) => removeSection(prev, id))
+  }, [])
+
+  const attach = useCallback((id: string, callbacks: { current: SectionCallbacks }) => {
+    const map = callbacksRef.current
+    map.set(id, callbacks)
+    return () => {
+      map.delete(id)
+    }
+  }, [])
+
+  const snapshot = useMemo(() => computeSnapshot(sections), [sections])
+
+  const save = useCallback(async () => {
+    setSaving(true)
+    try {
+      // One merged write, not a commit per section: `stories` carries no delta,
+      // so a mid-way failure across N writes would strand earlier sections
+      // persisted with no way to undo them.
+      let merged: Partial<StorySettings> = {}
+      for (const entry of callbacksRef.current.values()) {
+        merged = { ...merged, ...entry.current.getPatch() }
+      }
+      await onCommit(merged)
+      // Sections re-derive their draft from the now-updated store, so the
+      // session lands clean without each one tracking its own save baseline.
+      for (const entry of callbacksRef.current.values()) entry.current.reset()
+      onSaved?.()
+      return true
+    } catch (error) {
+      onSaveFailed?.(error)
+      return false
+    } finally {
+      setSaving(false)
+    }
+  }, [onCommit, onSaved, onSaveFailed])
+
+  const discard = useCallback(() => {
+    for (const entry of callbacksRef.current.values()) entry.current.reset()
+  }, [])
+
+  const requestLeave = useCallback(
+    (proceed: () => void) => {
+      if (!snapshot.isDirty) {
+        proceed()
+        return
+      }
+      setPendingLeave(() => proceed)
+    },
+    [snapshot.isDirty],
+  )
+
+  const resolveLeave = useCallback(
+    (outcome: 'save' | 'discard' | 'cancel') => {
+      const proceed = pendingLeave
+      setPendingLeave(null)
+      if (proceed == null || outcome === 'cancel') return
+      if (outcome === 'discard') {
+        discard()
+        proceed()
+        return
+      }
+      void save().then((ok) => {
+        if (ok) proceed()
+      })
+    },
+    [pendingLeave, discard, save],
+  )
+
+  const api = useMemo<SaveSessionApi>(
+    () => ({
+      snapshot,
+      saving,
+      publish,
+      unpublish,
+      attach,
+      save,
+      discard,
+      requestLeave,
+      pendingLeave: pendingLeave != null,
+      resolveLeave,
+    }),
+    [
+      snapshot,
+      saving,
+      publish,
+      unpublish,
+      attach,
+      save,
+      discard,
+      requestLeave,
+      pendingLeave,
+      resolveLeave,
+    ],
+  )
+
+  return <SaveSessionContext.Provider value={api}>{children}</SaveSessionContext.Provider>
+}
+
+export function useStorySettingsSaveSession(): SaveSessionApi {
+  const api = useContext(SaveSessionContext)
+  if (api == null) {
+    throw new Error(
+      'useStorySettingsSaveSession must be used inside StorySettingsSaveSessionProvider',
+    )
+  }
+  return api
+}
+
+type SectionRegistration = {
+  id: string
+  /** Rail order of the owning tab — drives save-bar label order. */
+  order: number
+  /** User-recognizable labels, e.g. `['suggestions', 'suggestion count']`. */
+  dirtyFields: readonly string[]
+  /**
+   * This section's contribution to the surface's single save. Read only at
+   * save time, so it may close over draft state freely. Return `{}` when clean.
+   * Sections own disjoint settings keys — the merge does not resolve conflicts.
+   */
+  getPatch: () => Partial<StorySettings>
+  /** Re-derive the draft from persisted state. Fires on Discard AND after a successful save. */
+  reset: () => void
+}
+
+/**
+ * Joins a section to the surface's save session. Call from inside the section
+ * component; it may be called with fresh arrays and closures every render.
+ */
+export function useStorySettingsSection({
+  id,
+  order,
+  dirtyFields,
+  getPatch,
+  reset,
+}: SectionRegistration): void {
+  const { publish, unpublish, attach } = useStorySettingsSaveSession()
+
+  const callbacksRef = useRef<SectionCallbacks>({ getPatch, reset })
+  callbacksRef.current = { getPatch, reset }
+
+  useEffect(() => attach(id, callbacksRef), [attach, id])
+
+  // A fresh array literal every render would re-fire this effect forever, so the
+  // effect keys on a serialized form while publishing the real array. No
+  // round-trip: upsertSection already does the per-field comparison.
+  const fieldsRef = useRef(dirtyFields)
+  fieldsRef.current = dirtyFields
+  const dirtyKey = JSON.stringify(dirtyFields)
+  useEffect(() => {
+    publish({ id, order, dirtyFields: fieldsRef.current })
+  }, [publish, id, order, dirtyKey])
+
+  useEffect(() => () => unpublish(id), [unpublish, id])
+}
+
+export type { SaveSessionApi, SectionRegistration }

--- a/components/story-settings/save-session.tsx
+++ b/components/story-settings/save-session.tsx
@@ -19,6 +19,9 @@ import {
   type SectionDirtyState,
 } from './save-session-state'
 
+// Node (vitest) leaves __DEV__ undefined, so the check runs there too.
+const DEV_CHECKS = typeof __DEV__ === 'undefined' || __DEV__
+
 type SectionCallbacks = {
   getPatch: () => Partial<StorySettings>
   reset: () => void
@@ -30,6 +33,12 @@ type SaveSessionApi = {
   publish: (state: SectionDirtyState) => void
   unpublish: (id: string) => void
   attach: (id: string, callbacks: { current: SectionCallbacks }) => () => void
+  /**
+   * Resolves `true` only when this call committed. `false` covers both a
+   * rejected commit and a call turned away because one was already in flight —
+   * in either case the outcome is unknown to the caller, so treat it as "do not
+   * proceed".
+   */
   save: () => Promise<boolean>
   discard: () => void
   requestLeave: (proceed: () => void) => void
@@ -38,6 +47,24 @@ type SaveSessionApi = {
 }
 
 const SaveSessionContext = createContext<SaveSessionApi | null>(null)
+
+function warnOnKeyCollision(
+  owners: Map<string, string>,
+  id: string,
+  patch: Partial<StorySettings>,
+): void {
+  for (const key of Object.keys(patch)) {
+    const owner = owners.get(key)
+    if (owner === undefined) {
+      owners.set(key, id)
+      continue
+    }
+    // eslint-disable-next-line no-console -- __DEV__ wiring warning; must fire regardless of the diagnostics master gate, so the logger is the wrong channel.
+    console.warn(
+      `Story Settings sections "${owner}" and "${id}" both patch the top-level key "${key}". The merge is shallow, so one clobbers the other and the winner depends on mount order.`,
+    )
+  }
+}
 
 type ProviderProps = {
   /**
@@ -59,6 +86,10 @@ export function StorySettingsSaveSessionProvider({
   const [sections, setSections] = useState<readonly SectionDirtyState[]>([])
   const [saving, setSaving] = useState(false)
   const [pendingLeave, setPendingLeave] = useState<(() => void) | null>(null)
+
+  // `saving` state lands a tick late, so only a ref can turn away a second entry
+  // synchronously — Cmd-S can race the leave guard's own save.
+  const savingRef = useRef(false)
 
   // Callbacks live in refs, never in state: sections hand us fresh closures on
   // every render and storing them would re-render the whole surface each time.
@@ -83,14 +114,19 @@ export function StorySettingsSaveSessionProvider({
   const snapshot = useMemo(() => computeSnapshot(sections), [sections])
 
   const save = useCallback(async () => {
+    if (savingRef.current) return false
+    savingRef.current = true
     setSaving(true)
     try {
       // One merged write, not a commit per section: `stories` carries no delta,
       // so a mid-way failure across N writes would strand earlier sections
       // persisted with no way to undo them.
       let merged: Partial<StorySettings> = {}
-      for (const entry of callbacksRef.current.values()) {
-        merged = { ...merged, ...entry.current.getPatch() }
+      const owners = DEV_CHECKS ? new Map<string, string>() : null
+      for (const [id, entry] of callbacksRef.current.entries()) {
+        const patch = entry.current.getPatch()
+        if (owners) warnOnKeyCollision(owners, id, patch)
+        merged = { ...merged, ...patch }
       }
       await onCommit(merged)
       // Sections re-derive their draft from the now-updated store, so the
@@ -102,6 +138,7 @@ export function StorySettingsSaveSessionProvider({
       onSaveFailed?.(error)
       return false
     } finally {
+      savingRef.current = false
       setSaving(false)
     }
   }, [onCommit, onSaved, onSaveFailed])
@@ -187,7 +224,12 @@ type SectionRegistration = {
   /**
    * This section's contribution to the surface's single save. Read only at
    * save time, so it may close over draft state freely. Return `{}` when clean.
-   * Sections own disjoint settings keys — the merge does not resolve conflicts.
+   *
+   * Sections must own disjoint **top-level** `StorySettings` keys. The merge is
+   * shallow, so two sections contributing different parts of one nested object
+   * (`translation`, `models`, `retrievalBudgets`, `packVariables`) clobber each
+   * other, and the winner is decided by mount order. Dev builds warn on
+   * collision.
    */
   getPatch: () => Partial<StorySettings>
   /** Re-derive the draft from persisted state. Fires on Discard AND after a successful save. */

--- a/components/story-settings/save-session.tsx
+++ b/components/story-settings/save-session.tsx
@@ -175,6 +175,9 @@ export function StorySettingsSaveSessionProvider({
 
   const resolveLeave = useCallback(
     (outcome: 'save' | 'discard' | 'cancel') => {
+      // A commit in flight owns the outcome. The dialog disables itself, but
+      // window-close intercepts reach this directly and bypass that.
+      if (savingRef.current) return
       const proceed = pendingLeave
       if (proceed == null || outcome === 'cancel') {
         setPendingLeave(null)

--- a/components/story-settings/save-session.tsx
+++ b/components/story-settings/save-session.tsx
@@ -176,15 +176,23 @@ export function StorySettingsSaveSessionProvider({
   const resolveLeave = useCallback(
     (outcome: 'save' | 'discard' | 'cancel') => {
       const proceed = pendingLeave
-      setPendingLeave(null)
-      if (proceed == null || outcome === 'cancel') return
+      if (proceed == null || outcome === 'cancel') {
+        setPendingLeave(null)
+        return
+      }
       if (outcome === 'discard') {
+        setPendingLeave(null)
         discard()
         proceed()
         return
       }
+      // The guard outlives the commit: it can then disable itself while the
+      // write runs, and a failure leaves the user on the same three choices
+      // rather than dropping the navigation they asked for.
       void save().then((ok) => {
-        if (ok) proceed()
+        if (!ok) return
+        setPendingLeave(null)
+        proceed()
       })
     },
     [pendingLeave, discard, save],

--- a/components/story-settings/save-session.tsx
+++ b/components/story-settings/save-session.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react'
 
 import type { StorySettings } from '@/lib/db'
+import { logger } from '@/lib/diagnostics'
 
 import {
   computeSnapshot,
@@ -18,7 +19,7 @@ import {
   type SaveSessionSnapshot,
   type SectionDirtyState,
 } from './save-session-state'
-import { storySettingsTabOrder, type StorySettingsTabId } from './tabs'
+import { type StorySettingsTabId } from './tabs'
 
 // Node (vitest) leaves __DEV__ undefined, so the check runs there too.
 const DEV_CHECKS = typeof __DEV__ === 'undefined' || __DEV__
@@ -31,14 +32,12 @@ type SectionCallbacks = {
 type SaveSessionApi = {
   snapshot: SaveSessionSnapshot
   saving: boolean
-  publish: (state: SectionDirtyState) => void
-  unpublish: (id: string) => void
-  attach: (id: string, callbacks: { current: SectionCallbacks }) => () => void
   /**
-   * Resolves `true` only when this call committed. `false` covers both a
-   * rejected commit and a call turned away because one was already in flight —
-   * in either case the outcome is unknown to the caller, so treat it as "do not
-   * proceed".
+   * Resolves `true` when the session reached a clean, persisted state — the
+   * commit landed, or there was nothing to commit. `false` means the write was
+   * rejected, or a commit was already in flight and this call was turned away;
+   * either way the caller must not proceed. A failure *after* the write lands
+   * never reports `false` — it is logged, because the data is on disk.
    */
   save: () => Promise<boolean>
   discard: () => void
@@ -47,13 +46,26 @@ type SaveSessionApi = {
   resolveLeave: (outcome: 'save' | 'discard' | 'cancel') => void
 }
 
+/** Section-only wiring. Split off `SaveSessionApi` so a consumer of the
+ *  session can't publish dirty state without registering callbacks for it. */
+type SectionRegistry = {
+  publish: (state: SectionDirtyState) => void
+  unpublish: (id: string) => void
+  attach: (id: string, callbacks: { current: SectionCallbacks }) => () => void
+}
+
 const SaveSessionContext = createContext<SaveSessionApi | null>(null)
+const SectionRegistryContext = createContext<SectionRegistry | null>(null)
 
 function dirtyIds(sections: readonly SectionDirtyState[]): Set<string> {
   return new Set(sections.filter((s) => s.dirtyFields.length > 0).map((s) => s.id))
 }
 
-function warnOnKeyCollision(
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function reportKeyCollision(
   owners: Map<string, string>,
   id: string,
   patch: Partial<StorySettings>,
@@ -64,17 +76,22 @@ function warnOnKeyCollision(
       owners.set(key, id)
       continue
     }
-    // eslint-disable-next-line no-console -- __DEV__ wiring warning; must fire regardless of the diagnostics master gate, so the logger is the wrong channel.
-    console.warn(
-      `Story Settings sections "${owner}" and "${id}" both patch the top-level key "${key}". The merge is shallow, so one clobbers the other and the winner depends on mount order.`,
-    )
+    const message = `Story Settings sections "${owner}" and "${id}" both patch the top-level key "${key}". The merge is shallow, so one clobbers the other and the winner depends on mount order.`
+    // Unrecoverable data loss (`stories` carries no delta), so it is logged in
+    // every build, not just dev.
+    logger.error('action_layer.story_settings_key_collision', { owner, sectionId: id, key })
+    if (DEV_CHECKS) {
+      // eslint-disable-next-line no-console -- __DEV__ wiring warning; must fire regardless of the diagnostics master gate, so the logger alone is the wrong channel.
+      console.warn(message)
+    }
   }
 }
 
 type ProviderProps = {
   /**
-   * Commits the merged patch from every section as ONE write. The provider
-   * never calls this more than once per save.
+   * Commits the merged patch from every dirty section as ONE write. The
+   * provider never calls this more than once per save, and never with an empty
+   * patch.
    */
   onCommit: (patch: Partial<StorySettings>) => Promise<unknown>
   onSaved?: () => void
@@ -112,7 +129,9 @@ export function StorySettingsSaveSessionProvider({
     const map = callbacksRef.current
     map.set(id, callbacks)
     return () => {
-      map.delete(id)
+      // Identity-checked: two sections sharing an id would otherwise let the
+      // first to unmount evict the survivor, leaving it dirty but invisible.
+      if (map.get(id) === callbacks) map.delete(id)
     }
   }, [])
 
@@ -126,8 +145,49 @@ export function StorySettingsSaveSessionProvider({
   const pendingLeaveRef = useRef(pendingLeave)
   pendingLeaveRef.current = pendingLeave
 
+  // `ids` undefined resets every section (Discard); a set resets only what a
+  // save committed, so an edit made mid-commit isn't reverted with it.
+  const resetSections = useCallback((ids?: ReadonlySet<string>) => {
+    for (const [id, entry] of callbacksRef.current.entries()) {
+      if (ids != null && !ids.has(id)) continue
+      try {
+        entry.current.reset()
+      } catch (error) {
+        // Isolated: one section's failure must not strand the rest mid-reset.
+        logger.error('action_layer.story_settings_reset_failed', {
+          sectionId: id,
+          error: errorMessage(error),
+        })
+      }
+    }
+  }, [])
+
+  const settlePendingLeave = useCallback(() => {
+    const proceed = pendingLeaveRef.current
+    if (proceed == null) return
+    setPendingLeave(null)
+    try {
+      proceed()
+    } catch (error) {
+      logger.error('action_layer.story_settings_leave_failed', { error: errorMessage(error) })
+    }
+  }, [])
+
   const save = useCallback(async () => {
     if (savingRef.current) return false
+
+    // Clean sections are skipped rather than trusted to return `{}`: every
+    // panel stays mounted so a draft survives a tab switch, so an
+    // unconditional getPatch would write a never-visited tab's mount-time
+    // values over whatever changed them since.
+    const dirty = dirtyIds(sectionsRef.current)
+    // Nothing to write. A leave waiting on this is already satisfied — the
+    // session is clean — so proceed rather than stranding it.
+    if (dirty.size === 0) {
+      settlePendingLeave()
+      return true
+    }
+
     savingRef.current = true
     setSaving(true)
     try {
@@ -135,32 +195,23 @@ export function StorySettingsSaveSessionProvider({
       // so a mid-way failure across N writes would strand earlier sections
       // persisted with no way to undo them.
       let merged: Partial<StorySettings> = {}
-      const owners = DEV_CHECKS ? new Map<string, string>() : null
-      // Clean sections are skipped rather than trusted to return `{}`: every
-      // panel stays mounted so a draft survives a tab switch, so an
-      // unconditional getPatch would write a never-visited tab's mount-time
-      // values over whatever changed them since.
-      const dirty = dirtyIds(sectionsRef.current)
+      const owners = new Map<string, string>()
       for (const [id, entry] of callbacksRef.current.entries()) {
         if (!dirty.has(id)) continue
-        const patch = entry.current.getPatch()
-        if (owners) warnOnKeyCollision(owners, id, patch)
+        let patch: Partial<StorySettings>
+        try {
+          patch = entry.current.getPatch()
+        } catch (error) {
+          // Name the offender: otherwise a section's serialization bug is
+          // indistinguishable from a DB failure.
+          throw new Error(`Story Settings section "${id}" failed to build its patch`, {
+            cause: error,
+          })
+        }
+        reportKeyCollision(owners, id, patch)
         merged = { ...merged, ...patch }
       }
       await onCommit(merged)
-      // Sections re-derive their draft from the now-updated store, so the
-      // session lands clean without each one tracking its own save baseline.
-      for (const entry of callbacksRef.current.values()) entry.current.reset()
-      onSaved?.()
-      // Any save satisfies a waiting leave, not just the one the guard started:
-      // the back arrow stays live during a commit, so a leave can be requested
-      // after it, and the session is clean now either way.
-      const proceed = pendingLeaveRef.current
-      if (proceed != null) {
-        setPendingLeave(null)
-        proceed()
-      }
-      return true
     } catch (error) {
       onSaveFailed?.(error)
       return false
@@ -168,28 +219,49 @@ export function StorySettingsSaveSessionProvider({
       savingRef.current = false
       setSaving(false)
     }
-  }, [onCommit, onSaved, onSaveFailed])
+
+    // Past the commit — the write is on disk, so nothing below may report a
+    // save failure, and each step is isolated so one failure can't strand the
+    // rest. Sections re-derive their draft from the now-updated store, so the
+    // session lands clean without each one tracking a save baseline.
+    resetSections(dirty)
+    try {
+      onSaved?.()
+    } catch (error) {
+      logger.error('action_layer.story_settings_post_commit_failed', {
+        error: errorMessage(error),
+      })
+    }
+    // Any save satisfies a waiting leave, not just the one the guard started:
+    // the back arrow stays live during a commit, so a leave can be requested
+    // after it, and the session is clean now either way.
+    settlePendingLeave()
+    return true
+  }, [onCommit, onSaved, onSaveFailed, resetSections, settlePendingLeave])
 
   const discard = useCallback(() => {
-    for (const entry of callbacksRef.current.values()) entry.current.reset()
-  }, [])
+    resetSections()
+  }, [resetSections])
 
   const requestLeave = useCallback(
     (proceed: () => void) => {
-      if (!snapshot.isDirty) {
+      if (snapshot.dirtyFields.length === 0) {
         proceed()
         return
       }
       setPendingLeave(() => proceed)
     },
-    [snapshot.isDirty],
+    [snapshot],
   )
 
   const resolveLeave = useCallback(
     (outcome: 'save' | 'discard' | 'cancel') => {
-      // A commit in flight owns the outcome. The dialog disables itself, but
-      // window-close intercepts reach this directly and bypass that.
-      if (savingRef.current) return
+      // A commit in flight owns the outcome; the dialog's disabled buttons are
+      // presentation, not enforcement.
+      if (savingRef.current) {
+        logger.warn('action_layer.story_settings_leave_ignored', { outcome })
+        return
+      }
       const proceed = pendingLeave
       if (proceed == null || outcome === 'cancel') {
         setPendingLeave(null)
@@ -214,30 +286,25 @@ export function StorySettingsSaveSessionProvider({
     () => ({
       snapshot,
       saving,
-      publish,
-      unpublish,
-      attach,
       save,
       discard,
       requestLeave,
       pendingLeave: pendingLeave != null,
       resolveLeave,
     }),
-    [
-      snapshot,
-      saving,
-      publish,
-      unpublish,
-      attach,
-      save,
-      discard,
-      requestLeave,
-      pendingLeave,
-      resolveLeave,
-    ],
+    [snapshot, saving, save, discard, requestLeave, pendingLeave, resolveLeave],
   )
 
-  return <SaveSessionContext.Provider value={api}>{children}</SaveSessionContext.Provider>
+  const registry = useMemo<SectionRegistry>(
+    () => ({ publish, unpublish, attach }),
+    [publish, unpublish, attach],
+  )
+
+  return (
+    <SaveSessionContext.Provider value={api}>
+      <SectionRegistryContext.Provider value={registry}>{children}</SectionRegistryContext.Provider>
+    </SaveSessionContext.Provider>
+  )
 }
 
 export function useStorySettingsSaveSession(): SaveSessionApi {
@@ -265,24 +332,23 @@ type SectionRegistration = {
    * sections whose `dirtyFields` is empty, so this never runs while clean —
    * return this section's whole slice, unconditionally.
    *
-   * Sections must own disjoint **top-level** `StorySettings` keys. The merge is
-   * shallow, so two sections contributing different parts of one nested object
-   * (`translation`, `models`, `retrievalBudgets`, `packVariables`) clobber each
-   * other, and the winner is decided by mount order. Dev builds warn on
-   * collision.
+   * Sections must own disjoint **top-level** `StorySettings` keys. Every value
+   * is replaced wholesale — nested objects and arrays included — so two
+   * sections contributing different parts of one key clobber each other. A
+   * collision is logged in every build.
    */
   getPatch: () => Partial<StorySettings>
   /**
-   * Re-derive the draft from persisted state. Fires on Discard AND after a
-   * successful save.
+   * Drop this section's local draft so it re-derives from the `settings` the
+   * surface passes down. Fires on Discard, and after a save for each section
+   * that save committed.
    *
-   * Re-derive from the settings the surface hands the panel, which
-   * `updateStorySettings` refreshes through `storiesStore`. Not
-   * `currentStoryStore` — nothing opens a story on the way to this screen, so
-   * it is null on any cold entry. And not a value reaching this section by some
-   * other route (memoized props, a query cache, a mirror updated in an effect):
-   * this runs before React yields, so such a value is still pre-save here and
-   * resetting to it makes the save bar reappear showing the old values.
+   * Reading the `settings` prop here is correct: `updateStorySettings`
+   * refreshes `storiesStore` inside the awaited commit, and React flushes that
+   * store-driven re-render before this runs, so the closure held here is
+   * already the post-save one. That ordering is why the callback ref below is
+   * written during render — moving it into an effect would leave this reading
+   * pre-save values.
    */
   reset: () => void
 }
@@ -298,8 +364,11 @@ export function useStorySettingsSection({
   getPatch,
   reset,
 }: SectionRegistration): void {
-  const { publish, unpublish, attach } = useStorySettingsSaveSession()
-  const order = storySettingsTabOrder(tab)
+  const registry = useContext(SectionRegistryContext)
+  if (registry == null) {
+    throw new Error('useStorySettingsSection must be used inside StorySettingsSaveSessionProvider')
+  }
+  const { publish, unpublish, attach } = registry
 
   const callbacksRef = useRef<SectionCallbacks>({ getPatch, reset })
   callbacksRef.current = { getPatch, reset }
@@ -313,8 +382,8 @@ export function useStorySettingsSection({
   fieldsRef.current = dirtyFields
   const dirtyKey = JSON.stringify(dirtyFields)
   useEffect(() => {
-    publish({ id, order, dirtyFields: fieldsRef.current })
-  }, [publish, id, order, dirtyKey])
+    publish({ id, tab, dirtyFields: fieldsRef.current })
+  }, [publish, id, tab, dirtyKey])
 
   useEffect(() => () => unpublish(id), [unpublish, id])
 }

--- a/components/story-settings/save-session.tsx
+++ b/components/story-settings/save-session.tsx
@@ -18,6 +18,7 @@ import {
   type SaveSessionSnapshot,
   type SectionDirtyState,
 } from './save-session-state'
+import { storySettingsTabOrder, type StorySettingsTabId } from './tabs'
 
 // Node (vitest) leaves __DEV__ undefined, so the check runs there too.
 const DEV_CHECKS = typeof __DEV__ === 'undefined' || __DEV__
@@ -243,8 +244,8 @@ export function useStorySettingsSaveSession(): SaveSessionApi {
 
 type SectionRegistration = {
   id: string
-  /** Rail order of the owning tab — drives save-bar label order. */
-  order: number
+  /** Owning tab. Its rail position drives this section's save-bar label order. */
+  tab: StorySettingsTabId
   /**
    * User-recognizable labels, e.g. `['suggestions', 'suggestion count']`.
    * Empty means clean, which also gates whether the save merges this section.
@@ -281,12 +282,13 @@ type SectionRegistration = {
  */
 export function useStorySettingsSection({
   id,
-  order,
+  tab,
   dirtyFields,
   getPatch,
   reset,
 }: SectionRegistration): void {
   const { publish, unpublish, attach } = useStorySettingsSaveSession()
+  const order = storySettingsTabOrder(tab)
 
   const callbacksRef = useRef<SectionCallbacks>({ getPatch, reset })
   callbacksRef.current = { getPatch, reset }

--- a/components/story-settings/save-session.tsx
+++ b/components/story-settings/save-session.tsx
@@ -9,6 +9,7 @@ import {
   type ReactNode,
 } from 'react'
 
+import { StorySettingsStaleStoreError } from '@/lib/actions'
 import type { StorySettings } from '@/lib/db'
 import { logger } from '@/lib/diagnostics'
 
@@ -90,13 +91,12 @@ function reportKeyCollision(
       continue
     }
     const message = `Story Settings sections "${owner}" and "${id}" both patch the top-level key "${key}". The merge is shallow, so one clobbers the other and the winner depends on mount order.`
-    // Unrecoverable data loss (`stories` carries no delta), so it is logged in
-    // every build, not just dev.
+    // A wiring error, not a runtime condition: the screen doc assigns each
+    // top-level key to exactly one tab. Dev throws, which refuses the save
+    // rather than clobbering; prod logs and merges, since refusing every save
+    // is worse than a shallow one when `stories` carries no delta to undo.
+    if (DEV_CHECKS) throw new Error(message)
     logger.error('action_layer.story_settings_key_collision', { owner, sectionId: id, key })
-    if (DEV_CHECKS) {
-      // eslint-disable-next-line no-console -- __DEV__ wiring warning; must fire regardless of the diagnostics master gate, so the logger alone is the wrong channel.
-      console.warn(message)
-    }
   }
 }
 
@@ -140,10 +140,20 @@ export function StorySettingsSaveSessionProvider({
 
   const attach = useCallback((id: string, callbacks: { current: SectionCallbacks }) => {
     const map = callbacksRef.current
+    // Every registry here is id-keyed, so two live sections sharing an id are
+    // indistinguishable: the second overwrites the first's callbacks and its
+    // published dirty fields, and `unpublish` then strips the pair on either
+    // unmount. Nothing can reconstruct the loser, so this is a wiring error to
+    // fail on, not a state to recover from.
+    if (DEV_CHECKS && map.has(id)) {
+      throw new Error(
+        `Two Story Settings sections registered the id "${id}". Section ids must be unique across the surface.`,
+      )
+    }
     map.set(id, callbacks)
     return () => {
-      // Identity-checked: two sections sharing an id would otherwise let the
-      // first to unmount evict the survivor, leaving it dirty but invisible.
+      // A remount can attach the replacement before this cleanup runs; without
+      // the identity check it would delete the live registration.
       if (map.get(id) === callbacks) map.delete(id)
     }
   }, [])
@@ -232,6 +242,15 @@ export function StorySettingsSaveSessionProvider({
       await onCommit(merged)
     } catch (error) {
       onSaveFailed?.(error)
+      // The write landed and only the store re-read failed, so this is not a
+      // save failure. Sections keep their drafts — resetting would re-derive
+      // them from a store still holding pre-save values — but the data is on
+      // disk, so a leave waiting on this save must not be refused, and the
+      // still-dirty sections below must not talk it out of settling.
+      if (error instanceof StorySettingsStaleStoreError) {
+        settlePendingLeave()
+        return true
+      }
       return false
     } finally {
       savingRef.current = false
@@ -240,8 +259,8 @@ export function StorySettingsSaveSessionProvider({
 
     // Past the commit — the write is on disk, so nothing below may report a
     // save failure, and each step is isolated so one failure can't strand the
-    // rest. Sections re-derive their draft from the now-updated store, so the
-    // session lands clean without each one tracking a save baseline.
+    // rest. A section that didn't move re-derives its draft from the
+    // now-updated store, so it lands clean without tracking a save baseline.
     const persisted = new Set<string>()
     for (const [id, entry] of callbacksRef.current.entries()) {
       const before = committed.get(id)
@@ -275,6 +294,13 @@ export function StorySettingsSaveSessionProvider({
   }, [onCommit, onSaved, onSaveFailed, resetSections, settlePendingLeave])
 
   const discard = useCallback(() => {
+    // A commit in flight owns the outcome, same as `resolveLeave`: the write
+    // lands regardless, so reverting the drafts here would leave the session
+    // clean and showing the values the user just asked to throw away.
+    if (savingRef.current) {
+      logger.warn('action_layer.story_settings_discard_ignored', {})
+      return
+    }
     resetSections()
   }, [resetSections])
 
@@ -308,10 +334,10 @@ export function StorySettingsSaveSessionProvider({
         proceed()
         return
       }
-      // The guard outlives the commit — save() clears it and proceeds on
-      // success — so it can disable itself while the write runs, and a failure
-      // leaves the user on the same three choices rather than dropping the
-      // navigation they asked for.
+      // The guard outlives the commit — save() clears it once the session is
+      // actually clean — so it can disable itself while the write runs. A
+      // failure, or an edit that landed mid-write, leaves the user on the same
+      // three choices rather than dropping the navigation they asked for.
       void save()
     },
     [pendingLeave, discard, save],

--- a/components/story-settings/save-session.tsx
+++ b/components/story-settings/save-session.tsx
@@ -30,21 +30,40 @@ type SectionCallbacks = {
   reset: () => void
 }
 
+/**
+ * What a save did. `committed` means the write is on disk — `storeStale` only
+ * says the re-read afterwards failed, and `stillDirty` that an edit landed
+ * while the write was in flight, so neither contradicts it.
+ */
+type SaveOutcome =
+  | { status: 'noop' }
+  | { status: 'busy' }
+  | { status: 'committed'; stillDirty: boolean; storeStale: boolean }
+  | { status: 'rejected'; error: unknown }
+
+/**
+ * The session's whole mutable state. One object so the synchronous mirror
+ * below can't drift from what's rendered: `saving` and `pendingLeave` are
+ * projections of this, never separate cells that need keeping in step.
+ */
+type SessionState = {
+  sections: readonly SectionDirtyState[]
+  committing: boolean
+  /**
+   * Leave intents waiting on the session, oldest first. A list, not one slot:
+   * a window close and a back-navigation can both be outstanding, and dropping
+   * the earlier one strands whoever queued it — the main process keeps holding
+   * a close nobody will ever confirm.
+   */
+  intents: readonly (() => void)[]
+}
+
+const EMPTY_STATE: SessionState = { sections: [], committing: false, intents: [] }
+
 type SaveSessionApi = {
   snapshot: SaveSessionSnapshot
   saving: boolean
-  /**
-   * Resolves `true` when the write landed, or when there was nothing to write.
-   * `false` means it was rejected, or a commit was already in flight and this
-   * call was turned away; either way the caller must not proceed. A failure
-   * *after* the write lands never reports `false` — it is logged, because the
-   * data is on disk.
-   *
-   * `true` does not promise a clean session: an edit made while the commit was
-   * in flight survives it and stays dirty. A caller that needs cleanliness must
-   * check `snapshot` rather than infer it from here.
-   */
-  save: () => Promise<boolean>
+  save: () => Promise<SaveOutcome>
   discard: () => void
   requestLeave: (proceed: () => void) => void
   pendingLeave: boolean
@@ -118,25 +137,43 @@ export function StorySettingsSaveSessionProvider({
   onSaveFailed,
   children,
 }: ProviderProps) {
-  const [sections, setSections] = useState<readonly SectionDirtyState[]>([])
-  const [saving, setSaving] = useState(false)
-  const [pendingLeave, setPendingLeave] = useState<(() => void) | null>(null)
+  const [state, setState] = useState<SessionState>(EMPTY_STATE)
 
-  // `saving` state lands a tick late, so only a ref can turn away a second entry
-  // synchronously — Cmd-S can race the leave guard's own save.
-  const savingRef = useRef(false)
+  // Rendered state lands a tick late, so every synchronous guard reads this
+  // instead — Cmd-S can race the leave guard's own save. Writing both through
+  // `update` is what keeps the two from disagreeing.
+  const stateRef = useRef(state)
+
+  const update = useCallback((fn: (prev: SessionState) => SessionState) => {
+    const next = fn(stateRef.current)
+    if (next === stateRef.current) return
+    stateRef.current = next
+    setState(next)
+  }, [])
 
   // Callbacks live in refs, never in state: sections hand us fresh closures on
   // every render and storing them would re-render the whole surface each time.
   const callbacksRef = useRef(new Map<string, { current: SectionCallbacks }>())
 
-  const publish = useCallback((state: SectionDirtyState) => {
-    setSections((prev) => upsertSection(prev, state))
-  }, [])
+  const publish = useCallback(
+    (section: SectionDirtyState) => {
+      update((prev) => {
+        const sections = upsertSection(prev.sections, section)
+        return sections === prev.sections ? prev : { ...prev, sections }
+      })
+    },
+    [update],
+  )
 
-  const unpublish = useCallback((id: string) => {
-    setSections((prev) => removeSection(prev, id))
-  }, [])
+  const unpublish = useCallback(
+    (id: string) => {
+      update((prev) => {
+        const sections = removeSection(prev.sections, id)
+        return sections === prev.sections ? prev : { ...prev, sections }
+      })
+    },
+    [update],
+  )
 
   const attach = useCallback((id: string, callbacks: { current: SectionCallbacks }) => {
     const map = callbacksRef.current
@@ -158,15 +195,7 @@ export function StorySettingsSaveSessionProvider({
     }
   }, [])
 
-  const snapshot = useMemo(() => computeSnapshot(sections), [sections])
-
-  // Read at save time rather than closed over, so a consumer holding a stale
-  // `api` still merges against the newest published dirty state.
-  const sectionsRef = useRef(sections)
-  sectionsRef.current = sections
-
-  const pendingLeaveRef = useRef(pendingLeave)
-  pendingLeaveRef.current = pendingLeave
+  const snapshot = useMemo(() => computeSnapshot(state.sections), [state.sections])
 
   // `ids` undefined resets every section (Discard); a set resets only what a
   // save committed, so an edit made mid-commit isn't reverted with it.
@@ -185,38 +214,42 @@ export function StorySettingsSaveSessionProvider({
     }
   }, [])
 
-  const settlePendingLeave = useCallback(() => {
-    const proceed = pendingLeaveRef.current
-    if (proceed == null) return
-    setPendingLeave(null)
-    try {
-      proceed()
-    } catch (error) {
-      logger.error('action_layer.story_settings_leave_failed', { error: errorMessage(error) })
+  // Drains every waiting intent. Cleared before running them so an intent that
+  // navigates and unmounts the surface can't see itself still queued.
+  const settleIntents = useCallback(() => {
+    const intents = stateRef.current.intents
+    if (intents.length === 0) return
+    update((prev) => ({ ...prev, intents: [] }))
+    for (const proceed of intents) {
+      try {
+        proceed()
+      } catch (error) {
+        // Isolated: one intent failing must not strand the rest.
+        logger.error('action_layer.story_settings_leave_failed', { error: errorMessage(error) })
+      }
     }
-  }, [])
+  }, [update])
 
-  const save = useCallback(async () => {
-    if (savingRef.current) return false
+  const save = useCallback(async (): Promise<SaveOutcome> => {
+    if (stateRef.current.committing) return { status: 'busy' }
 
     // Clean sections are skipped rather than trusted to return `{}`: every
     // panel stays mounted so a draft survives a tab switch, so an
     // unconditional getPatch would write a never-visited tab's mount-time
     // values over whatever changed them since.
-    const dirty = dirtyIds(sectionsRef.current)
+    const dirty = dirtyIds(stateRef.current.sections)
     // Nothing to write. A leave waiting on this is already satisfied — the
     // session is clean — so proceed rather than stranding it.
     if (dirty.size === 0) {
-      settlePendingLeave()
-      return true
+      settleIntents()
+      return { status: 'noop' }
     }
 
     // What each section's draft looked like when its patch was read, so an
     // edit made while the write was in flight isn't re-derived away after it.
     const committed = new Map<string, string>()
 
-    savingRef.current = true
-    setSaving(true)
+    update((prev) => ({ ...prev, committing: true }))
     try {
       // One merged write, not a commit per section: `stories` carries no delta,
       // so a mid-way failure across N writes would strand earlier sections
@@ -245,16 +278,14 @@ export function StorySettingsSaveSessionProvider({
       // The write landed and only the store re-read failed, so this is not a
       // save failure. Sections keep their drafts — resetting would re-derive
       // them from a store still holding pre-save values — but the data is on
-      // disk, so a leave waiting on this save must not be refused, and the
-      // still-dirty sections below must not talk it out of settling.
+      // disk, so a leave waiting on this save must not be refused.
       if (error instanceof StorySettingsStaleStoreError) {
-        settlePendingLeave()
-        return true
+        settleIntents()
+        return { status: 'committed', stillDirty: true, storeStale: true }
       }
-      return false
+      return { status: 'rejected', error }
     } finally {
-      savingRef.current = false
-      setSaving(false)
+      update((prev) => ({ ...prev, committing: false }))
     }
 
     // Past the commit — the write is on disk, so nothing below may report a
@@ -288,16 +319,16 @@ export function StorySettingsSaveSessionProvider({
     // the back arrow stays live during a commit. Only once the session is
     // actually clean, though: an edit that landed mid-write is still unsaved,
     // and proceeding would drop it.
-    const stillDirty = [...dirtyIds(sectionsRef.current)].some((id) => !persisted.has(id))
-    if (!stillDirty) settlePendingLeave()
-    return true
-  }, [onCommit, onSaved, onSaveFailed, resetSections, settlePendingLeave])
+    const stillDirty = [...dirtyIds(stateRef.current.sections)].some((id) => !persisted.has(id))
+    if (!stillDirty) settleIntents()
+    return { status: 'committed', stillDirty, storeStale: false }
+  }, [onCommit, onSaved, onSaveFailed, resetSections, settleIntents, update])
 
   const discard = useCallback(() => {
     // A commit in flight owns the outcome, same as `resolveLeave`: the write
     // lands regardless, so reverting the drafts here would leave the session
     // clean and showing the values the user just asked to throw away.
-    if (savingRef.current) {
+    if (stateRef.current.committing) {
       logger.warn('action_layer.story_settings_discard_ignored', {})
       return
     }
@@ -306,54 +337,54 @@ export function StorySettingsSaveSessionProvider({
 
   const requestLeave = useCallback(
     (proceed: () => void) => {
-      if (snapshot.dirtyFields.length === 0) {
+      if (dirtyIds(stateRef.current.sections).size === 0) {
         proceed()
         return
       }
-      setPendingLeave(() => proceed)
+      update((prev) => ({ ...prev, intents: [...prev.intents, proceed] }))
     },
-    [snapshot],
+    [update],
   )
 
   const resolveLeave = useCallback(
     (outcome: 'save' | 'discard' | 'cancel') => {
       // A commit in flight owns the outcome; the dialog's disabled buttons are
       // presentation, not enforcement.
-      if (savingRef.current) {
+      if (stateRef.current.committing) {
         logger.warn('action_layer.story_settings_leave_ignored', { outcome })
         return
       }
-      const proceed = pendingLeave
-      if (proceed == null || outcome === 'cancel') {
-        setPendingLeave(null)
+      if (stateRef.current.intents.length === 0 || outcome === 'cancel') {
+        // Cancel drops every queued intent, not just the newest: the user asked
+        // to stay, so nothing outstanding may quietly navigate later.
+        update((prev) => (prev.intents.length === 0 ? prev : { ...prev, intents: [] }))
         return
       }
       if (outcome === 'discard') {
-        setPendingLeave(null)
         discard()
-        proceed()
+        settleIntents()
         return
       }
-      // The guard outlives the commit — save() clears it once the session is
-      // actually clean — so it can disable itself while the write runs. A
-      // failure, or an edit that landed mid-write, leaves the user on the same
+      // The intents outlive the commit — save() drains them once the session is
+      // actually clean — so the dialog can disable itself while the write runs.
+      // A failure, or an edit that landed mid-write, leaves the user on the same
       // three choices rather than dropping the navigation they asked for.
       void save()
     },
-    [pendingLeave, discard, save],
+    [discard, save, settleIntents, update],
   )
 
   const api = useMemo<SaveSessionApi>(
     () => ({
       snapshot,
-      saving,
+      saving: state.committing,
       save,
       discard,
       requestLeave,
-      pendingLeave: pendingLeave != null,
+      pendingLeave: state.intents.length > 0,
       resolveLeave,
     }),
-    [snapshot, saving, save, discard, requestLeave, pendingLeave, resolveLeave],
+    [snapshot, state.committing, state.intents, save, discard, requestLeave, resolveLeave],
   )
 
   const registry = useMemo<SectionRegistry>(
@@ -453,4 +484,4 @@ export function useStorySettingsSection({
   useEffect(() => () => unpublish(id), [unpublish, id])
 }
 
-export type { SaveSessionApi, SectionRegistration }
+export type { SaveOutcome, SaveSessionApi, SectionRegistration }

--- a/components/story-settings/save-session.tsx
+++ b/components/story-settings/save-session.tsx
@@ -123,6 +123,9 @@ export function StorySettingsSaveSessionProvider({
   const sectionsRef = useRef(sections)
   sectionsRef.current = sections
 
+  const pendingLeaveRef = useRef(pendingLeave)
+  pendingLeaveRef.current = pendingLeave
+
   const save = useCallback(async () => {
     if (savingRef.current) return false
     savingRef.current = true
@@ -149,6 +152,14 @@ export function StorySettingsSaveSessionProvider({
       // session lands clean without each one tracking its own save baseline.
       for (const entry of callbacksRef.current.values()) entry.current.reset()
       onSaved?.()
+      // Any save satisfies a waiting leave, not just the one the guard started:
+      // the back arrow stays live during a commit, so a leave can be requested
+      // after it, and the session is clean now either way.
+      const proceed = pendingLeaveRef.current
+      if (proceed != null) {
+        setPendingLeave(null)
+        proceed()
+      }
       return true
     } catch (error) {
       onSaveFailed?.(error)
@@ -190,14 +201,11 @@ export function StorySettingsSaveSessionProvider({
         proceed()
         return
       }
-      // The guard outlives the commit: it can then disable itself while the
-      // write runs, and a failure leaves the user on the same three choices
-      // rather than dropping the navigation they asked for.
-      void save().then((ok) => {
-        if (!ok) return
-        setPendingLeave(null)
-        proceed()
-      })
+      // The guard outlives the commit — save() clears it and proceeds on
+      // success — so it can disable itself while the write runs, and a failure
+      // leaves the user on the same three choices rather than dropping the
+      // navigation they asked for.
+      void save()
     },
     [pendingLeave, discard, save],
   )

--- a/components/story-settings/save-session.tsx
+++ b/components/story-settings/save-session.tsx
@@ -33,11 +33,15 @@ type SaveSessionApi = {
   snapshot: SaveSessionSnapshot
   saving: boolean
   /**
-   * Resolves `true` when the session reached a clean, persisted state — the
-   * commit landed, or there was nothing to commit. `false` means the write was
-   * rejected, or a commit was already in flight and this call was turned away;
-   * either way the caller must not proceed. A failure *after* the write lands
-   * never reports `false` — it is logged, because the data is on disk.
+   * Resolves `true` when the write landed, or when there was nothing to write.
+   * `false` means it was rejected, or a commit was already in flight and this
+   * call was turned away; either way the caller must not proceed. A failure
+   * *after* the write lands never reports `false` — it is logged, because the
+   * data is on disk.
+   *
+   * `true` does not promise a clean session: an edit made while the commit was
+   * in flight survives it and stays dirty. A caller that needs cleanliness must
+   * check `snapshot` rather than infer it from here.
    */
   save: () => Promise<boolean>
   discard: () => void
@@ -63,6 +67,15 @@ function dirtyIds(sections: readonly SectionDirtyState[]): Set<string> {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
+}
+
+/**
+ * Identifies a section's draft at a point in time. Both sides always come from
+ * the same `getPatch`, so key order matches; a reordering would read as
+ * "changed", which only skips a reset — it can never discard an edit.
+ */
+function patchSignature(patch: Partial<StorySettings>): string {
+  return JSON.stringify(patch)
 }
 
 function reportKeyCollision(
@@ -188,6 +201,10 @@ export function StorySettingsSaveSessionProvider({
       return true
     }
 
+    // What each section's draft looked like when its patch was read, so an
+    // edit made while the write was in flight isn't re-derived away after it.
+    const committed = new Map<string, string>()
+
     savingRef.current = true
     setSaving(true)
     try {
@@ -209,6 +226,7 @@ export function StorySettingsSaveSessionProvider({
           })
         }
         reportKeyCollision(owners, id, patch)
+        committed.set(id, patchSignature(patch))
         merged = { ...merged, ...patch }
       }
       await onCommit(merged)
@@ -224,7 +242,22 @@ export function StorySettingsSaveSessionProvider({
     // save failure, and each step is isolated so one failure can't strand the
     // rest. Sections re-derive their draft from the now-updated store, so the
     // session lands clean without each one tracking a save baseline.
-    resetSections(dirty)
+    const persisted = new Set<string>()
+    for (const [id, entry] of callbacksRef.current.entries()) {
+      const before = committed.get(id)
+      if (before === undefined) continue
+      try {
+        if (patchSignature(entry.current.getPatch()) === before) persisted.add(id)
+      } catch (error) {
+        // Treat an unreadable draft as changed: skipping a reset costs a stale
+        // save bar, resetting one the user has moved on from costs their edit.
+        logger.error('action_layer.story_settings_reset_check_failed', {
+          sectionId: id,
+          error: errorMessage(error),
+        })
+      }
+    }
+    resetSections(persisted)
     try {
       onSaved?.()
     } catch (error) {
@@ -232,10 +265,12 @@ export function StorySettingsSaveSessionProvider({
         error: errorMessage(error),
       })
     }
-    // Any save satisfies a waiting leave, not just the one the guard started:
-    // the back arrow stays live during a commit, so a leave can be requested
-    // after it, and the session is clean now either way.
-    settlePendingLeave()
+    // Any save satisfies a waiting leave, not just the one the guard started —
+    // the back arrow stays live during a commit. Only once the session is
+    // actually clean, though: an edit that landed mid-write is still unsaved,
+    // and proceeding would drop it.
+    const stillDirty = [...dirtyIds(sectionsRef.current)].some((id) => !persisted.has(id))
+    if (!stillDirty) settlePendingLeave()
     return true
   }, [onCommit, onSaved, onSaveFailed, resetSections, settlePendingLeave])
 
@@ -327,10 +362,13 @@ type SectionRegistration = {
    */
   dirtyFields: readonly string[]
   /**
-   * This section's contribution to the surface's single save. Read only at
-   * save time, so it may close over draft state freely. The provider skips
-   * sections whose `dirtyFields` is empty, so this never runs while clean —
-   * return this section's whole slice, unconditionally.
+   * This section's contribution to the surface's single save. Called only
+   * during a save, so it may close over draft state freely, but called
+   * **twice** per save — once to build the write, once after it lands to check
+   * whether the draft moved while it was in flight. Keep it free of side
+   * effects. The provider skips sections whose `dirtyFields` is empty, so this
+   * never runs while clean — return this section's whole slice,
+   * unconditionally.
    *
    * Sections must own disjoint **top-level** `StorySettings` keys. Every value
    * is replaced wholesale — nested objects and arrays included — so two
@@ -341,7 +379,8 @@ type SectionRegistration = {
   /**
    * Drop this section's local draft so it re-derives from the `settings` the
    * surface passes down. Fires on Discard, and after a save for each section
-   * that save committed.
+   * whose draft still matches what that save wrote — a section the user kept
+   * editing during the commit is left alone and stays dirty.
    *
    * Reading the `settings` prop here is correct: `updateStorySettings`
    * refreshes `storiesStore` inside the awaited commit, and React flushes that

--- a/components/story-settings/save-session.tsx
+++ b/components/story-settings/save-session.tsx
@@ -48,6 +48,10 @@ type SaveSessionApi = {
 
 const SaveSessionContext = createContext<SaveSessionApi | null>(null)
 
+function dirtyIds(sections: readonly SectionDirtyState[]): Set<string> {
+  return new Set(sections.filter((s) => s.dirtyFields.length > 0).map((s) => s.id))
+}
+
 function warnOnKeyCollision(
   owners: Map<string, string>,
   id: string,
@@ -113,6 +117,11 @@ export function StorySettingsSaveSessionProvider({
 
   const snapshot = useMemo(() => computeSnapshot(sections), [sections])
 
+  // Read at save time rather than closed over, so a consumer holding a stale
+  // `api` still merges against the newest published dirty state.
+  const sectionsRef = useRef(sections)
+  sectionsRef.current = sections
+
   const save = useCallback(async () => {
     if (savingRef.current) return false
     savingRef.current = true
@@ -123,7 +132,13 @@ export function StorySettingsSaveSessionProvider({
       // persisted with no way to undo them.
       let merged: Partial<StorySettings> = {}
       const owners = DEV_CHECKS ? new Map<string, string>() : null
+      // Clean sections are skipped rather than trusted to return `{}`: every
+      // panel stays mounted so a draft survives a tab switch, so an
+      // unconditional getPatch would write a never-visited tab's mount-time
+      // values over whatever changed them since.
+      const dirty = dirtyIds(sectionsRef.current)
       for (const [id, entry] of callbacksRef.current.entries()) {
+        if (!dirty.has(id)) continue
         const patch = entry.current.getPatch()
         if (owners) warnOnKeyCollision(owners, id, patch)
         merged = { ...merged, ...patch }
@@ -219,11 +234,16 @@ type SectionRegistration = {
   id: string
   /** Rail order of the owning tab — drives save-bar label order. */
   order: number
-  /** User-recognizable labels, e.g. `['suggestions', 'suggestion count']`. */
+  /**
+   * User-recognizable labels, e.g. `['suggestions', 'suggestion count']`.
+   * Empty means clean, which also gates whether the save merges this section.
+   */
   dirtyFields: readonly string[]
   /**
    * This section's contribution to the surface's single save. Read only at
-   * save time, so it may close over draft state freely. Return `{}` when clean.
+   * save time, so it may close over draft state freely. The provider skips
+   * sections whose `dirtyFields` is empty, so this never runs while clean —
+   * return this section's whole slice, unconditionally.
    *
    * Sections must own disjoint **top-level** `StorySettings` keys. The merge is
    * shallow, so two sections contributing different parts of one nested object
@@ -232,7 +252,15 @@ type SectionRegistration = {
    * collision.
    */
   getPatch: () => Partial<StorySettings>
-  /** Re-derive the draft from persisted state. Fires on Discard AND after a successful save. */
+  /**
+   * Re-derive the draft from persisted state. Fires on Discard AND after a
+   * successful save.
+   *
+   * After a save this runs before React yields, so re-derive from the store. A
+   * value reaching this section by any other route — memoized props, a query
+   * cache, a mirror updated in an effect — is still pre-save here, and
+   * resetting to it makes the save bar reappear showing the old values.
+   */
   reset: () => void
 }
 

--- a/components/story-settings/save-session.tsx
+++ b/components/story-settings/save-session.tsx
@@ -14,8 +14,10 @@ import type { StorySettings } from '@/lib/db'
 import { logger } from '@/lib/diagnostics'
 
 import {
+  cloneDraft,
   computeSnapshot,
   removeSection,
+  sameDraft,
   upsertSection,
   type SaveSessionSnapshot,
   type SectionDirtyState,
@@ -87,15 +89,6 @@ function dirtyIds(sections: readonly SectionDirtyState[]): Set<string> {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
-}
-
-/**
- * Identifies a section's draft at a point in time. Both sides always come from
- * the same `getPatch`, so key order matches; a reordering would read as
- * "changed", which only skips a reset — it can never discard an edit.
- */
-function patchSignature(patch: Partial<StorySettings>): string {
-  return JSON.stringify(patch)
 }
 
 function reportKeyCollision(
@@ -247,7 +240,7 @@ export function StorySettingsSaveSessionProvider({
 
     // What each section's draft looked like when its patch was read, so an
     // edit made while the write was in flight isn't re-derived away after it.
-    const committed = new Map<string, string>()
+    const committed = new Map<string, unknown>()
 
     update((prev) => ({ ...prev, committing: true }))
     try {
@@ -269,7 +262,7 @@ export function StorySettingsSaveSessionProvider({
           })
         }
         reportKeyCollision(owners, id, patch)
-        committed.set(id, patchSignature(patch))
+        committed.set(id, cloneDraft(patch))
         merged = { ...merged, ...patch }
       }
       await onCommit(merged)
@@ -294,10 +287,9 @@ export function StorySettingsSaveSessionProvider({
     // now-updated store, so it lands clean without tracking a save baseline.
     const persisted = new Set<string>()
     for (const [id, entry] of callbacksRef.current.entries()) {
-      const before = committed.get(id)
-      if (before === undefined) continue
+      if (!committed.has(id)) continue
       try {
-        if (patchSignature(entry.current.getPatch()) === before) persisted.add(id)
+        if (sameDraft(entry.current.getPatch(), committed.get(id))) persisted.add(id)
       } catch (error) {
         // Treat an unreadable draft as changed: skipping a reset costs a stale
         // save bar, resetting one the user has moved on from costs their edit.

--- a/components/story-settings/save-session.tsx
+++ b/components/story-settings/save-session.tsx
@@ -276,9 +276,12 @@ type SectionRegistration = {
    * Re-derive the draft from persisted state. Fires on Discard AND after a
    * successful save.
    *
-   * After a save this runs before React yields, so re-derive from the store. A
-   * value reaching this section by any other route — memoized props, a query
-   * cache, a mirror updated in an effect — is still pre-save here, and
+   * Re-derive from the settings the surface hands the panel, which
+   * `updateStorySettings` refreshes through `storiesStore`. Not
+   * `currentStoryStore` — nothing opens a story on the way to this screen, so
+   * it is null on any cold entry. And not a value reaching this section by some
+   * other route (memoized props, a query cache, a mirror updated in an effect):
+   * this runs before React yields, so such a value is still pre-save here and
    * resetting to it makes the save bar reappear showing the old values.
    */
   reset: () => void

--- a/components/story-settings/tabs.test.ts
+++ b/components/story-settings/tabs.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+import { t } from '@/lib/i18n'
+
+import {
+  isStorySettingsTabId,
+  STORY_SETTINGS_TAB_GROUPS,
+  STORY_SETTINGS_TAB_IDS,
+  storySettingsTabOrder,
+} from './tabs'
+
+describe('story-settings tabs', () => {
+  it('registers every group tab exactly once', () => {
+    const flattened = STORY_SETTINGS_TAB_GROUPS.flatMap((group) => group.tabs)
+    expect(STORY_SETTINGS_TAB_IDS).toEqual(flattened)
+    expect(new Set(STORY_SETTINGS_TAB_IDS).size).toBe(STORY_SETTINGS_TAB_IDS.length)
+  })
+
+  it('ranks every tab by its rail position', () => {
+    const orders = STORY_SETTINGS_TAB_IDS.map(storySettingsTabOrder)
+    expect(orders).toEqual(STORY_SETTINGS_TAB_IDS.map((_, index) => index))
+  })
+
+  // A tab added without its locale entry would ship the raw key as the rail
+  // label, which reads as a rendering bug rather than a missing translation.
+  it('resolves a label for every tab and a header for every group', () => {
+    for (const id of STORY_SETTINGS_TAB_IDS) {
+      const key = `storySettings:tabs.${id}` as const
+      expect(t(key)).not.toBe(key)
+    }
+    for (const group of STORY_SETTINGS_TAB_GROUPS) {
+      const key = `storySettings:sections.${group.id}` as const
+      expect(t(key)).not.toBe(key)
+    }
+  })
+
+  describe('isStorySettingsTabId', () => {
+    it('accepts every registered id', () => {
+      expect(STORY_SETTINGS_TAB_IDS.every(isStorySettingsTabId)).toBe(true)
+    })
+
+    it('rejects an unregistered id, a wrong case, and undefined', () => {
+      expect(isStorySettingsTabId('nope')).toBe(false)
+      expect(isStorySettingsTabId('Advanced')).toBe(false)
+      expect(isStorySettingsTabId(undefined)).toBe(false)
+    })
+  })
+})

--- a/components/story-settings/tabs.test.ts
+++ b/components/story-settings/tabs.test.ts
@@ -29,7 +29,7 @@ describe('story-settings tabs', () => {
       expect(t(key)).not.toBe(key)
     }
     for (const group of STORY_SETTINGS_TAB_GROUPS) {
-      const key = `storySettings:sections.${group.id}` as const
+      const key = `storySettings:groups.${group.id}` as const
       expect(t(key)).not.toBe(key)
     }
   })

--- a/components/story-settings/tabs.ts
+++ b/components/story-settings/tabs.ts
@@ -1,10 +1,9 @@
 /**
- * C7 seam: adding a tab id to a group here registers the tab. The id union,
- * the deep-link accept-list, and each section's save-bar `order` all derive
- * from this one structure, so a rail entry can't drift out of sync with them.
- * Labels resolve at render (`storySettings:tabs.<id>`) so a language switch
- * still reaches them; the section body itself lives in its own module and
- * joins the save session via `useStorySettingsSection`.
+ * Adding an id to a group here registers the tab: the id union, the
+ * deep-link accept-list, each section's save-bar order, and the
+ * `storySettings:tabs.<id>` label lookup all derive from this structure, so a
+ * rail entry can't drift out of sync with them. A missing locale key is a
+ * typecheck failure, not a runtime one.
  */
 const STORY_SETTINGS_TAB_GROUPS = [
   { id: 'story', tabs: ['about', 'generation'] },
@@ -18,7 +17,17 @@ const STORY_SETTINGS_TAB_IDS: readonly StorySettingsTabId[] = STORY_SETTINGS_TAB
   (group) => group.tabs,
 )
 
-/** Rail position of a tab. `useStorySettingsSection` resolves it from `tab`. */
+// A duplicate id keeps the union intact but silently mounts two panels and
+// makes `indexOf` resolve both to the first one's rail slot. Node (vitest)
+// leaves __DEV__ undefined, so the check runs there too.
+if (typeof __DEV__ === 'undefined' || __DEV__) {
+  const unique = new Set(STORY_SETTINGS_TAB_IDS)
+  if (unique.size !== STORY_SETTINGS_TAB_IDS.length) {
+    throw new Error('STORY_SETTINGS_TAB_GROUPS contains a duplicate tab id.')
+  }
+}
+
+/** Rail position of a tab. `computeSnapshot` resolves it to order the save bar. */
 function storySettingsTabOrder(id: StorySettingsTabId): number {
   return STORY_SETTINGS_TAB_IDS.indexOf(id)
 }

--- a/components/story-settings/tabs.ts
+++ b/components/story-settings/tabs.ts
@@ -1,0 +1,36 @@
+/**
+ * C7 seam: adding a tab id to a group here registers the tab. The id union,
+ * the deep-link accept-list, and each section's save-bar `order` all derive
+ * from this one structure, so a rail entry can't drift out of sync with them.
+ * Labels resolve at render (`storySettings:tabs.<id>`) so a language switch
+ * still reaches them; the section body itself lives in its own module and
+ * joins the save session via `useStorySettingsSection`.
+ */
+const STORY_SETTINGS_TAB_GROUPS = [
+  { id: 'story', tabs: ['about', 'generation'] },
+  { id: 'settings', tabs: ['models', 'memory', 'translation', 'pack', 'calendar', 'advanced'] },
+] as const
+
+type StorySettingsGroupId = (typeof STORY_SETTINGS_TAB_GROUPS)[number]['id']
+type StorySettingsTabId = (typeof STORY_SETTINGS_TAB_GROUPS)[number]['tabs'][number]
+
+const STORY_SETTINGS_TAB_IDS: readonly StorySettingsTabId[] = STORY_SETTINGS_TAB_GROUPS.flatMap(
+  (group) => group.tabs,
+)
+
+/** Rail position of the owning tab — what `useStorySettingsSection` wants for `order`. */
+function storySettingsTabOrder(id: StorySettingsTabId): number {
+  return STORY_SETTINGS_TAB_IDS.indexOf(id)
+}
+
+function isStorySettingsTabId(value: string | undefined): value is StorySettingsTabId {
+  return STORY_SETTINGS_TAB_IDS.includes(value as StorySettingsTabId)
+}
+
+export {
+  isStorySettingsTabId,
+  STORY_SETTINGS_TAB_GROUPS,
+  STORY_SETTINGS_TAB_IDS,
+  storySettingsTabOrder,
+}
+export type { StorySettingsGroupId, StorySettingsTabId }

--- a/components/story-settings/tabs.ts
+++ b/components/story-settings/tabs.ts
@@ -18,7 +18,7 @@ const STORY_SETTINGS_TAB_IDS: readonly StorySettingsTabId[] = STORY_SETTINGS_TAB
   (group) => group.tabs,
 )
 
-/** Rail position of the owning tab — what `useStorySettingsSection` wants for `order`. */
+/** Rail position of a tab. `useStorySettingsSection` resolves it from `tab`. */
 function storySettingsTabOrder(id: StorySettingsTabId): number {
   return STORY_SETTINGS_TAB_IDS.indexOf(id)
 }

--- a/components/story-settings/unsaved-changes-dialog.stories.tsx
+++ b/components/story-settings/unsaved-changes-dialog.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite'
+import { expect, fn, screen, userEvent, waitFor } from 'storybook/test'
+
+import { UnsavedChangesDialog } from './unsaved-changes-dialog'
+
+const meta: Meta<typeof UnsavedChangesDialog> = {
+  title: 'Compounds/StorySettings/UnsavedChangesDialog',
+  component: UnsavedChangesDialog,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Open: Story = {
+  args: { open: true, onSave: fn(), onDiscard: fn(), onCancel: fn() },
+}
+
+/**
+ * Commit in flight — all three actions are inert. The owner keeps the
+ * dialog mounted until the pending leave resolves.
+ */
+export const Saving: Story = {
+  args: { open: true, saving: true, onSave: fn(), onDiscard: fn(), onCancel: fn() },
+  play: async ({ args }) => {
+    for (const name of ['Cancel', 'Discard', 'Save']) {
+      expect(await screen.findByRole('button', { name })).toBeDisabled()
+    }
+    // Escape and Android back reach the same close handler the disabled
+    // Cancel does, so the guard has to hold for them too.
+    await userEvent.keyboard('{Escape}')
+    expect(args.onCancel).not.toHaveBeenCalled()
+    expect(args.onSave).not.toHaveBeenCalled()
+    expect(args.onDiscard).not.toHaveBeenCalled()
+  },
+}
+
+export const SaveFires: Story = {
+  args: { open: true, onSave: fn(), onDiscard: fn(), onCancel: fn() },
+  play: async ({ args }) => {
+    await userEvent.click(await screen.findByRole('button', { name: 'Save' }))
+    await waitFor(() => expect(args.onSave).toHaveBeenCalled())
+    // Save must not also request close — that would resolve the leave twice.
+    expect(args.onCancel).not.toHaveBeenCalled()
+  },
+}
+
+export const DiscardFires: Story = {
+  args: { open: true, onSave: fn(), onDiscard: fn(), onCancel: fn() },
+  play: async ({ args }) => {
+    await userEvent.click(await screen.findByRole('button', { name: 'Discard' }))
+    await waitFor(() => expect(args.onDiscard).toHaveBeenCalled())
+    expect(args.onCancel).not.toHaveBeenCalled()
+  },
+}
+
+export const CancelFires: Story = {
+  args: { open: true, onSave: fn(), onDiscard: fn(), onCancel: fn() },
+  play: async ({ args }) => {
+    await userEvent.click(await screen.findByRole('button', { name: 'Cancel' }))
+    await waitFor(() => expect(args.onCancel).toHaveBeenCalled())
+    expect(args.onSave).not.toHaveBeenCalled()
+    expect(args.onDiscard).not.toHaveBeenCalled()
+  },
+}
+
+export const EscapeCancels: Story = {
+  args: { open: true, onSave: fn(), onDiscard: fn(), onCancel: fn() },
+  play: async ({ args }) => {
+    await screen.findByRole('button', { name: 'Cancel' })
+    await userEvent.keyboard('{Escape}')
+    await waitFor(() => expect(args.onCancel).toHaveBeenCalled())
+  },
+}

--- a/components/story-settings/unsaved-changes-dialog.tsx
+++ b/components/story-settings/unsaved-changes-dialog.tsx
@@ -1,0 +1,64 @@
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import { Text } from '@/components/ui/text'
+import { t } from '@/lib/i18n'
+
+type UnsavedChangesDialogProps = {
+  open: boolean
+  saving?: boolean
+  onSave: () => void
+  onDiscard: () => void
+  onCancel: () => void
+}
+
+export function UnsavedChangesDialog({
+  open,
+  saving = false,
+  onSave,
+  onDiscard,
+  onCancel,
+}: UnsavedChangesDialogProps) {
+  function handleOpenChange(next: boolean) {
+    // Escape and the Android back button also land here; a commit in flight
+    // must not resolve the leave as a cancel behind it.
+    if (next || saving) return
+    onCancel()
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t('storySettings:save.unsavedTitle')}</AlertDialogTitle>
+          <AlertDialogDescription>{t('storySettings:save.unsavedBody')}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel asChild>
+            <Button variant="secondary" disabled={saving}>
+              <Text>{t('cancel')}</Text>
+            </Button>
+          </AlertDialogCancel>
+          {/* Plain buttons: an AlertDialogAction wrapper would also request
+              close, firing onCancel alongside the chosen action. The owner
+              closes this once the pending leave resolves. */}
+          <Button variant="secondary" onPress={onDiscard} disabled={saving}>
+            <Text>{t('storySettings:save.unsavedDiscard')}</Text>
+          </Button>
+          <Button variant="primary" onPress={onSave} disabled={saving}>
+            <Text>{t('storySettings:save.unsavedSave')}</Text>
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+export type { UnsavedChangesDialogProps }

--- a/docs/implementation/lessons-learned/README.md
+++ b/docs/implementation/lessons-learned/README.md
@@ -51,6 +51,9 @@ slice plans when relevant.
   — engine anchoring silently skips RN-Web wrapper trees; opt out
   with `overflow-anchor: none` and compensate deterministically,
   never mid-gesture.
+- [`BackHandler` is not inert on web](./backhandler-web-console-error.md)
+  — RN-Web's shim `console.error`s on every subscribe; gate the
+  subscribe on `Platform.OS === 'android'`, not the handler.
 
 ### rn-primitives substrate
 

--- a/docs/implementation/lessons-learned/README.md
+++ b/docs/implementation/lessons-learned/README.md
@@ -117,6 +117,9 @@ slice plans when relevant.
   — the published xxh32 vectors all hash below `0x80000000`, so a
   signed-int32 leak survived a green suite; assert format
   invariants over a sweep, not just point values.
+- [A literal NUL in a plan file silently rewrites the code it specifies](./plan-file-nul-corruption.md)
+  — `file .impl-plans/*.md` should never say `data`; reading tools disagree
+  about a raw NUL and each renders a different separator.
 - [Vite eagerly bundles a runtime-guarded `require()`, Metro doesn't](./storybook-vite-eager-guarded-require.md)
   — a `typeof window` guard around a Node-only `require()` is safe under
   Metro but can crash every Storybook story importing that module; alias

--- a/docs/implementation/lessons-learned/backhandler-web-console-error.md
+++ b/docs/implementation/lessons-learned/backhandler-web-console-error.md
@@ -1,0 +1,43 @@
+# `BackHandler` is not inert on web — subscribing logs a console error
+
+React Native's `BackHandler` looks safely cross-platform: on web nothing ever
+dispatches `hardwareBackPress`, so a handler registered there simply never
+fires. That reasoning is right about the **handler** and wrong about the
+**subscription**. `react-native-web`'s shim is not a no-op:
+
+```js
+// react-native-web/dist/exports/BackHandler/index.js
+addEventListener() {
+  console.error('BackHandler is not supported on web and should not be used.');
+  return { remove: emptyFunction };
+}
+```
+
+Every `addEventListener` call emits a `console.error` — once per subscribe. In
+a hook driven by `useFocusEffect`, that is once per route focus, for the whole
+life of the app.
+
+**Why it bites.** The noise lands on the platform least likely to be tested for
+it: desktop, where the app runs under Electron and the message reads like an
+app-level failure rather than a shim notice. It also bypasses the repo's
+logging discipline entirely — the call is inside `node_modules`, so `no-console`
+cannot see it and nothing routes it to `diagnosticsStore`. Worse, the natural
+mitigation is to write a comment claiming the shim is a harmless no-op, which
+is exactly the assertion that stops the next reader from adding the guard.
+
+**What it cost.** `useMasterDetailBack` subscribed unconditionally and carried a
+docblock stating that Expo's web build "shims `BackHandler` to a no-op". The
+claim survived a review pass and was only caught by reading the shim source.
+`app/wizard.tsx` had guarded correctly since it was written, so the repo
+already contained both the bug and its fix.
+
+## How to apply
+
+- Gate the **subscribe**, not the handler:
+  `if (Platform.OS !== 'android') return undefined` before
+  `BackHandler.addEventListener`.
+- Treat "this library no-ops off-platform" as a claim to verify in the shim
+  source, not an inference from the absence of an event. Shims warn.
+- When a comment asserts that something is harmless, that assertion is the part
+  that needs evidence — it is what future readers will rely on instead of
+  re-checking.

--- a/docs/implementation/lessons-learned/plan-file-nul-corruption.md
+++ b/docs/implementation/lessons-learned/plan-file-nul-corruption.md
@@ -1,0 +1,47 @@
+# A literal NUL in a plan file silently rewrites the code it specifies
+
+An execution plan that specifies a separator — `join('\0')`, a delimiter
+constant, any escape written inside a fenced code block — can end up carrying
+a **literal NUL byte** instead of the two-character escape. `file` reports the
+plan as `data` rather than `text`; nothing else complains.
+
+**Why it bites.** Reading tools disagree about what they render, silently:
+`rg` shows `join(' ')`, `tr -d '\0'` shows `join('')`, an editor may show
+nothing at all. Whoever implements the task reads one of those and writes it
+into real code. Typecheck, lint, remark, and the test suite all pass, because
+the test is written from the same corrupted source and moves with it.
+
+**What it cost.** M3.1a's plan carried five NUL bytes. Its spec chose a NUL
+separator and gave a rationale for it; the shipped `compositeText` joins with a
+space, and the test that should have caught the change is _named_ after a
+single-space separator while its drafted assertions expected NUL. A stated,
+reasoned design decision was reversed with no reviewer, no failing gate, and no
+record — it took a hand audit two milestones later to notice, and only then
+could anyone establish that the divergence happened to be harmless. M3.11's
+plan carried three NUL bytes, at exactly the sites defining a dirty-field
+serialization separator.
+
+## How to apply
+
+Check any plan that specifies a separator before dispatching from it:
+
+```sh
+file .impl-plans/*.md    # every one should say "text", never "data"
+```
+
+**Root cause.** Tool-call parameters are JSON, and a six-character Unicode
+escape for codepoint zero is a _valid JSON escape_ that decodes to a real NUL
+before the file is ever written. Nothing downstream can tell the difference
+between "the author wanted a NUL" and "the author wrote an escape".
+
+**How to write it safely.** Don't hand-write a codepoint escape for a control
+character into a plan at all. Either double the backslash so the escape reaches
+the file as text, or — better — restructure so no separator is needed. In the
+M3.11 case the round-trip was removable entirely: the comparison it
+approximated already existed in `upsertSection`, so publishing the real array
+behind a ref and using `JSON.stringify` only as an effect key was both correct
+and simpler. This lesson was itself corrupted twice while being written, which
+is the strongest argument available for the restructure over the escape.
+
+Related: [known-answer vectors can share a blind spot](./known-answer-vectors-share-blind-spots.md)
+— another case where a green suite proved less than it appeared to.

--- a/docs/implementation/milestones/03-memory-floor/milestone.md
+++ b/docs/implementation/milestones/03-memory-floor/milestone.md
@@ -88,8 +88,9 @@ dropped: canon defines no reader-entry refine (refine is a
 wizard-opening affordance, 3.6).
 [Slice 3.11](./slices/11-story-settings-shell.md) (also added at
 promotion, from an audit finding) ships the minimal Story Settings
-host that 3.1b's embedding-status panel and 3.7's Composer section
-register into — the real basic surface remains M4.4.
+host that 3.1b's embedding-status panel and 3.7's Generation-tab
+Authoring aids section register into — the real basic surface
+remains M4.4.
 
 What changes from "before" to "after": the app goes from "one loop
 that forgets everything past the recent buffer" to "prose and
@@ -289,13 +290,19 @@ slice lands first; the insertion order above is binding either way.
 ### C7 — Story Settings section registration
 
 [Slice 3.11](./slices/11-story-settings-shell.md) owns the minimal
-Story Settings shell and a section-registration seam: a section is
-a self-registered module declaring its tab and rendering its own
-body — consumers touch no shared file (same spirit as the M1.5
-delta-dispatch registration API). Consumers: 3.1b registers the
-Memory tab's embedding-status panel; 3.7 registers the Composer
-section (categories editor, master toggle, count stepper).
-Registration names fixed in 3.11's first commit.
+Story Settings shell. Two seams: the route's **tab map** — a
+consumer slice renders its section in the tab's branch, the same way
+M3.1a extended the App Settings route — and the shell's
+**save session**, which a section joins at runtime by calling
+`useStorySettingsSection` from inside its own body, reporting
+`{ dirtyFields, getPatch, reset }` into the surface's single save
+bar.
+Consumers: 3.1b registers the Memory tab's embedding-status panel;
+3.7 registers the Generation tab's Authoring aids section
+(categories editor, master toggle, count stepper). Story Settings
+saves write `stories.settings` directly — `stories` is absent from
+`deltas.target_table`, so a settings save carries no delta and is
+not CTRL-Z reversible. Names fixed in 3.11's first commit.
 
 ### C8 — Swap-dialog open action
 

--- a/docs/implementation/milestones/03-memory-floor/slices/01b-embedder-lifecycle.md
+++ b/docs/implementation/milestones/03-memory-floor/slices/01b-embedder-lifecycle.md
@@ -179,6 +179,31 @@ Zod, and `stories.settings.effectiveDim` is locked at creation.
   without it, and no per-row deletion path (entity, lore, happening,
   thread, chapter) calls it at all — so whichever slice introduces
   one inherits this question. Surfaced by M3.1a review (2026-07-21).
+- **Embedding-model install fails its smoke test in packaged desktop
+  builds.** Reported on a packaged Linux build (2026-07-22): the
+  download itself completes, then the dialog shows
+  `embedder:failure.smokeTestHint` ("The files are intact but this
+  device couldn't run the model"). So this is the post-download
+  inference check, not the transfer. The path is
+  `embedder-download-dialog.tsx` calling `driver.smokeTestEmbed`, the
+  `smokeTest` IPC, then `getPipeline` in
+  `electron/embedder/service.ts`, whose `buildPipeline` opens with a
+  dynamic import of `@huggingface/transformers`. The reporter's
+  initial "ONNX runtime packaging" hypothesis is **falsified** by
+  inspecting the artifact: `@huggingface/transformers` is present
+  inside `app.asar`, and `onnxruntime-node` is correctly listed in
+  `asarUnpack` and present under `app.asar.unpacked` with the
+  `linux/x64` `onnxruntime_binding.node` and `libonnxruntime.so.1` in
+  place. Live leads instead: transformers.js v3 may select its wasm
+  backend inside the Electron main process and then fail to read
+  `ort-wasm-simd-threaded.jsep.wasm` from inside the asar, or the
+  `modelDir` handed to the pipeline may not resolve under packaging
+  with `allowRemoteModels` disabled. First step is probably to surface
+  the real error: the failure envelope carries a message the dialog
+  collapses into generic copy, and the logger is gated off by default,
+  so nothing reaches the user or diagnostics. Not reproduced in dev;
+  nothing beyond the artifact inspection is verified. Surfaced by
+  M3.11 review (2026-07-22).
 
 ## Implementation notes
 

--- a/docs/implementation/milestones/03-memory-floor/slices/07-suggestions.md
+++ b/docs/implementation/milestones/03-memory-floor/slices/07-suggestions.md
@@ -20,7 +20,8 @@ turn: a sibling `<suggestions>` block emits in the narrative fold
 the entry's metadata, and renders as the reader's chip strip with
 category overlines, a refresh re-roll through the new
 `suggestion-refresh` pipeline, and an empty-state Generate. Story
-Settings gains the Composer categories editor (wiring the shipped
+Settings gains the Generation tab's Authoring aids categories
+editor (wiring the shipped
 `SuggestionCategoriesEditor`) plus the `suggestionsEnabled` toggle
 and `suggestionCount` stepper.
 
@@ -87,8 +88,8 @@ tap-after-typing draft loss is a documented v1 wart.
   `(removed)` fallback; disabled-category render rules;
   accessibility (chip = button with category label, `aria-busy`
   loading, refresh `aria-label`).
-- **Settings surface:** the Composer section registered into the
-  Story Settings shell per C7
+- **Settings surface:** the Generation tab's Authoring aids section
+  hosted by the Story Settings shell per C7
   ([Slice 3.11](./11-story-settings-shell.md) hosts), with
   `suggestionsEnabled` master toggle, `suggestionCount` stepper,
   and the categories editor wiring the shipped

--- a/docs/implementation/milestones/03-memory-floor/slices/07-suggestions.md
+++ b/docs/implementation/milestones/03-memory-floor/slices/07-suggestions.md
@@ -164,6 +164,49 @@ tap-after-typing draft loss is a documented v1 wart.
   virtualized entry list and the composer; confirm it lives outside
   the scroll container (reader-document pattern) rather than as a
   list row.
+- **Which navigate-away intercepts the settings section needs.**
+  [`save-sessions.md → Navigate-away guard`](../../../../ui/patterns/save-sessions.md#navigate-away-guard--global-intercept)
+  lists window-close intent (electron close, web `beforeunload`)
+  and Actions-menu route jumps among its required categories, and
+  [Slice 3.11](./11-story-settings-shell.md) wired neither — only
+  the surface's own back path (chrome Return, Android hardware
+  back). Window-close was left out deliberately: cross-cutting
+  infra no surface wires today, and wiring it would pull a UI slice
+  into `electron/`. The shell anticipates one anyway —
+  `resolveLeave` is documented as reachable directly, because a
+  `beforeunload` handler cannot route through a React modal. Both
+  gaps are inert while the session has no sections and so can never
+  be dirty; the Authoring aids section makes them live — the route
+  jump everywhere, window-close on desktop. Decide at planning
+  whether to wire them or accept that a window close or a
+  Diagnostics jump drops unsaved category edits. Surfaced by M3.11
+  (2026-07-22).
+- **The save bar is invisible in the phone collapsed state.** The
+  shell renders it inside the detail pane, and `MasterDetailLayout`
+  hides that pane on phone whenever no tab is selected — so a dirty
+  session collapsed back to the rail shows no bar, no dirty count,
+  and no way to save or discard. Nothing is lost (every panel stays
+  mounted, and leaving still routes through the guard), but the
+  user cannot see or act on the unsaved changes.
+  [`save-sessions.md → Save bar`](../../../../ui/patterns/save-sessions.md#save-bar--the-visible-ui)
+  does not cover the collapsed case, and its positioning rule
+  ("spans the editable pane only — never the rail or the
+  surrounding chrome") argues against the obvious fix. This slice
+  is the first that can make the session dirty, so it inherits the
+  call: lift the bar to the surface footer on phone, or accept
+  rail-state invisibility. Surfaced by M3.11 (2026-07-22).
+- **The route-to-session wiring has no test coverage.**
+  [Slice 3.11](./11-story-settings-shell.md)'s route mounts the
+  save bar on `snapshot.isDirty` and the guard dialog on
+  `pendingLeave && isFocused`, then maps their actions onto
+  `resolveLeave`. With zero registered sections none of that can
+  execute, so deleting both blocks outright passes typecheck, lint,
+  and all 1928 tests across the unit and storybook vitest
+  projects — and running the app cannot catch it either. This slice
+  is the first able to exercise the path end to end; decide whether
+  to pin the seam with a story or test that mounts the provider
+  over a fixture section and asserts the wiring. Surfaced by M3.11
+  (2026-07-22).
 
 ## Implementation notes
 

--- a/docs/implementation/milestones/03-memory-floor/slices/11-story-settings-shell.md
+++ b/docs/implementation/milestones/03-memory-floor/slices/11-story-settings-shell.md
@@ -110,7 +110,9 @@ surface. M4.4 extends this shell rather than replacing it.
 
 Resolved developer decisions and deviations worth carrying forward.
 Cross-cutting findings this slice surfaced went to
-[triage](../../../triage.md) instead.
+[triage](../../../triage.md) instead, and the ones that go live with
+the first real section consumer went to
+[Slice 3.7's Open questions](./07-suggestions.md#open-questions).
 
 - **The C7 seam is a route tab map plus a save-session context, not
   a component registry.** The contract cites the M1.5 delta-registry
@@ -144,4 +146,6 @@ Cross-cutting findings this slice surfaced went to
   a bare `router.push`, so the navigate-away guard — which wraps only
   the surface's own back path — does not intercept it. A general
   router-event interceptor was out of scope. Window-close intent is
-  likewise unwired; both sit in [triage](../../../triage.md).
+  likewise unwired; both wait on
+  [Slice 3.7](./07-suggestions.md#open-questions), the first slice
+  that can make the session dirty.

--- a/docs/implementation/milestones/03-memory-floor/slices/11-story-settings-shell.md
+++ b/docs/implementation/milestones/03-memory-floor/slices/11-story-settings-shell.md
@@ -143,6 +143,13 @@ the first real section consumer went to
   load-bearing precisely because every panel is mounted: an unvisited
   section returning its slice of settings unconditionally would write
   mount-time values back on any save.
+- **`getPatch()` runs twice per save and must stay side-effect
+  free.** Panel inputs stay live while a commit is in flight, so the
+  provider re-reads each committed section afterwards and resets only
+  those whose draft still matches what it wrote. A section the user
+  kept editing keeps its newer draft, stays dirty, and holds a
+  pending leave open — the save bar reappearing right after `Saved.`
+  is the correct reading of "that edit is not on disk yet".
 - **Accepted scope gap.** `AppActionsMenu`'s Diagnostics-Hub jump is
   a bare `router.push`, so the navigate-away guard — which wraps only
   the surface's own back path — does not intercept it. A general

--- a/docs/implementation/milestones/03-memory-floor/slices/11-story-settings-shell.md
+++ b/docs/implementation/milestones/03-memory-floor/slices/11-story-settings-shell.md
@@ -7,28 +7,29 @@
   the M2 in-story routing are merged prerequisites)
 - **Blocks:** the settings-section portions of
   [Slice 3.1b](./01b-embedder-lifecycle.md) (embedding-status
-  panel) and [Slice 3.7](./07-suggestions.md) (Composer section) —
-  partial gates; both slices' core work is independent of this
-  shell.
+  panel) and [Slice 3.7](./07-suggestions.md) (Authoring aids
+  section) — partial gates; both slices' core work is independent
+  of this shell.
 
 ## Goal
 
 A minimal Story Settings host so M3's two settings surfaces have
 somewhere to live: the route, the screen scaffold with tab /
-section structure per the canonical layout, and a
-section-registration seam (C7) that lets 3.1b and 3.7 add their
-sections without touching shared files. Added at milestone
+section structure per the canonical layout, and the C7 seam — the
+route's tab map plus the shell's save session — that 3.1b and 3.7
+hang their sections off. Added at milestone
 promotion — the audit found 3.1b and 3.7 authoring sections into a
 screen the roadmap doesn't build until M4.4.
 
 ## Background
 
-The canonical Story Settings screen is large — models, generation,
-memory, translation, pack, and calendar tabs — and its real basic
-surface is M4.4's job, with deep tabs in M7.2. M3 needs only a
-host: the staleness resolution panel canon places in Story
-Settings · Memory, and the suggestions controls canon places in
-Story Settings → Composer. This slice ships the smallest honest
+The canonical Story Settings screen is large — about, generation,
+models, memory, translation, pack, calendar, and advanced tabs —
+and its real basic surface is M4.4's job, with deep tabs in M7.2.
+M3 needs only a host: the staleness resolution panel canon places
+in Story Settings · Memory, and the suggestions controls canon
+places on the Generation tab under _Authoring aids_. This slice
+ships the smallest honest
 version of the screen — navigable route, canonical tab skeleton
 with empty-state placeholders, and a registration mechanism —
 explicitly _not_ the M4.4 surface. M4.4 extends this shell rather
@@ -58,10 +59,12 @@ than replacing it.
   empty-state placeholders for tabs M3 doesn't fill ("lands in a
   later milestone" copy), themed per foundations, mobile
   expression per the standard narrow-tier rules.
-- **Section-registration seam (C7):** each section is a
-  self-registered module (same spirit as the M1.5 delta-dispatch
-  registration — consumers touch no shared file); registration
-  names fixed in this slice's first commit.
+- **Tab map + save-session seam (C7):** the route's tab map is the
+  extension point — a consumer slice adds its section to the tab's
+  branch, mirroring how M3.1a extended App Settings. Sections join
+  the surface's save session at runtime via
+  `useStorySettingsSection`; names fixed in this slice's first
+  commit.
 - **Save plumbing floor:** whatever minimal save-session wiring the
   two M3 sections need to persist through the existing
   story-settings mutators (3.7's editor and 3.1b's panel bring
@@ -80,10 +83,10 @@ than replacing it.
 - The Story Settings route opens from an open story and renders
   the tab skeleton with empty-state placeholders on desktop and
   Android; navigation back to the reader preserves reader state.
-- A fixture section registered through C7 renders in its declared
-  tab without edits to any shared file (vitest / component test on
-  the registration, mirroring the M1.5 registration-API test
-  shape).
+- A fixture section joining the save session through
+  `useStorySettingsSection` surfaces its dirty fields in the shell's
+  single save bar, and Save / Discard reach its `getPatch` /
+  `reset` (vitest on the aggregation module).
 - Unfilled tabs show the placeholder, not blank panes; no dead
   controls.
 - Every chrome string routes through `t()`; new compounds have
@@ -98,10 +101,11 @@ than replacing it.
 
 ## Open questions
 
-- **Skeleton breadth** — render all six canonical tabs with
-  placeholders vs only the tabs M3 fills (Memory, Generation /
-  Composer). Lean minimal (two tabs) to avoid advertising dead
-  surface; confirm at planning.
+- **Skeleton breadth** — **Resolved at planning:** all eight
+  canonical tabs render, with unfilled tabs showing the
+  later-milestone placeholder. Matches App Settings, which already
+  ships its full rail with placeholders, and keeps M4.4 / M7.2 to
+  adding content rather than restructuring the rail.
 
 ## Implementation notes
 

--- a/docs/implementation/milestones/03-memory-floor/slices/11-story-settings-shell.md
+++ b/docs/implementation/milestones/03-memory-floor/slices/11-story-settings-shell.md
@@ -17,9 +17,9 @@ A minimal Story Settings host so M3's two settings surfaces have
 somewhere to live: the route, the screen scaffold with tab /
 section structure per the canonical layout, and the C7 seam — the
 route's tab map plus the shell's save session — that 3.1b and 3.7
-hang their sections off. Added at milestone
-promotion — the audit found 3.1b and 3.7 authoring sections into a
-screen the roadmap doesn't build until M4.4.
+hang their sections off. Added at milestone promotion — the audit
+found 3.1b and 3.7 authoring sections into a screen the roadmap
+doesn't build until M4.4.
 
 ## Background
 
@@ -29,11 +29,10 @@ and its real basic surface is M4.4's job, with deep tabs in M7.2.
 M3 needs only a host: the staleness resolution panel canon places
 in Story Settings · Memory, and the suggestions controls canon
 places on the Generation tab under _Authoring aids_. This slice
-ships the smallest honest
-version of the screen — navigable route, canonical tab skeleton
-with empty-state placeholders, and a registration mechanism —
-explicitly _not_ the M4.4 surface. M4.4 extends this shell rather
-than replacing it.
+ships the smallest honest version of the screen — navigable route,
+canonical tab skeleton with empty-state placeholders, and the
+save-session seam sections join — explicitly _not_ the M4.4
+surface. M4.4 extends this shell rather than replacing it.
 
 ## Required reading
 

--- a/docs/implementation/milestones/03-memory-floor/slices/11-story-settings-shell.md
+++ b/docs/implementation/milestones/03-memory-floor/slices/11-story-settings-shell.md
@@ -59,8 +59,9 @@ surface. M4.4 extends this shell rather than replacing it.
   later milestone" copy), themed per foundations, mobile
   expression per the standard narrow-tier rules.
 - **Tab map + save-session seam (C7):** the route's tab map is the
-  extension point — a consumer slice adds its section to the tab's
-  branch, mirroring how M3.1a extended App Settings. Sections join
+  extension point — `renderPanel` switches on the tab id and a
+  consumer slice introduces its own branch there, mirroring how
+  M3.1a extended App Settings. Sections join
   the surface's save session at runtime via
   `useStorySettingsSection`; names fixed in this slice's first
   commit.
@@ -145,7 +146,12 @@ the first real section consumer went to
 - **Accepted scope gap.** `AppActionsMenu`'s Diagnostics-Hub jump is
   a bare `router.push`, so the navigate-away guard — which wraps only
   the surface's own back path — does not intercept it. A general
-  router-event interceptor was out of scope. Window-close intent is
-  likewise unwired; both wait on
+  router-event interceptor was out of scope; it waits on
   [Slice 3.7](./07-suggestions.md#open-questions), the first slice
   that can make the session dirty.
+- **Window-close intent is wired.** `useUnsavedChangesGuard` raises
+  the surface's own dialog for an Electron window-close (held in the
+  main process until the user answers) and the browser's native
+  prompt for a web reload or tab close. Electron's own reload path
+  still bypasses it — queued in
+  [triage](../../../triage.md#inbox).

--- a/docs/implementation/milestones/03-memory-floor/slices/11-story-settings-shell.md
+++ b/docs/implementation/milestones/03-memory-floor/slices/11-story-settings-shell.md
@@ -108,4 +108,40 @@ surface. M4.4 extends this shell rather than replacing it.
 
 ## Implementation notes
 
-_Populated at finish: notable deviations from the plan and resolved developer decisions._
+Resolved developer decisions and deviations worth carrying forward.
+Cross-cutting findings this slice surfaced went to
+[triage](../../../triage.md) instead.
+
+- **The C7 seam is a route tab map plus a save-session context, not
+  a component registry.** The contract cites the M1.5 delta-registry
+  precedent, but App Settings — canonically the same layout
+  pattern — extends by editing its own route file, and
+  [Slice 3.1a](./01a-embedder-core.md) did exactly that to add its
+  Embedding models tab, for nine lines. A registry would have saved a
+  consumer slice roughly four lines at the price of giving the two
+  settings screens divergent extension patterns. The seam is
+  `components/story-settings/tabs.ts`: adding an id to a group
+  registers the tab, and the id union, the deep-link accept-list, and
+  each section's save-bar `order` all derive from that one structure.
+- **Story Settings saves are direct writes, with no delta and no
+  CTRL-Z**, because `stories` is absent from the tables
+  [`deltas.target_table`](../../../../data-model.md#diagram)
+  enumerates. Sections contribute patches that the shell merges into
+  exactly one `updateStorySettings` call; per-section commits would
+  strand earlier sections persisted and unrecoverable if a later one
+  failed.
+- **The shell renders every tab panel and hides the inactive ones on
+  purpose.** A section joins the save session from inside its own
+  body, so lazily mounting panels would drop a dirty section on a tab
+  switch and silently discard the draft, against the
+  one-session-per-surface rule. A later slice must not optimize this
+  into lazy mounting.
+- **`getPatch()` is gated on the section being dirty**, which is
+  load-bearing precisely because every panel is mounted: an unvisited
+  section returning its slice of settings unconditionally would write
+  mount-time values back on any save.
+- **Accepted scope gap.** `AppActionsMenu`'s Diagnostics-Hub jump is
+  a bare `router.push`, so the navigate-away guard — which wraps only
+  the surface's own back path — does not intercept it. A general
+  router-event interceptor was out of scope. Window-close intent is
+  likewise unwired; both sit in [triage](../../../triage.md).

--- a/docs/implementation/triage.md
+++ b/docs/implementation/triage.md
@@ -72,9 +72,17 @@ slice-planning gate forces its resolution before that slice is planned.
   [Slice 3.1b](./milestones/03-memory-floor/slices/01b-embedder-lifecycle.md)
   clears `embedding_swap_target` atomically at its swap phase-2 commit
   and will need an explicit affordance (a `null` sentinel, or a
-  dedicated clear action). Nullable fields are unaffected — the filter
+  dedicated clear action). The shape is already specced:
+  [`retrieval.md → Model swap UX`](../memory/retrieval.md#model-swap-ux)
+  writes that commit as
+  `UPDATE stories SET settings = jsonb_remove(settings, '$.embedding_swap_target')`.
+  Suggested shape is a `StorySettingsPatch` type distinct from
+  `Partial<StorySettings>`, widening those three keys to `T | null`
+  with `null` meaning clear and `undefined` still meaning leave
+  untouched — deliberately left to 3.1b, which owns the semantics and
+  is the only consumer. Nullable fields are unaffected — the filter
   drops only `undefined`, so `null` still writes. Surfaced by M3.11
-  Task 1 (2026-07-22).
+  Task 1 (2026-07-22), scoped to 3.1b 2026-07-22.
 - **`compositeText` space-joins fields, diverging silently from its
   spec.** `lib/db/embeddings/source-hash.ts:104` joins embedded fields
   with a space. `.impl-plans/M03-01a-embedder-core.md:187` specified
@@ -143,10 +151,14 @@ slice-planning gate forces its resolution before that slice is planned.
   overwrites the first's slot rather than both surviving, while
   `removeSection` filters _every_ match, so one section unmounting
   takes its twin's dirty state with it. The result presents as "the
-  save bar forgot my edits", not as a visible duplicate. Suggested:
-  warn on `id` collision in `__DEV__`, and give same-tab sections an
-  explicit intra-tab rank. Surfaced by M3.11 Task 4 review
-  (2026-07-22).
+  save bar forgot my edits", not as a visible duplicate. **Partly
+  closed by M3.11 review:** `attach`'s cleanup is now identity-checked,
+  so a twin unmounting no longer detaches the survivor's callbacks, and
+  `SectionDirtyState` carries `tab` rather than a raw `order`. What
+  remains is the intra-tab rank for same-tab siblings, and a `__DEV__`
+  warning on `id` collision — the shared-`id` publish slot is still
+  last-writer-wins. Surfaced by M3.11 Task 4 review (2026-07-22),
+  narrowed 2026-07-22.
 - **`save-sessions.md` overstates delta participation.**
   [`save-sessions.md → Session semantics`](../ui/patterns/save-sessions.md#session-semantics)
   says "Save commits all session changes as deltas under a single
@@ -196,34 +208,39 @@ slice-planning gate forces its resolution before that slice is planned.
   web.** `app/settings/index.tsx:119` sets `accessibilityRole="tab"`
   with `accessibilityState={{ selected }}`, but react-native-web does
   not translate that into an `aria-selected` attribute — verified, the
-  attribute is `null`. A `role="tab"` without `aria-selected` is an
-  axe `aria-required-attr` violation, and a screen reader cannot tell
-  which tab is active. M3.11's Story Settings rail was lifted from
+  attribute is `null`. This is **not** an axe finding: axe-core's
+  `tab` role lists `aria-selected` under `allowedAttrs` with no
+  `requiredAttrs`, so no rule fires. The damage is real anyway — a
+  screen reader cannot tell which tab is active, and because no
+  linter flags it the bug is invisible. M3.11's Story Settings rail was lifted from
   this JSX and adds `aria-selected={selected}` alongside (a valid RN
   prop, so it is correct on native too). App Settings still ships the
   bug and wants the same one-line fix. Surfaced by M3.11 Task 7
   (2026-07-22).
-- **`rehydrateStories`'s boolean is discarded, so a failed read
-  reads as "story missing".** The hydration effect in
-  `app/story-settings/[storyId].tsx` sets its `hydrated` flag
-  unconditionally in `.then()`, but `rehydrateStories`
-  (`lib/stores/stories/stories.ts`) logs and swallows read errors,
-  then returns `false`. On a cold entry where that read fails the
-  route shows "This story could not be loaded." across all eight
-  tabs, conflating a transient failure with a deleted story.
-  `app/reader-composer/[branchId].tsx` already models the three
-  states its own branch hydration needs — failed, still-loading,
-  empty — and is the shape to copy. Surfaced by M3.11 final review
-  (2026-07-22).
-- **The save-session context rebuilds on every snapshot change.**
-  `components/story-settings/save-session.tsx` rebuilds its `api`
-  object whenever `snapshot`, `saving`, or `pendingLeave` changes,
-  and `useStorySettingsSection` subscribes to the whole object — so
-  with every tab panel mounted by design, one section going dirty
-  re-renders every mounted section. Harmless at M3 scale (zero
-  sections today, one once 3.7 lands), but M4.4's basic surface and
-  M7.2's deep tabs fill most of the eight tabs, and the cost scales
-  with the number of registered sections. Splitting the stable
-  registration surface (`publish` / `unpublish` / `attach`) from the
-  volatile snapshot into two contexts would make that free.
-  Surfaced by M3.11 final review (2026-07-22).
+- **A settings save is not atomic against a concurrent writer.**
+  `updateStorySettings` reads `stories.settings`, merges, then writes
+  in a separate `runInTransaction` call. `stories.settings` is one
+  JSON blob, so any interleaved writer — `resetStorySettings`, a
+  second Electron window, or 3.1b's pipeline writing `effectiveDim` —
+  loses one side of the merge entirely, not just the overlapping key,
+  and both writers report success. Not fixable at the action layer as
+  the bridge stands: `runInTransaction(ops: SqlOp[])` takes only SQL
+  ops and resolves `void`, so the read cannot join the transaction and
+  a compare-and-set (`WHERE updated_at = ?`) cannot be verified
+  without a row count. Needs a bridge capability — a transaction that
+  can read, or one that returns `changes` — before the action can do
+  better. Surfaced by M3.11 review (2026-07-22).
+- **Electron reload is unguarded while a save session is dirty.**
+  M3.11 routes the desktop window-close intent through the main
+  process (`native:set-close-guard` / `native:close-requested`), so
+  closing the window raises the surface's own Save / Discard / Cancel
+  dialog. A renderer-initiated reload (Ctrl-R, devtools) does not go
+  through `win.on('close')` and so bypasses the guard, dropping the
+  session. A renderer `beforeunload` would catch it but cancels
+  **silently** under Electron — the docs are explicit that returning a
+  non-void value gives no prompt — so the naive fix trades data loss
+  for a mystery no-op. Wants either a main-process
+  `webContents.on('will-prevent-unload')` handler that shows the
+  dialog, or an in-app reload command that routes through
+  `requestLeave`. Browsers are unaffected: they get the native
+  `beforeunload` prompt. Surfaced by M3.11 review (2026-07-22).

--- a/docs/implementation/triage.md
+++ b/docs/implementation/triage.md
@@ -182,8 +182,11 @@ slice-planning gate forces its resolution before that slice is planned.
   an emergent property of how the blurred screen is frozen and
   portaled, not something the code guarantees. Same family as the
   Ctrl-Z hazard M3.11 Task 9 closed; `SaveBar` registers an equally
-  ungated Ctrl-S, inert only because no product surface mounts two
-  save bars at once yet. Not a one-liner: `useGlobalHotkey` is called
+  ungated Ctrl-S, and the trigger there is a mounted-but-blurred save
+  bar rather than two at once — with a dirty session, the Diagnostics
+  jump pushes over Story Settings and leaves one live `capture: true`
+  Ctrl-S listener behind the new screen. Not a one-liner:
+  `useGlobalHotkey` is called
   inside a shared compound that Storybook mounts with no navigator,
   and `useIsFocused` throws outside one — so focus state has to be
   threaded down as a prop from each route, or the compound needs a

--- a/docs/implementation/triage.md
+++ b/docs/implementation/triage.md
@@ -159,20 +159,6 @@ slice-planning gate forces its resolution before that slice is planned.
   sentence needs a scope qualifier. Cross-cutting (App Settings is
   equally affected), so not 3.11's to own. Surfaced by M3.11 planning
   (2026-07-22).
-- **The save-session window-close intercept is unimplemented.**
-  [`save-sessions.md → Navigate-away guard`](../ui/patterns/save-sessions.md#navigate-away-guard--global-intercept)
-  lists "window-close intent — electron window-close or the web
-  `beforeunload`" as a required intercept category, and M3.11's save
-  session anticipates it (`resolveLeave` is documented as reachable
-  directly, since a `beforeunload` handler cannot route through a
-  React modal). Nothing registers one. Inert while Story Settings has
-  zero registered sections, so it cannot be dirty; it goes live on the
-  primary platform the moment
-  [Slice 3.7](./milestones/03-memory-floor/slices/07-suggestions.md)
-  lands its authoring-aids section. Deliberately out of M3.11's
-  scope — the intercept is cross-cutting infra no surface wires today
-  and would pull a UI slice into `electron/`. Surfaced by M3.11 Task 8
-  review (2026-07-22).
 - **`AppActionsMenu`'s Ctrl-K is not focus-gated.** The reader and
   Story Settings both mount `AppActionsMenu`, and expo-router's Stack
   keeps the pushed-under screen alive — so with Story Settings open
@@ -217,3 +203,27 @@ slice-planning gate forces its resolution before that slice is planned.
   prop, so it is correct on native too). App Settings still ships the
   bug and wants the same one-line fix. Surfaced by M3.11 Task 7
   (2026-07-22).
+- **`rehydrateStories`'s boolean is discarded, so a failed read
+  reads as "story missing".** The hydration effect in
+  `app/story-settings/[storyId].tsx` sets its `hydrated` flag
+  unconditionally in `.then()`, but `rehydrateStories`
+  (`lib/stores/stories/stories.ts`) logs and swallows read errors,
+  then returns `false`. On a cold entry where that read fails the
+  route shows "This story could not be loaded." across all eight
+  tabs, conflating a transient failure with a deleted story.
+  `app/reader-composer/[branchId].tsx` already models the three
+  states its own branch hydration needs — failed, still-loading,
+  empty — and is the shape to copy. Surfaced by M3.11 final review
+  (2026-07-22).
+- **The save-session context rebuilds on every snapshot change.**
+  `components/story-settings/save-session.tsx` rebuilds its `api`
+  object whenever `snapshot`, `saving`, or `pendingLeave` changes,
+  and `useStorySettingsSection` subscribes to the whole object — so
+  with every tab panel mounted by design, one section going dirty
+  re-renders every mounted section. Harmless at M3 scale (zero
+  sections today, one once 3.7 lands), but M4.4's basic surface and
+  M7.2's deep tabs fill most of the eight tabs, and the cost scales
+  with the number of registered sections. Splitting the stable
+  registration surface (`publish` / `unpublish` / `attach`) from the
+  volatile snapshot into two contexts would make that free.
+  Surfaced by M3.11 final review (2026-07-22).

--- a/docs/implementation/triage.md
+++ b/docs/implementation/triage.md
@@ -186,12 +186,11 @@ slice-planning gate forces its resolution before that slice is planned.
   bar rather than two at once — with a dirty session, the Diagnostics
   jump pushes over Story Settings and leaves one live `capture: true`
   Ctrl-S listener behind the new screen. Not a one-liner:
-  `useGlobalHotkey` is called
-  inside a shared compound that Storybook mounts with no navigator,
-  and `useIsFocused` throws outside one — so focus state has to be
-  threaded down as a prop from each route, or the compound needs a
-  navigator-optional focus hook. Surfaced by M3.11 Task 9
-  (2026-07-22).
+  `useGlobalHotkey` is called inside a shared compound that Storybook
+  mounts with no navigator, and `useIsFocused` throws outside one — so
+  focus state has to be threaded down as a prop from each route, or the
+  compound needs a navigator-optional focus hook. Surfaced by M3.11
+  Task 9 (2026-07-22).
 - **Storybook vitest project applies no NativeWind classNames.**
   `storybookTest` in `vitest.config.ts` does not carry
   `framework.options.pluginReactOptions.jsxImportSource: 'nativewind'`

--- a/docs/implementation/triage.md
+++ b/docs/implementation/triage.md
@@ -244,3 +244,24 @@ slice-planning gate forces its resolution before that slice is planned.
   dialog, or an in-app reload command that routes through
   `requestLeave`. Browsers are unaffected: they get the native
   `beforeunload` prompt. Surfaced by M3.11 review (2026-07-22).
+- **Reloading any deep route in a packaged desktop build renders a
+  black screen.** `resolveBundlePath` in `electron/main.ts` maps a URL
+  path straight onto `dist/`, and its only fallback is a traversal
+  guard — a _missing_ file falls through to `net.fetch` on a
+  nonexistent `file://` path, which rejects. `protocol.handle` has no
+  rejection handler, so the main-frame load fails and the window shows
+  its `#000000` background. `app.json` sets web `output` to `single`,
+  so `dist/` holds one `index.html` and no per-route directories:
+  `/settings`, `/story-settings/<id>`, `/reader-composer/<id>` and
+  `/diagnostics` all miss. Dev is unaffected — `isDev` loads the Metro
+  dev server, which does its own SPA routing, so the `app://` handler
+  never runs unpackaged. Confirmed on a packaged Linux build
+  (2026-07-22): Ctrl-R on App Settings blacks out, Ctrl-R on the story
+  list reloads fine. Wants an existence check falling back to
+  `index.html` — extension sniffing breaks on dotted route params —
+  plus a rejection handler on `protocol.handle`. Distinct from the
+  unguarded-reload entry above: that one loses the session, this one
+  stops the page coming back. Pre-existing and repo-wide, not
+  introduced by M3.11, but M3.11's window-close guard would compound it
+  into a window that is also unclosable once a section can be dirty.
+  Surfaced by M3.11 review (2026-07-22).

--- a/docs/implementation/triage.md
+++ b/docs/implementation/triage.md
@@ -61,3 +61,157 @@ slice-planning gate forces its resolution before that slice is planned.
   spec doesn't model. Resolve when M7.1 plans the import flow; verify the
   native requirement rather than assuming symmetry. Surfaced by M3.1a
   device review (2026-07-21).
+- **Story settings has no unset affordance for optional keys.**
+  `updateStorySettings` ignores `undefined`-valued patch keys, so an
+  explicit `undefined` reads as "leave untouched" rather than "clear
+  this key". The three optional fields in
+  [`stories.settings`](../data-model.md#story-settings-shape) —
+  `embedding_swap_target`, `embedding_provider_id`, `effectiveDim` —
+  therefore have no clear path through the action. Nothing reads or
+  writes them today, so nothing regresses; but
+  [Slice 3.1b](./milestones/03-memory-floor/slices/01b-embedder-lifecycle.md)
+  clears `embedding_swap_target` atomically at its swap phase-2 commit
+  and will need an explicit affordance (a `null` sentinel, or a
+  dedicated clear action). Nullable fields are unaffected — the filter
+  drops only `undefined`, so `null` still writes. Surfaced by M3.11
+  Task 1 (2026-07-22).
+- **`compositeText` space-joins fields, diverging silently from its
+  spec.** `lib/db/embeddings/source-hash.ts:104` joins embedded fields
+  with a space. `.impl-plans/M03-01a-embedder-core.md:187` specified
+  `'\0'` and gave the rationale ("unambiguous separator"), but that
+  plan file carries literal NUL bytes at five sites, and its test at
+  line 179 is _named_ "single-space separator" while its assertions
+  expect NUL — the plan contradicted itself and the space won.
+  Implementation and test moved together, so the suite is green and no
+  gate can see the divergence. The obvious fear does **not**
+  materialize: `lib/embedder/service.ts:120-142` hashes the very
+  composite it embeds, so two field partitions that collide on the
+  hash also embed to an identical vector, and keeping that vector is
+  correct rather than stale. What remains is that the separator is
+  load-bearing for the _embedder_ — `['Kara Vex', 'a scout']` and
+  `['Kara', 'Vex a scout']` are one string to the model — and nothing
+  records whether that is intended. A NUL inside provider JSON is a
+  fair reason to prefer the space; if field boundaries should be
+  visible, the clean split is to hash a NUL-joined composite and embed
+  a space-joined one, which also decouples the two uses. Needs the
+  M3.1a owner. Surfaced by M3.11 Task 4 review (2026-07-22).
+- **Story Settings sections must own disjoint top-level settings
+  keys.** The save session merges each section's patch shallowly
+  (`{ ...merged, ...patch }`) and commits once, and
+  `updateStorySettings` deliberately replaces nested objects rather
+  than merging them (pinned by test). So two sections contributing
+  different parts of the SAME nested object — `translation`, `models`,
+  `retrievalBudgets`, `packVariables` — silently clobber one another,
+  and the winner is decided by `Map` insertion order, i.e. section
+  mount order, i.e. whichever tab the user opened first.
+  Non-deterministic data loss with no delta to recover it. No
+  collision exists in M3 (3.7's section owns only top-level keys), and
+  3.11 adds a `__DEV__` collision warning so the next one is loud
+  rather than silent. But the rule needs a real home before M7.2,
+  where a Translation tab section plausibly splits
+  `translation.enabled` from `translation.granularToggles`. Options:
+  enforce one-section-per-top-level-key at registration, give sections
+  a declared key-ownership manifest, or introduce a merge strategy at
+  the aggregation layer that is consistent with the action's
+  shallow-replace contract. Surfaced by M3.11 Task 5 (2026-07-22).
+- **The unsaved-changes guard lives in a single-domain folder.**
+  [`save-sessions.md → Navigate-away guard`](../ui/patterns/save-sessions.md#navigate-away-guard--global-intercept)
+  specifies the intercept as **global** — "same modal, same copy, same
+  actions across every surface that uses the save-session pattern" —
+  but M3.11 shipped `UnsavedChangesDialog` under
+  `components/story-settings/`, a single-domain folder, with its copy
+  in the `storySettings` i18n namespace. World, Plot, App Settings,
+  the Vault calendar editor, and the chapter-timeline cards all
+  inherit the same pattern and would have to reach across domains or
+  duplicate it. Taxonomy-correct home is `components/compounds/`, with
+  the four `save.unsaved*` keys moving to `common`. Deliberately
+  deferred in M3.11 rather than churning the route's import path for a
+  surface with no second consumer yet; the move is a `git mv` plus a
+  key relocation whenever the second guard lands. Surfaced by M3.11
+  Task 6 (2026-07-22).
+- **Story Settings section `id` has no uniqueness guard, and same-tab
+  siblings tie on `order`.** `save-session-state.ts` sorts sections by
+  `order`, tie-breaking on `id.localeCompare`. `order` now derives
+  from the route's tab map (`storySettingsTabOrder`), so a tab
+  insertion can no longer desync it — but two sections sharing a tab
+  still tie, and the tie-break is alphabetical by internal slug,
+  unrelated to on-screen position, so the save bar lists same-tab
+  siblings in the wrong order with nothing looking broken. Separately,
+  `id` uniqueness is an unstated invariant, and the two helpers
+  disagree about duplicates in a way that hides the symptom:
+  `upsertSection` matches with `findIndex`, so a second registrant
+  overwrites the first's slot rather than both surviving, while
+  `removeSection` filters _every_ match, so one section unmounting
+  takes its twin's dirty state with it. The result presents as "the
+  save bar forgot my edits", not as a visible duplicate. Suggested:
+  warn on `id` collision in `__DEV__`, and give same-tab sections an
+  explicit intra-tab rank. Surfaced by M3.11 Task 4 review
+  (2026-07-22).
+- **`save-sessions.md` overstates delta participation.**
+  [`save-sessions.md → Session semantics`](../ui/patterns/save-sessions.md#session-semantics)
+  says "Save commits all session changes as deltas under a single
+  shared `action_id`. CTRL-Z reverses the entire session as one step."
+  That holds for the World / Plot detail panes it was written from,
+  but not for either settings surface: `stories` and `app_settings`
+  are both absent from the twelve tables
+  [`deltas.target_table`](../data-model.md#diagram) enumerates, so
+  settings saves are direct writes with no delta and no CTRL-Z. The
+  sentence needs a scope qualifier. Cross-cutting (App Settings is
+  equally affected), so not 3.11's to own. Surfaced by M3.11 planning
+  (2026-07-22).
+- **The save-session window-close intercept is unimplemented.**
+  [`save-sessions.md → Navigate-away guard`](../ui/patterns/save-sessions.md#navigate-away-guard--global-intercept)
+  lists "window-close intent — electron window-close or the web
+  `beforeunload`" as a required intercept category, and M3.11's save
+  session anticipates it (`resolveLeave` is documented as reachable
+  directly, since a `beforeunload` handler cannot route through a
+  React modal). Nothing registers one. Inert while Story Settings has
+  zero registered sections, so it cannot be dirty; it goes live on the
+  primary platform the moment
+  [Slice 3.7](./milestones/03-memory-floor/slices/07-suggestions.md)
+  lands its authoring-aids section. Deliberately out of M3.11's
+  scope — the intercept is cross-cutting infra no surface wires today
+  and would pull a UI slice into `electron/`. Surfaced by M3.11 Task 8
+  review (2026-07-22).
+- **`AppActionsMenu`'s Ctrl-K is not focus-gated.** The reader and
+  Story Settings both mount `AppActionsMenu`, and expo-router's Stack
+  keeps the pushed-under screen alive — so with Story Settings open
+  there are two live `capture: true` Ctrl-K listeners, the reader's
+  included. Observed behaviour is benign today (only the focused
+  screen's menu paints, and one Escape closes everything), but that is
+  an emergent property of how the blurred screen is frozen and
+  portaled, not something the code guarantees. Same family as the
+  Ctrl-Z hazard M3.11 Task 9 closed; `SaveBar` registers an equally
+  ungated Ctrl-S, inert only because no product surface mounts two
+  save bars at once yet. Not a one-liner: `useGlobalHotkey` is called
+  inside a shared compound that Storybook mounts with no navigator,
+  and `useIsFocused` throws outside one — so focus state has to be
+  threaded down as a prop from each route, or the compound needs a
+  navigator-optional focus hook. Surfaced by M3.11 Task 9
+  (2026-07-22).
+- **Storybook vitest project applies no NativeWind classNames.**
+  `storybookTest` in `vitest.config.ts` does not carry
+  `framework.options.pluginReactOptions.jsxImportSource: 'nativewind'`
+  into the vitest project, so components render with `style=null` and
+  only react-native-web's own classes — no `rounded-md`, no `hidden`,
+  no theme tokens. The CSS rules are present in the loaded
+  stylesheets; nothing carries the classes. Consequence: **any story
+  assertion about styling passes vacuously under `pnpm test:run`**,
+  and the repo currently has zero style-level test coverage in CI. The
+  Storybook dev server is unaffected. Found while trying to assert
+  that an inactive tab panel is hidden — `toBeVisible()` and
+  `checkVisibility()` both passed against a panel that is
+  `display: none` in the real app. Any future visual-regression or
+  style assertion needs this fixed first. Surfaced by M3.11 Task 7
+  (2026-07-22).
+- **`accessibilityState={{ selected }}` emits no `aria-selected` on
+  web.** `app/settings/index.tsx:119` sets `accessibilityRole="tab"`
+  with `accessibilityState={{ selected }}`, but react-native-web does
+  not translate that into an `aria-selected` attribute — verified, the
+  attribute is `null`. A `role="tab"` without `aria-selected` is an
+  axe `aria-required-attr` violation, and a screen reader cannot tell
+  which tab is active. M3.11's Story Settings rail was lifted from
+  this JSX and adds `aria-selected={selected}` alongside (a valid RN
+  prop, so it is correct on native too). App Settings still ships the
+  bug and wants the same one-line fix. Surfaced by M3.11 Task 7
+  (2026-07-22).

--- a/docs/ui/patterns/save-sessions.md
+++ b/docs/ui/patterns/save-sessions.md
@@ -153,6 +153,15 @@ row-click intent; a settings surface wires route changes; both
 wire the window-close intent), but the user-visible UX is
 identical. No surface gets to skip the guard while dirty.
 
+**Window-close is the one intent that cannot always show this
+modal.** On desktop it can: Electron's main process holds the
+close, the renderer raises the normal Save / Discard / Cancel
+dialog, and confirming releases the close — `useUnsavedChangesGuard`
+wires both halves. In a browser it cannot: `beforeunload` cannot be
+resumed once the handler returns, so the only available affordance
+is the browser's own generic prompt. Surfaces get the modal
+everywhere else; this one degrades by platform, deliberately.
+
 ---
 
 ## Quick-edit exception — peek drawer

--- a/docs/ui/patterns/save-sessions.md
+++ b/docs/ui/patterns/save-sessions.md
@@ -96,11 +96,12 @@ single primitive, never a second row. The visual contract stays
 single-row across surfaces.
 
 **Positioning** — the save bar is a flex item at the bottom of the
-editable pane (after the form sections). Not sticky-positioned;
-on long forms it scrolls below the visible viewport. Sticky-
-positioning is a cross-cutting change worth its own pass if it
-becomes friction in practice; v1 stays consistent across surfaces
-with the non-sticky pattern.
+editable pane, a **sibling of the pane's scroller rather than a
+child of it**. It stays anchored to the pane's bottom edge no
+matter how long the form is, and it spans the editable pane only —
+never the rail or the surrounding chrome. Pinned by layout — the
+scroller is the flex sibling that shrinks — not by
+`position: sticky`.
 
 **Save success → toast.** On a successful save the bar disappears
 and a `toast.success` fires (`Saved.` or surface-specific copy).

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -101,10 +101,18 @@ function applyContentSecurityPolicy(): void {
   })
 }
 
-// Windows whose renderer holds unsaved work, and those that have already
-// answered the prompt and may close.
+// Windows whose renderer holds unsaved work, those that have already answered
+// the prompt and may close, and those whose close cancelled a quit.
 const closeGuards = new Set<number>()
 const confirmedCloses = new Set<number>()
+const pendingQuits = new Set<number>()
+
+// `before-quit` runs before any window's `close`, so a guard that cancels the
+// close also cancels this quit. Recorded per window so confirming resumes it.
+let quitRequested = false
+app.on('before-quit', () => {
+  quitRequested = true
+})
 
 function createWindow(): void {
   const win = new BrowserWindow({
@@ -144,11 +152,23 @@ function createWindow(): void {
     return { action: 'deny' }
   })
 
-  // Fail-open: only a renderer that has armed the guard gets asked. A renderer
-  // that never armed it, or died holding it, closes normally.
+  // A dead renderer can never answer the prompt, and preventing the close keeps
+  // `closed` from firing — so without this the window becomes unclosable and
+  // every later quit is blocked too.
+  win.webContents.on('render-process-gone', () => {
+    closeGuards.delete(win.id)
+  })
+
+  // Fail-open: only a live renderer that armed the guard gets asked.
   win.on('close', (event) => {
     if (!closeGuards.has(win.id) || confirmedCloses.has(win.id)) return
+    if (win.webContents.isDestroyed() || win.webContents.isCrashed()) return
     event.preventDefault()
+    // Assigned, not merged: a close arriving outside a quit must clear an
+    // intent left behind by a quit the user cancelled.
+    if (quitRequested) pendingQuits.add(win.id)
+    else pendingQuits.delete(win.id)
+    quitRequested = false
     win.webContents.send('native:close-requested')
   })
   win.on('closed', () => {
@@ -156,6 +176,7 @@ function createWindow(): void {
     // unrelated future window.
     closeGuards.delete(win.id)
     confirmedCloses.delete(win.id)
+    pendingQuits.delete(win.id)
   })
 
   if (isDev) {
@@ -202,7 +223,11 @@ app.whenReady().then(async () => {
     const win = BrowserWindow.fromWebContents(event.sender)
     if (win == null) return
     confirmedCloses.add(win.id)
+    // `window-all-closed` does not quit on darwin, so a Cmd-Q whose close we
+    // cancelled would otherwise leave the process running with no windows.
+    const resumeQuit = pendingQuits.delete(win.id)
     win.close()
+    if (resumeQuit) app.quit()
   })
   ipcMain.handle('db:query', (_e, sql: string, params: unknown[], method: DbProxyMethod) =>
     dbQuery(sql, params, method),

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -101,6 +101,11 @@ function applyContentSecurityPolicy(): void {
   })
 }
 
+// Windows whose renderer holds unsaved work, and those that have already
+// answered the prompt and may close.
+const closeGuards = new Set<number>()
+const confirmedCloses = new Set<number>()
+
 function createWindow(): void {
   const win = new BrowserWindow({
     width: 1280,
@@ -139,6 +144,20 @@ function createWindow(): void {
     return { action: 'deny' }
   })
 
+  // Fail-open: only a renderer that has armed the guard gets asked. A renderer
+  // that never armed it, or died holding it, closes normally.
+  win.on('close', (event) => {
+    if (!closeGuards.has(win.id) || confirmedCloses.has(win.id)) return
+    event.preventDefault()
+    win.webContents.send('native:close-requested')
+  })
+  win.on('closed', () => {
+    // Window ids are reused; a stale entry here would arm the guard on an
+    // unrelated future window.
+    closeGuards.delete(win.id)
+    confirmedCloses.delete(win.id)
+  })
+
   if (isDev) {
     win.loadURL(process.env.EXPO_WEB_URL ?? 'http://localhost:8081')
     win.webContents.openDevTools({ mode: 'detach' })
@@ -172,6 +191,18 @@ app.whenReady().then(async () => {
   })
   ipcMain.handle('native:reveal-db-file', () => {
     shell.showItemInFolder(getDbFilePath())
+  })
+  ipcMain.on('native:set-close-guard', (event, active: boolean) => {
+    const win = BrowserWindow.fromWebContents(event.sender)
+    if (win == null) return
+    if (active) closeGuards.add(win.id)
+    else closeGuards.delete(win.id)
+  })
+  ipcMain.on('native:confirm-close', (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender)
+    if (win == null) return
+    confirmedCloses.add(win.id)
+    win.close()
   })
   ipcMain.handle('db:query', (_e, sql: string, params: unknown[], method: DbProxyMethod) =>
     dbQuery(sql, params, method),

--- a/electron/native/types.ts
+++ b/electron/native/types.ts
@@ -1,0 +1,8 @@
+export type NativeApi = {
+  readonly platform: NodeJS.Platform
+  revealDbFile(): Promise<void>
+  /** Arm/disarm the window-close prompt. Disarmed windows close untouched. */
+  setCloseGuard(active: boolean): void
+  confirmClose(): void
+  onCloseRequested(cb: () => void): () => void
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -2,11 +2,11 @@ import { contextBridge, ipcRenderer } from 'electron'
 
 import type { DbBridge } from './db/types'
 import type { EmbedderBridge, EmbedderDownloadProgress } from './embedder/types'
+import type { NativeApi } from './native/types'
 
-const api = {
+const api: NativeApi = {
   platform: process.platform,
   revealDbFile: (): Promise<void> => ipcRenderer.invoke('native:reveal-db-file'),
-  /** Arm/disarm the window-close prompt. Disarmed windows close untouched. */
   setCloseGuard: (active: boolean): void => {
     ipcRenderer.send('native:set-close-guard', active)
   },
@@ -18,7 +18,7 @@ const api = {
     ipcRenderer.on('native:close-requested', listener)
     return () => ipcRenderer.removeListener('native:close-requested', listener)
   },
-} as const
+}
 
 contextBridge.exposeInMainWorld('native', api)
 
@@ -48,5 +48,3 @@ const embedderBridge: EmbedderBridge & {
 }
 
 contextBridge.exposeInMainWorld('aventurasEmbedder', embedderBridge)
-
-export type NativeApi = typeof api

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -6,6 +6,18 @@ import type { EmbedderBridge, EmbedderDownloadProgress } from './embedder/types'
 const api = {
   platform: process.platform,
   revealDbFile: (): Promise<void> => ipcRenderer.invoke('native:reveal-db-file'),
+  /** Arm/disarm the window-close prompt. Disarmed windows close untouched. */
+  setCloseGuard: (active: boolean): void => {
+    ipcRenderer.send('native:set-close-guard', active)
+  },
+  confirmClose: (): void => {
+    ipcRenderer.send('native:confirm-close')
+  },
+  onCloseRequested: (cb: () => void): (() => void) => {
+    const listener = (): void => cb()
+    ipcRenderer.on('native:close-requested', listener)
+    return () => ipcRenderer.removeListener('native:close-requested', listener)
+  },
 } as const
 
 contextBridge.exposeInMainWorld('native', api)

--- a/hooks/use-global-hotkey.ts
+++ b/hooks/use-global-hotkey.ts
@@ -14,6 +14,11 @@ type UseGlobalHotkeyOptions = {
   capture?: boolean
   stopPropagation?: boolean
   ignoreEditableTargets?: boolean
+  /**
+   * Pass a screen's focus state. A pushed-under expo-router screen stays
+   * mounted, so an ungated listener keeps firing from behind the new screen.
+   */
+  enabled?: boolean
 }
 
 export function useGlobalHotkey(
@@ -23,10 +28,11 @@ export function useGlobalHotkey(
     capture = false,
     stopPropagation = false,
     ignoreEditableTargets = false,
+    enabled = true,
   }: UseGlobalHotkeyOptions = {},
 ): void {
   useEffect(() => {
-    if (Platform.OS !== 'web') return undefined
+    if (Platform.OS !== 'web' || !enabled) return undefined
     const handler = (event: KeyboardEvent) => {
       if (event.repeat) return
       if (ignoreEditableTargets && isEditableTarget(event.target)) return
@@ -37,5 +43,5 @@ export function useGlobalHotkey(
     }
     window.addEventListener('keydown', handler, capture)
     return () => window.removeEventListener('keydown', handler, capture)
-  }, [matches, onMatch, capture, stopPropagation, ignoreEditableTargets])
+  }, [matches, onMatch, capture, stopPropagation, ignoreEditableTargets, enabled])
 }

--- a/hooks/use-master-detail-back.ts
+++ b/hooks/use-master-detail-back.ts
@@ -1,6 +1,6 @@
 import { useFocusEffect } from 'expo-router'
 import { useCallback, useRef } from 'react'
-import { BackHandler } from 'react-native'
+import { BackHandler, Platform } from 'react-native'
 
 /**
  * Android hardware-back for a master-detail surface. While `canCollapse` is
@@ -8,8 +8,9 @@ import { BackHandler } from 'react-native'
  * falls through to the default route-pop. Pass "detail is open" for the plain
  * phone case, or a constant `true` where the surface must own every back —
  * a route guarding unsaved changes has to intercept on tablet / desktop too,
- * where no collapse state exists. Inert off Android: Expo's web build shims
- * `BackHandler` to a no-op.
+ * where no collapse state exists. Android-only: RN-Web's `BackHandler` shim
+ * console.errors on every subscribe, so the platform check gates the listener
+ * rather than the handler.
  *
  * Lives in a route-level hook rather than in `MasterDetailLayout` because
  * `useFocusEffect` needs a navigation context, and the shell renders in
@@ -23,6 +24,7 @@ export function useMasterDetailBack(canCollapse: boolean, onCollapse: () => void
 
   useFocusEffect(
     useCallback(() => {
+      if (Platform.OS !== 'android') return undefined
       const onHardwareBack = () => {
         if (!canCollapse) return false
         onCollapseRef.current()

--- a/hooks/use-master-detail-back.ts
+++ b/hooks/use-master-detail-back.ts
@@ -3,10 +3,13 @@ import { useCallback, useRef } from 'react'
 import { BackHandler } from 'react-native'
 
 /**
- * Android hardware-back for a phone master-detail surface: while a row is
- * selected (detail open), back collapses to the list instead of exiting the
- * route; otherwise it falls through to the default route-pop. No-op on
- * tablet / desktop (pass `canCollapse: false`).
+ * Android hardware-back for a master-detail surface. While `canCollapse` is
+ * true the handler runs `onCollapse` and swallows the event; while false it
+ * falls through to the default route-pop. Pass "detail is open" for the plain
+ * phone case, or a constant `true` where the surface must own every back —
+ * a route guarding unsaved changes has to intercept on tablet / desktop too,
+ * where no collapse state exists. Inert off Android: Expo's web build shims
+ * `BackHandler` to a no-op.
  *
  * Lives in a route-level hook rather than in `MasterDetailLayout` because
  * `useFocusEffect` needs a navigation context, and the shell renders in

--- a/hooks/use-unsaved-changes-guard.test.tsx
+++ b/hooks/use-unsaved-changes-guard.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useUnsavedChangesGuard } from './use-unsaved-changes-guard'
+
+type Listener = () => void
+
+function stubBridge() {
+  const listeners = new Set<Listener>()
+  const bridge = {
+    platform: 'linux' as NodeJS.Platform,
+    revealDbFile: vi.fn(() => Promise.resolve()),
+    setCloseGuard: vi.fn(),
+    confirmClose: vi.fn(),
+    onCloseRequested: vi.fn((cb: Listener) => {
+      listeners.add(cb)
+      return () => listeners.delete(cb)
+    }),
+  }
+  window.native = bridge
+  return {
+    ...bridge,
+    requestClose: () => listeners.forEach((cb) => cb()),
+    get armed() {
+      const calls = bridge.setCloseGuard.mock.calls
+      return calls.length > 0 ? calls[calls.length - 1][0] : undefined
+    },
+  }
+}
+
+function Guard({ dirty, requestLeave }: { dirty: boolean; requestLeave: (p: () => void) => void }) {
+  useUnsavedChangesGuard(dirty, requestLeave)
+  return null
+}
+
+afterEach(() => {
+  cleanup()
+  delete window.native
+  vi.restoreAllMocks()
+})
+
+describe('useUnsavedChangesGuard', () => {
+  it('arms the window guard only while a surface is dirty', () => {
+    const bridge = stubBridge()
+    const view = render(<Guard dirty={false} requestLeave={vi.fn()} />)
+    expect(bridge.armed).toBe(false)
+
+    view.rerender(<Guard dirty requestLeave={vi.fn()} />)
+    expect(bridge.armed).toBe(true)
+
+    view.rerender(<Guard dirty={false} requestLeave={vi.fn()} />)
+    expect(bridge.armed).toBe(false)
+  })
+
+  // expo-router keeps a pushed-under screen mounted, so two surfaces can hold
+  // the guard at once. `setCloseGuard` is one boolean per window, so a clean
+  // second surface used to disarm a first that still had unsaved work.
+  it('stays armed while another surface is still dirty', () => {
+    const bridge = stubBridge()
+    const view = render(
+      <>
+        <Guard dirty requestLeave={vi.fn()} />
+        <Guard dirty requestLeave={vi.fn()} />
+      </>,
+    )
+    expect(bridge.armed).toBe(true)
+
+    view.rerender(
+      <>
+        <Guard dirty requestLeave={vi.fn()} />
+        <Guard dirty={false} requestLeave={vi.fn()} />
+      </>,
+    )
+    expect(bridge.armed).toBe(true)
+  })
+
+  it('asks every dirty surface before confirming the close', () => {
+    const bridge = stubBridge()
+    const first = vi.fn((proceed: () => void) => proceed())
+    const second = vi.fn((proceed: () => void) => proceed())
+    render(
+      <>
+        <Guard dirty requestLeave={first} />
+        <Guard dirty requestLeave={second} />
+      </>,
+    )
+
+    bridge.requestClose()
+
+    expect(first).toHaveBeenCalledTimes(1)
+    expect(second).toHaveBeenCalledTimes(1)
+    expect(bridge.confirmClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves the window open when a surface cancels', () => {
+    const bridge = stubBridge()
+    const cancels = vi.fn(() => {})
+    const later = vi.fn((proceed: () => void) => proceed())
+    render(
+      <>
+        <Guard dirty requestLeave={cancels} />
+        <Guard dirty requestLeave={later} />
+      </>,
+    )
+
+    bridge.requestClose()
+
+    expect(cancels).toHaveBeenCalledTimes(1)
+    expect(later).not.toHaveBeenCalled()
+    expect(bridge.confirmClose).not.toHaveBeenCalled()
+    expect(bridge.armed).toBe(true)
+  })
+
+  it('falls back to beforeunload when no desktop bridge is present', () => {
+    const add = vi.spyOn(window, 'addEventListener')
+    render(<Guard dirty requestLeave={vi.fn()} />)
+
+    expect(add).toHaveBeenCalledWith('beforeunload', expect.any(Function))
+  })
+})

--- a/hooks/use-unsaved-changes-guard.ts
+++ b/hooks/use-unsaved-changes-guard.ts
@@ -21,21 +21,55 @@ function closeBridge(): CloseBridge | null {
   return native
 }
 
+type LeaveRequest = (proceed: () => void) => void
+
+// `setCloseGuard` is one boolean per window, so it can't be a per-surface
+// claim: expo-router keeps a pushed-under screen mounted, and a second surface
+// mounting clean would otherwise disarm a first that is still dirty. This set
+// is the source of truth and the bridge only mirrors whether it is empty.
+const armed = new Set<{ current: LeaveRequest }>()
+let unsubscribe: (() => void) | null = null
+
+function askEach(native: CloseBridge): void {
+  // Snapshot: a surface goes clean and drops out of `armed` as it answers, so
+  // iterating the live set would skip whoever follows it.
+  const queue = [...armed]
+  const step = (index: number): void => {
+    if (index >= queue.length) {
+      native.confirmClose()
+      return
+    }
+    // Cancel is the absence of a call: a surface that never runs `proceed`
+    // stops the chain here, leaving the close prevented and the guard armed.
+    queue[index].current(() => step(index + 1))
+  }
+  step(0)
+}
+
+function syncBridge(native: CloseBridge): void {
+  if (armed.size > 0) {
+    native.setCloseGuard(true)
+    unsubscribe ??= native.onCloseRequested(() => askEach(native))
+    return
+  }
+  native.setCloseGuard(false)
+  unsubscribe?.()
+  unsubscribe = null
+}
+
 /**
  * Extends a surface's unsaved-changes guard to the window itself.
  *
- * On Electron the main process holds the close until `requestLeave` resolves,
- * so the user gets the surface's own Save / Discard / Cancel dialog. In a
- * browser `beforeunload` cannot be resumed once it returns, so the guard can
- * only raise the browser's native prompt — `requestLeave` never runs there.
+ * On Electron the main process holds the close until every dirty surface has
+ * run the callback it is handed, so the user answers each surface's own Save /
+ * Discard / Cancel dialog in turn. In a browser `beforeunload` cannot be
+ * resumed once it returns, so the guard can only raise the browser's native
+ * prompt — `requestLeave` never runs there.
  *
  * @param dirty - Whether the surface currently holds unsaved work.
  * @param requestLeave - Runs its argument once the user confirms leaving.
  */
-export function useUnsavedChangesGuard(
-  dirty: boolean,
-  requestLeave: (proceed: () => void) => void,
-): void {
+export function useUnsavedChangesGuard(dirty: boolean, requestLeave: LeaveRequest): void {
   const requestLeaveRef = useRef(requestLeave)
   requestLeaveRef.current = requestLeave
 
@@ -44,14 +78,18 @@ export function useUnsavedChangesGuard(
 
     const native = closeBridge()
     if (native != null) {
-      native.setCloseGuard(dirty)
-      if (!dirty) return undefined
-      const off = native.onCloseRequested(() => {
-        requestLeaveRef.current(() => native.confirmClose())
-      })
+      if (!dirty) {
+        // Still syncs: a reload leaves the main process holding a guard armed
+        // by the previous renderer, with no listener behind it.
+        syncBridge(native)
+        return undefined
+      }
+      const entry = requestLeaveRef
+      armed.add(entry)
+      syncBridge(native)
       return () => {
-        off()
-        native.setCloseGuard(false)
+        armed.delete(entry)
+        syncBridge(native)
       }
     }
 

--- a/hooks/use-unsaved-changes-guard.ts
+++ b/hooks/use-unsaved-changes-guard.ts
@@ -1,15 +1,16 @@
 import { useEffect, useRef } from 'react'
 import { Platform } from 'react-native'
 
-type CloseBridge = {
-  setCloseGuard: (active: boolean) => void
-  confirmClose: () => void
-  onCloseRequested: (cb: () => void) => () => void
-}
+import type { NativeApi } from '@/types/native'
 
+type CloseBridge = Pick<NativeApi, 'setCloseGuard' | 'confirmClose' | 'onCloseRequested'>
+
+// The declared type says nothing about what the running preload exposes: the
+// web build has no `window.native` at all, and an older desktop shell can be
+// missing methods this build expects. Probe before trusting it.
 function closeBridge(): CloseBridge | null {
   if (Platform.OS !== 'web' || typeof window === 'undefined') return null
-  const native = (window as { native?: Partial<CloseBridge> }).native
+  const native = window.native
   if (
     typeof native?.setCloseGuard !== 'function' ||
     typeof native.confirmClose !== 'function' ||
@@ -17,7 +18,7 @@ function closeBridge(): CloseBridge | null {
   ) {
     return null
   }
-  return native as CloseBridge
+  return native
 }
 
 /**

--- a/hooks/use-unsaved-changes-guard.ts
+++ b/hooks/use-unsaved-changes-guard.ts
@@ -1,0 +1,64 @@
+import { useEffect, useRef } from 'react'
+import { Platform } from 'react-native'
+
+type CloseBridge = {
+  setCloseGuard: (active: boolean) => void
+  confirmClose: () => void
+  onCloseRequested: (cb: () => void) => () => void
+}
+
+function closeBridge(): CloseBridge | null {
+  if (Platform.OS !== 'web' || typeof window === 'undefined') return null
+  const native = (window as { native?: Partial<CloseBridge> }).native
+  if (
+    typeof native?.setCloseGuard !== 'function' ||
+    typeof native.confirmClose !== 'function' ||
+    typeof native.onCloseRequested !== 'function'
+  ) {
+    return null
+  }
+  return native as CloseBridge
+}
+
+/**
+ * Extends a surface's unsaved-changes guard to the window itself.
+ *
+ * On Electron the main process holds the close until `requestLeave` resolves,
+ * so the user gets the surface's own Save / Discard / Cancel dialog. In a
+ * browser `beforeunload` cannot be resumed once it returns, so the guard can
+ * only raise the browser's native prompt — `requestLeave` never runs there.
+ *
+ * @param dirty - Whether the surface currently holds unsaved work.
+ * @param requestLeave - Runs its argument once the user confirms leaving.
+ */
+export function useUnsavedChangesGuard(
+  dirty: boolean,
+  requestLeave: (proceed: () => void) => void,
+): void {
+  const requestLeaveRef = useRef(requestLeave)
+  requestLeaveRef.current = requestLeave
+
+  useEffect(() => {
+    if (Platform.OS !== 'web' || typeof window === 'undefined') return undefined
+
+    const native = closeBridge()
+    if (native != null) {
+      native.setCloseGuard(dirty)
+      if (!dirty) return undefined
+      const off = native.onCloseRequested(() => {
+        requestLeaveRef.current(() => native.confirmClose())
+      })
+      return () => {
+        off()
+        native.setCloseGuard(false)
+      }
+    }
+
+    if (!dirty) return undefined
+    const onBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault()
+    }
+    window.addEventListener('beforeunload', onBeforeUnload)
+    return () => window.removeEventListener('beforeunload', onBeforeUnload)
+  }, [dirty])
+}

--- a/lib/actions/index.ts
+++ b/lib/actions/index.ts
@@ -23,6 +23,7 @@ export type { SettingsActionCtx } from './settings'
 export { createStoryWithBranch, type CreateStoryInput } from './stories/create-story'
 export { deleteStory } from './stories/delete-story'
 export { resetStorySettings } from './stories/reset-settings'
+export { updateStorySettings } from './stories/update-story-settings'
 export {
   loadOpenStory,
   openStory,

--- a/lib/actions/index.ts
+++ b/lib/actions/index.ts
@@ -23,7 +23,7 @@ export type { SettingsActionCtx } from './settings'
 export { createStoryWithBranch, type CreateStoryInput } from './stories/create-story'
 export { deleteStory } from './stories/delete-story'
 export { resetStorySettings } from './stories/reset-settings'
-export { updateStorySettings } from './stories/update-story-settings'
+export { StorySettingsStaleStoreError, updateStorySettings } from './stories/update-story-settings'
 export {
   loadOpenStory,
   openStory,

--- a/lib/actions/stories/update-story-settings.test.ts
+++ b/lib/actions/stories/update-story-settings.test.ts
@@ -5,7 +5,7 @@ import { branches, buildStorySettings, stories, storyDefinitionSchema } from '@/
 import { createTestDb } from '@/lib/db/__tests__/test-db'
 import { currentStoryStore, resetAllStores, storiesStore } from '@/lib/stores'
 
-import { updateStorySettings } from './update-story-settings'
+import { StorySettingsStaleStoreError, updateStorySettings } from './update-story-settings'
 
 const STORY_DEFINITION = storyDefinitionSchema.parse({
   mode: 'adventure',
@@ -180,5 +180,64 @@ describe('updateStorySettings', () => {
 
     const [row] = await db.select().from(stories).where(eq(stories.id, 'story_1'))
     expect(row.updatedAt).toBe(1)
+  })
+
+  // Zod strips unknown keys, so without an explicit check a typo'd key reports
+  // a successful save that wrote nothing.
+  it('rejects an unknown key by name instead of silently dropping it', async () => {
+    const { db, runInTransaction } = await seed()
+
+    await expect(
+      updateStorySettings('story_1', { suggestionCoutn: 4 } as never, { db, runInTransaction }, 99),
+    ).rejects.toThrow('suggestionCoutn')
+
+    const [row] = await db.select().from(stories).where(eq(stories.id, 'story_1'))
+    expect(row.updatedAt).toBe(1)
+  })
+
+  it('flags the story for repair when the stored settings are unreadable', async () => {
+    const { db, sqlite, runInTransaction } = await seed()
+    sqlite.exec(`UPDATE stories SET settings = NULL WHERE id = 'story_1'`)
+
+    await expect(
+      updateStorySettings('story_1', { suggestionCount: 2 }, { db, runInTransaction }, 99),
+    ).rejects.toThrow()
+
+    expect(storiesStore.getStories().openFailures.story_1).toBe('settings-corrupt')
+  })
+
+  it('reports a stale store distinctly from a failed save', async () => {
+    const { db, runInTransaction, settings } = await seed()
+    // The write lands, then rehydrateStories' re-read fails — the user must
+    // not be told their changes were lost. The action's own select is the
+    // first; the store's re-read is the second.
+    let selects = 0
+    const brokenDb = new Proxy(db, {
+      get(target, prop) {
+        const value = Reflect.get(target, prop) as unknown
+        if (prop !== 'select' || typeof value !== 'function') {
+          return typeof value === 'function' ? value.bind(target) : value
+        }
+        return (...args: unknown[]) => {
+          selects += 1
+          if (selects > 1) throw new Error('read failed')
+          return (value as (...a: unknown[]) => unknown).apply(target, args)
+        }
+      },
+    })
+
+    await expect(
+      updateStorySettings(
+        'story_1',
+        { suggestionCount: 2 },
+        { db: brokenDb, runInTransaction },
+        99,
+      ),
+    ).rejects.toBeInstanceOf(StorySettingsStaleStoreError)
+
+    const [row] = await db.select().from(stories).where(eq(stories.id, 'story_1'))
+    expect(row.settings?.suggestionCount).toBe(2)
+    expect(row.updatedAt).toBe(99)
+    expect(settings.suggestionCount).toBe(6)
   })
 })

--- a/lib/actions/stories/update-story-settings.test.ts
+++ b/lib/actions/stories/update-story-settings.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 
 import { branches, buildStorySettings, stories, storyDefinitionSchema } from '@/lib/db'
 import { createTestDb } from '@/lib/db/__tests__/test-db'
-import { currentStoryStore, resetAllStores } from '@/lib/stores'
+import { currentStoryStore, resetAllStores, storiesStore } from '@/lib/stores'
 
 import { updateStorySettings } from './update-story-settings'
 
@@ -22,9 +22,20 @@ afterEach(() => {
   resetAllStores()
 })
 
+// classifierCadence and suggestionCount must stay different from
+// STORY_SETTINGS_DEFAULTS (5 and 3): the merge assertions can only tell a
+// preserved value from a re-defaulted one while those differ.
 async function seed() {
-  const { db, runInTransaction } = await createTestDb()
-  const settings = buildStorySettings({ classifierCadence: 2, suggestionCount: 6 }, 'embed-a', null)
+  const { db, sqlite, runInTransaction } = await createTestDb()
+  const settings = buildStorySettings(
+    {
+      classifierCadence: 2,
+      suggestionCount: 6,
+      models: { narrative: 'model-a', classifier: 'model-b' },
+    },
+    'embed-a',
+    null,
+  )
   await db.insert(stories).values({
     id: 'story_1',
     title: 'Aria',
@@ -38,7 +49,7 @@ async function seed() {
   await db
     .insert(branches)
     .values({ id: 'branch_1', storyId: 'story_1', name: 'main', createdAt: 1 })
-  return { db, runInTransaction, settings }
+  return { db, sqlite, runInTransaction, settings }
 }
 
 describe('updateStorySettings', () => {
@@ -60,6 +71,24 @@ describe('updateStorySettings', () => {
     expect(row.settings?.suggestionCount).toBe(5)
     expect(row.settings?.classifierCadence).toBe(2)
     expect(row.updatedAt).toBe(99)
+
+    const mirrored = storiesStore.getStories().rows.find((r) => r.id === 'story_1')
+    expect(mirrored?.settings?.suggestionCount).toBe(5)
+    expect(mirrored?.updatedAt).toBe(99)
+  })
+
+  it('replaces nested objects wholesale rather than merging them', async () => {
+    const { db, runInTransaction, settings } = await seed()
+    expect(settings.models).toEqual({ narrative: 'model-a', classifier: 'model-b' })
+
+    const next = await updateStorySettings(
+      'story_1',
+      { models: { narrative: 'model-c' } },
+      { db, runInTransaction },
+      99,
+    )
+
+    expect(next.models).toEqual({ narrative: 'model-c' })
   })
 
   it('refreshes currentStoryStore when the updated story is open', async () => {
@@ -114,6 +143,19 @@ describe('updateStorySettings', () => {
 
     const [row] = await db.select().from(stories).where(eq(stories.id, 'story_1'))
     expect(row.settings?.suggestionCount).toBe(6)
+  })
+
+  it('rejects rather than self-heals when the stored settings are corrupt', async () => {
+    const { db, sqlite, runInTransaction, settings } = await seed()
+    const corrupt = JSON.stringify({ ...settings, classifierCadence: 'broken' })
+    sqlite.exec(`UPDATE stories SET settings = '${corrupt}' WHERE id = 'story_1'`)
+
+    await expect(
+      updateStorySettings('story_1', { classifierCadence: 7 }, { db, runInTransaction }, 99),
+    ).rejects.toThrow()
+
+    const [row] = await db.select().from(stories).where(eq(stories.id, 'story_1'))
+    expect(row.updatedAt).toBe(1)
   })
 
   it('throws for an unknown story', async () => {

--- a/lib/actions/stories/update-story-settings.test.ts
+++ b/lib/actions/stories/update-story-settings.test.ts
@@ -195,6 +195,22 @@ describe('updateStorySettings', () => {
     expect(row.updatedAt).toBe(1)
   })
 
+  // `key in shape` passes for every Object.prototype member, so these reached
+  // zod, were stripped, and reported a successful save that wrote nothing.
+  it.each(['constructor', 'toString', 'valueOf', 'hasOwnProperty'])(
+    'rejects the prototype key %s instead of silently dropping it',
+    async (key) => {
+      const { db, runInTransaction } = await seed()
+
+      await expect(
+        updateStorySettings('story_1', { [key]: 'x' } as never, { db, runInTransaction }, 99),
+      ).rejects.toThrow(key)
+
+      const [row] = await db.select().from(stories).where(eq(stories.id, 'story_1'))
+      expect(row.updatedAt).toBe(1)
+    },
+  )
+
   it('flags the story for repair when the stored settings are unreadable', async () => {
     const { db, sqlite, runInTransaction } = await seed()
     sqlite.exec(`UPDATE stories SET settings = NULL WHERE id = 'story_1'`)

--- a/lib/actions/stories/update-story-settings.test.ts
+++ b/lib/actions/stories/update-story-settings.test.ts
@@ -23,8 +23,8 @@ afterEach(() => {
 })
 
 async function seed() {
-  const { db, sqlite, runInTransaction } = await createTestDb()
-  const settings = buildStorySettings({ classifierCadence: 2 }, 'embed-a', null)
+  const { db, runInTransaction } = await createTestDb()
+  const settings = buildStorySettings({ classifierCadence: 2, suggestionCount: 6 }, 'embed-a', null)
   await db.insert(stories).values({
     id: 'story_1',
     title: 'Aria',
@@ -38,7 +38,7 @@ async function seed() {
   await db
     .insert(branches)
     .values({ id: 'branch_1', storyId: 'story_1', name: 'main', createdAt: 1 })
-  return { db, sqlite, runInTransaction, settings }
+  return { db, runInTransaction, settings }
 }
 
 describe('updateStorySettings', () => {
@@ -90,12 +90,30 @@ describe('updateStorySettings', () => {
       settings,
     })
 
-    await updateStorySettings('story_1', { suggestionCount: 6 }, { db, runInTransaction }, 99)
+    await updateStorySettings('story_1', { suggestionCount: 4 }, { db, runInTransaction }, 99)
 
     expect(currentStoryStore.getCurrentStory()?.storyId).toBe('story_other')
     expect(currentStoryStore.getCurrentStory()?.settings.suggestionCount).toBe(
       settings.suggestionCount,
     )
+  })
+
+  it('treats an undefined-valued key as untouched rather than a reset to default', async () => {
+    const { db, runInTransaction, settings } = await seed()
+    expect(settings.suggestionCount).toBe(6)
+
+    const next = await updateStorySettings(
+      'story_1',
+      { suggestionCount: undefined, piggybackMode: 'on' },
+      { db, runInTransaction },
+      99,
+    )
+
+    expect(next.suggestionCount).toBe(6)
+    expect(next.piggybackMode).toBe('on')
+
+    const [row] = await db.select().from(stories).where(eq(stories.id, 'story_1'))
+    expect(row.settings?.suggestionCount).toBe(6)
   })
 
   it('throws for an unknown story', async () => {

--- a/lib/actions/stories/update-story-settings.test.ts
+++ b/lib/actions/stories/update-story-settings.test.ts
@@ -1,0 +1,124 @@
+import { eq } from 'drizzle-orm'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { branches, buildStorySettings, stories, storyDefinitionSchema } from '@/lib/db'
+import { createTestDb } from '@/lib/db/__tests__/test-db'
+import { currentStoryStore, resetAllStores } from '@/lib/stores'
+
+import { updateStorySettings } from './update-story-settings'
+
+const STORY_DEFINITION = storyDefinitionSchema.parse({
+  mode: 'adventure',
+  leadEntityId: 'entity_1',
+  narration: 'third',
+  genre: { label: 'Fantasy', promptBody: 'high fantasy' },
+  tone: { label: 'Wry', promptBody: 'wry' },
+  setting: 'A keep on a hill.',
+  calendarSystemId: 'gregorian',
+  worldTimeOrigin: { year: 0 },
+})
+
+afterEach(() => {
+  resetAllStores()
+})
+
+async function seed() {
+  const { db, sqlite, runInTransaction } = await createTestDb()
+  const settings = buildStorySettings({ classifierCadence: 2 }, 'embed-a', null)
+  await db.insert(stories).values({
+    id: 'story_1',
+    title: 'Aria',
+    status: 'active',
+    currentBranchId: 'branch_1',
+    definition: STORY_DEFINITION,
+    settings,
+    createdAt: 1,
+    updatedAt: 1,
+  })
+  await db
+    .insert(branches)
+    .values({ id: 'branch_1', storyId: 'story_1', name: 'main', createdAt: 1 })
+  return { db, sqlite, runInTransaction, settings }
+}
+
+describe('updateStorySettings', () => {
+  it('merges the patch without clobbering sibling fields', async () => {
+    const { db, runInTransaction, settings } = await seed()
+
+    const next = await updateStorySettings(
+      'story_1',
+      { suggestionCount: 5 },
+      { db, runInTransaction },
+      99,
+    )
+
+    expect(next.suggestionCount).toBe(5)
+    expect(next.classifierCadence).toBe(2)
+    expect(next.embedding_model_id).toBe(settings.embedding_model_id)
+
+    const [row] = await db.select().from(stories).where(eq(stories.id, 'story_1'))
+    expect(row.settings?.suggestionCount).toBe(5)
+    expect(row.settings?.classifierCadence).toBe(2)
+    expect(row.updatedAt).toBe(99)
+  })
+
+  it('refreshes currentStoryStore when the updated story is open', async () => {
+    const { db, runInTransaction, settings } = await seed()
+    currentStoryStore.set({
+      storyId: 'story_1',
+      branchId: 'branch_1',
+      definition: STORY_DEFINITION,
+      settings,
+    })
+
+    expect(settings.suggestionsEnabled).toBe(false)
+
+    await updateStorySettings('story_1', { suggestionsEnabled: true }, { db, runInTransaction }, 99)
+
+    expect(currentStoryStore.getCurrentStory()?.settings.suggestionsEnabled).toBe(true)
+    expect(currentStoryStore.getCurrentStory()?.settings.classifierCadence).toBe(2)
+    expect(currentStoryStore.getCurrentStory()?.branchId).toBe('branch_1')
+    expect(currentStoryStore.getCurrentStory()?.definition).toEqual(STORY_DEFINITION)
+  })
+
+  it('leaves currentStoryStore alone when a different story is open', async () => {
+    const { db, runInTransaction, settings } = await seed()
+    currentStoryStore.set({
+      storyId: 'story_other',
+      branchId: 'branch_other',
+      definition: STORY_DEFINITION,
+      settings,
+    })
+
+    await updateStorySettings('story_1', { suggestionCount: 6 }, { db, runInTransaction }, 99)
+
+    expect(currentStoryStore.getCurrentStory()?.storyId).toBe('story_other')
+    expect(currentStoryStore.getCurrentStory()?.settings.suggestionCount).toBe(
+      settings.suggestionCount,
+    )
+  })
+
+  it('throws for an unknown story', async () => {
+    const { db, runInTransaction } = await seed()
+
+    await expect(
+      updateStorySettings('story_missing', { suggestionCount: 2 }, { db, runInTransaction }, 99),
+    ).rejects.toThrow('Story not found')
+  })
+
+  it('rejects an invalid patch without writing', async () => {
+    const { db, runInTransaction } = await seed()
+
+    await expect(
+      updateStorySettings(
+        'story_1',
+        { suggestionCount: 'lots' } as never,
+        { db, runInTransaction },
+        99,
+      ),
+    ).rejects.toThrow()
+
+    const [row] = await db.select().from(stories).where(eq(stories.id, 'story_1'))
+    expect(row.updatedAt).toBe(1)
+  })
+})

--- a/lib/actions/stories/update-story-settings.ts
+++ b/lib/actions/stories/update-story-settings.ts
@@ -1,17 +1,35 @@
 import { eq } from 'drizzle-orm'
 
-import { stories, storySettingsSchema, type DbCtx, type StorySettings } from '@/lib/db'
-import { currentStoryStore, rehydrateStories } from '@/lib/stores'
+import {
+  stories,
+  storySettingsPartialSchema,
+  storySettingsSchema,
+  type DbCtx,
+  type StorySettings,
+} from '@/lib/db'
+import { currentStoryStore, rehydrateStories, storiesStore } from '@/lib/stores'
+
+/**
+ * The write landed but the store could not be re-read, so every rendered copy
+ * of these settings is stale. Distinct from a failed save: the caller must not
+ * tell the user their changes were lost.
+ */
+export class StorySettingsStaleStoreError extends Error {
+  constructor() {
+    super('Story settings were saved but the store could not be refreshed')
+    this.name = 'StorySettingsStaleStoreError'
+  }
+}
 
 // `stories` is absent from deltas.target_table, so a settings save is a direct
 // write: no delta row, no CTRL-Z reversal.
-// See data-model.md → Diagram, the deltas entity.
+// See docs/data-model.md#diagram (deltas).
 /**
- * @param patch - Shallow-merged onto the stored settings. Nested objects
- * (`models`, `packVariables`, `translation`) are replaced, not merged; a key
- * whose value is `undefined` is left untouched. Pass only the changed keys —
- * spreading a whole settings object in discards any concurrent write that the
- * read picked up.
+ * @param patch - Shallow-merged onto the stored settings. Every value is
+ * replaced wholesale, nested objects and arrays included; a key whose value is
+ * `undefined` is left untouched. Pass only the changed keys — spreading a whole
+ * settings object in discards any concurrent write that the read picked up.
+ * Unknown keys reject rather than being silently dropped.
  */
 export async function updateStorySettings(
   storyId: string,
@@ -19,18 +37,35 @@ export async function updateStorySettings(
   ctx: DbCtx,
   nowMs: number = Date.now(),
 ): Promise<StorySettings> {
+  // Explicit `undefined` typechecks without exactOptionalPropertyTypes, and
+  // spreading it in would trip zod's defaults instead of leaving the key alone.
+  const changed = Object.fromEntries(
+    Object.entries(patch).filter(([, value]) => value !== undefined),
+  )
+  // `Partial<StorySettings>` is a compile-time claim only, and zod strips
+  // unknown keys — without this a typo'd key reports a successful save that
+  // wrote nothing.
+  const unknownKeys = Object.keys(changed).filter((key) => !(key in storySettingsSchema.shape))
+  if (unknownKeys.length > 0) {
+    throw new Error(`Unknown story-settings key(s): ${unknownKeys.join(', ')}`)
+  }
+  const validated = storySettingsPartialSchema.parse(changed)
+
   const [row] = await ctx.db
     .select({ settings: stories.settings })
     .from(stories)
     .where(eq(stories.id, storyId))
   if (!row) throw new Error('Story not found')
 
-  const settings = storySettingsSchema.parse({
-    ...storySettingsSchema.parse(row.settings),
-    // Explicit `undefined` typechecks without exactOptionalPropertyTypes, and
-    // spreading it in would trip zod's defaults instead of leaving the key alone.
-    ...Object.fromEntries(Object.entries(patch).filter(([, value]) => value !== undefined)),
-  })
+  const stored = storySettingsSchema.safeParse(row.settings)
+  if (!stored.success) {
+    // Surfaces the repair affordance `resetStorySettings` clears, rather than
+    // dead-ending on a generic save error every retry reproduces.
+    storiesStore.setOpenFailure({ storyId, kind: 'settings-corrupt' })
+    throw new Error('Story settings could not be read', { cause: stored.error })
+  }
+
+  const settings = storySettingsSchema.parse({ ...stored.data, ...validated })
 
   await ctx.runInTransaction([
     ctx.db
@@ -40,7 +75,9 @@ export async function updateStorySettings(
       .toSQL(),
   ])
 
-  await rehydrateStories(ctx.db)
+  // `rehydrateStories` swallows its own failure, so an unchecked call leaves
+  // the store showing pre-save values while reporting a clean save.
+  if (!(await rehydrateStories(ctx.db))) throw new StorySettingsStaleStoreError()
   const open = currentStoryStore.getCurrentStory()
   if (open?.storyId === storyId) currentStoryStore.set({ ...open, settings })
   return settings

--- a/lib/actions/stories/update-story-settings.ts
+++ b/lib/actions/stories/update-story-settings.ts
@@ -45,7 +45,11 @@ export async function updateStorySettings(
   // `Partial<StorySettings>` is a compile-time claim only, and zod strips
   // unknown keys — without this a typo'd key reports a successful save that
   // wrote nothing.
-  const unknownKeys = Object.keys(changed).filter((key) => !(key in storySettingsSchema.shape))
+  // `hasOwn`, not `in`: `in` walks the prototype chain, so `constructor` and
+  // `toString` would pass the guard and then be stripped by zod.
+  const unknownKeys = Object.keys(changed).filter(
+    (key) => !Object.hasOwn(storySettingsSchema.shape, key),
+  )
   if (unknownKeys.length > 0) {
     throw new Error(`Unknown story-settings key(s): ${unknownKeys.join(', ')}`)
   }

--- a/lib/actions/stories/update-story-settings.ts
+++ b/lib/actions/stories/update-story-settings.ts
@@ -1,0 +1,38 @@
+import { eq } from 'drizzle-orm'
+
+import { stories, storySettingsSchema, type DbCtx, type StorySettings } from '@/lib/db'
+import { currentStoryStore, rehydrateStories } from '@/lib/stores'
+
+// `stories` is absent from deltas.target_table, so a settings save is a direct
+// write: no delta row, no CTRL-Z reversal.
+// See data-model.md → Entry mutability & rollback.
+export async function updateStorySettings(
+  storyId: string,
+  patch: Partial<StorySettings>,
+  ctx: DbCtx,
+  nowMs: number = Date.now(),
+): Promise<StorySettings> {
+  const [row] = await ctx.db
+    .select({ settings: stories.settings })
+    .from(stories)
+    .where(eq(stories.id, storyId))
+  if (!row) throw new Error('Story not found')
+
+  const settings = storySettingsSchema.parse({
+    ...storySettingsSchema.parse(row.settings),
+    ...patch,
+  })
+
+  await ctx.runInTransaction([
+    ctx.db
+      .update(stories)
+      .set({ settings, updatedAt: nowMs })
+      .where(eq(stories.id, storyId))
+      .toSQL(),
+  ])
+
+  await rehydrateStories(ctx.db)
+  const open = currentStoryStore.getCurrentStory()
+  if (open?.storyId === storyId) currentStoryStore.set({ ...open, settings })
+  return settings
+}

--- a/lib/actions/stories/update-story-settings.ts
+++ b/lib/actions/stories/update-story-settings.ts
@@ -5,7 +5,14 @@ import { currentStoryStore, rehydrateStories } from '@/lib/stores'
 
 // `stories` is absent from deltas.target_table, so a settings save is a direct
 // write: no delta row, no CTRL-Z reversal.
-// See data-model.md → Entry mutability & rollback.
+// See data-model.md → Diagram, the deltas entity.
+/**
+ * @param patch - Shallow-merged onto the stored settings. Nested objects
+ * (`models`, `packVariables`, `translation`) are replaced, not merged; a key
+ * whose value is `undefined` is left untouched. Pass only the changed keys —
+ * spreading a whole settings object in discards any concurrent write that the
+ * read picked up.
+ */
 export async function updateStorySettings(
   storyId: string,
   patch: Partial<StorySettings>,

--- a/lib/actions/stories/update-story-settings.ts
+++ b/lib/actions/stories/update-story-settings.ts
@@ -20,7 +20,9 @@ export async function updateStorySettings(
 
   const settings = storySettingsSchema.parse({
     ...storySettingsSchema.parse(row.settings),
-    ...patch,
+    // Explicit `undefined` typechecks without exactOptionalPropertyTypes, and
+    // spreading it in would trip zod's defaults instead of leaving the key alone.
+    ...Object.fromEntries(Object.entries(patch).filter(([, value]) => value !== undefined)),
   })
 
   await ctx.runInTransaction([

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -52,6 +52,7 @@ export type {
 } from './stories/story-config-schema'
 export {
   storyDefinitionSchema,
+  storySettingsPartialSchema,
   storySettingsSchema,
   suggestionCategorySchema,
 } from './stories/story-config-schema'

--- a/lib/i18n/i18n.test.ts
+++ b/lib/i18n/i18n.test.ts
@@ -24,6 +24,9 @@ describe('lib/i18n', () => {
     expect(t('reader:send')).toBe('Send')
     expect(t('settings:tabs.diagnostics')).toBe('Diagnostics')
     expect(t('settings:diagnosticsHub.comingSoon')).toBe('Diagnostics Hub — coming soon')
+    expect(t('storySettings:title')).toBe('Story Settings')
+    expect(t('storySettings:tabs.memory')).toBe('Memory')
+    expect(t('storySettings:save.unsavedTitle')).toBe('Unsaved changes')
   })
 
   it('resolves the shared chrome keys from the common namespace', () => {

--- a/lib/i18n/i18n.ts
+++ b/lib/i18n/i18n.ts
@@ -6,9 +6,12 @@ import embedder from '@/locales/en/embedder.json'
 import landing from '@/locales/en/landing.json'
 import reader from '@/locales/en/reader.json'
 import settings from '@/locales/en/settings.json'
+import storySettings from '@/locales/en/story-settings.json'
 import wizard from '@/locales/en/wizard.json'
 
-const resources = { en: { common, embedder, landing, reader, settings, wizard } } as const
+const resources = {
+  en: { common, embedder, landing, reader, settings, storySettings, wizard },
+} as const
 
 // Synchronous init: resources are bundled, no async backend. The instance is
 // usable (i18n.t) the moment this module is imported — before any boot logic —
@@ -18,7 +21,7 @@ void i18n.use(initReactI18next).init({
   resources,
   lng: 'en',
   fallbackLng: 'en',
-  ns: ['common', 'embedder', 'landing', 'reader', 'settings', 'wizard'],
+  ns: ['common', 'embedder', 'landing', 'reader', 'settings', 'storySettings', 'wizard'],
   defaultNS: 'common',
   returnNull: false,
   interpolation: { escapeValue: false },

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -43,6 +43,12 @@
     "noProviders": "No providers configured. Add one in App Settings → Providers.",
     "noMatch": "No models match \"{{query}}\"."
   },
+  "saveBar": {
+    "unsavedChanges_one": "{{count}} unsaved change",
+    "unsavedChanges_other": "{{count}} unsaved changes",
+    "discard": "Discard",
+    "save": "Save"
+  },
   "storyCard": {
     "genreNotSet": "Genre not set",
     "noDescription": "(no description yet)",

--- a/locales/en/story-settings.json
+++ b/locales/en/story-settings.json
@@ -2,7 +2,6 @@
   "title": "Story Settings",
   "landsLater": "Lands in a later milestone",
   "landsLaterBody": "This tab isn't built yet. Nothing here is configurable.",
-  "moreLandsLater": "More Memory settings land in a later milestone.",
   "sections": {
     "story": "Story",
     "settings": "Settings"

--- a/locales/en/story-settings.json
+++ b/locales/en/story-settings.json
@@ -1,0 +1,29 @@
+{
+  "title": "Story Settings",
+  "landsLater": "Lands in a later milestone",
+  "landsLaterBody": "This tab isn't built yet. Nothing here is configurable.",
+  "moreLandsLater": "More Memory settings land in a later milestone.",
+  "sections": {
+    "story": "Story",
+    "settings": "Settings"
+  },
+  "tabs": {
+    "about": "About",
+    "generation": "Generation",
+    "models": "Models",
+    "memory": "Memory",
+    "translation": "Translation",
+    "pack": "Pack",
+    "calendar": "Calendar",
+    "advanced": "Advanced"
+  },
+  "save": {
+    "saved": "Saved.",
+    "failed": "Couldn't save your changes.",
+    "unsavedTitle": "Unsaved changes",
+    "unsavedBody": "You have unsaved changes on this screen. Save them, discard them, or stay here.",
+    "unsavedSave": "Save",
+    "unsavedDiscard": "Discard"
+  },
+  "missingStory": "This story could not be loaded."
+}

--- a/locales/en/story-settings.json
+++ b/locales/en/story-settings.json
@@ -1,7 +1,12 @@
 {
   "title": "Story Settings",
+  "loading": "Loading story settings…",
   "landsLater": "Lands in a later milestone",
   "landsLaterBody": "This tab isn't built yet. Nothing here is configurable.",
+  "unavailable": "Couldn't read your stories",
+  "unavailableBody": "Something went wrong loading this device's story list. Go back and try again.",
+  "uninitialized": "This story has no settings yet",
+  "uninitializedBody": "Settings are written when a story finishes setup. Finish the wizard for this story, or reset its settings to defaults.",
   "sections": {
     "story": "Story",
     "settings": "Settings"
@@ -18,7 +23,8 @@
   },
   "save": {
     "saved": "Saved.",
-    "failed": "Couldn't save your changes.",
+    "failed": "Couldn't save your changes. They're still here — try again.",
+    "stale": "Saved, but this screen is out of date. Reload to see the current values.",
     "unsavedTitle": "Unsaved changes",
     "unsavedBody": "You have unsaved changes on this screen. Save them, discard them, or stay here.",
     "unsavedSave": "Save",

--- a/locales/en/story-settings.json
+++ b/locales/en/story-settings.json
@@ -7,7 +7,7 @@
   "unavailableBody": "Something went wrong loading this device's story list. Go back and try again.",
   "uninitialized": "This story has no settings yet",
   "uninitializedBody": "Settings are written when a story finishes setup. Finish the wizard for this story, or reset its settings to defaults.",
-  "sections": {
+  "groups": {
     "story": "Story",
     "settings": "Settings"
   },

--- a/types/native.d.ts
+++ b/types/native.d.ts
@@ -1,6 +1,13 @@
+// types/native.d.ts — renderer + global Window augmentation.
+// (Electron preload gets its own copy in electron/native/types.ts — the two
+// compile units are separate tsconfigs, so the small duplication is intentional.)
 export type NativeApi = {
   readonly platform: NodeJS.Platform
   revealDbFile(): Promise<void>
+  /** Arm/disarm the window-close prompt. Disarmed windows close untouched. */
+  setCloseGuard(active: boolean): void
+  confirmClose(): void
+  onCloseRequested(cb: () => void): () => void
 }
 
 declare global {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -69,6 +69,7 @@ export default defineConfig({
             'lib/**/*.test.{ts,tsx}',
             'scripts/**/*.test.ts',
             'components/**/*.test.{ts,tsx}',
+            'hooks/**/*.test.{ts,tsx}',
             'electron/**/*.test.ts',
           ],
           setupFiles: ['./vitest.setup.ts'],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Story Settings screen with organized tabs for story details, generation, models, memory, translation, calendar, and advanced options.
  - Added saving, discarding, unsaved-change prompts, and localized status messages.
  - Story Settings can now be opened directly from the reader composer.
  - Added protection against losing unsaved edits when navigating, closing windows, or quitting the desktop app.

- **Bug Fixes**
  - Keyboard shortcuts now activate only when the relevant screen is focused.
  - Android back navigation is handled only on Android.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->