### PR TITLE
Test/e2e coverage expansion

### DIFF
--- a/docs/implementation/triage.md
+++ b/docs/implementation/triage.md
@@ -340,17 +340,33 @@ slice-planning gate forces its resolution before that slice is planned.
   pins current behavior and flags the change if the flag is wired.
   Surfaced by the M3 E2E harness work (2026-07-24).
 
-- **E2E suite sits at the happy-path core; backfill to the "thorough"
-  bar.** The harness and the eight specs cover one representative path
-  per seam (home, embedder, wizard-create, turn, classifier, force-on),
-  but [`docs/testing.md → Coverage`](../testing.md#coverage-thorough-not-exhaustive)
-  sets the bar at thorough — common alternative flows and common
-  seam-crossing edge cases too. Known gaps on flows that already exist:
-  creative-mode create (no lead / no embed), regenerate, undo,
-  resume-draft, open-existing, composer modes; and the edge cases —
-  generation-failure → retry surface, cancel mid-turn,
-  embedder-gate-blocked wizard, opening-only-branch turn, settings-corrupt
-  recovery. New seam-touching slices meet the bar at plan time (the
-  plan-slice gate); this queues the backfill for the pre-existing flows
-  so it isn't assumed done. Surfaced by the M3 E2E harness work
-  (2026-07-24).
+- **E2E coverage — remaining backfill after the coverage-expansion
+  pass.** The coverage-expansion pass (2026-07-24) added nine specs —
+  creative-mode create, resume-draft, embedder-gate-blocked, undo/redo,
+  edit, rollback, failure → retry, cancel mid-turn, and composer modes —
+  closing most of the gap
+  [`docs/testing.md → Coverage`](../testing.md#coverage-thorough-not-exhaustive)
+  named. What still isn't E2E'd, by deliberate scope: **opening-only-branch
+  turn** (a marginal variant of the covered turn happy path — it differs
+  only in an empty content tail); **settings-corrupt recovery** and the
+  rest of the **config surfaces** (settings / story-settings / diagnostics
+  are stub-heavy today — revisit when their real tabs / sections land);
+  and **regenerate** (the `EntryCard` control exists but `onRegen` is
+  unwired in the reader, so there is nothing to drive). **Bad-branch
+  hydration failure** was written then cut: the only way to reach it —
+  hard-navigating to a deep route — trips the packaged `app://` deep-route
+  protocol bug (the black-screen entry above), so it can't be
+  packaged-green until that's fixed, and there is no clean in-app route to
+  a non-existent branch. Surfaced by the M3 E2E harness work (2026-07-24),
+  narrowed by the coverage-expansion pass (2026-07-24).
+- **`EntryCard` action controls are not internationalized.**
+  `components/compounds/entry-card.tsx` hardcodes English on its per-row
+  controls — `Edit entry`, `Delete entry`, `Regenerate`, `Branch from
+here`, `Flip era`, the edit textarea's `Edit entry content`, `Save` /
+  `Cancel`, and the system-entry `Retry` / `Dismiss` — rather than routing
+  through `t()` like the rest of the chrome. No user-facing regression yet
+  (English-only today), but it breaks the i18n discipline and forces E2E to
+  match literals: `e2e/locators/reader.ts` centralizes them so the eventual
+  i18n pass is a one-line locator change. Fix is to move the strings into
+  the `reader` / `common` namespaces and swap the locators to `t()`.
+  Surfaced by the coverage-expansion pass (2026-07-24).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -224,6 +224,13 @@ on the request:
   can't drift because it reuses the app's own renderer, and tests
   override a specific agent's reply via `setStructured(name, value)`.
 
+Two one-shot narrative controls model the boundary states a running turn
+can hit: `failNextNarrative()` makes the next streaming call return HTTP
+500 (the failed-turn → retriable-system-entry path), and
+`holdNextNarrative()` opens the stream but holds it unfinished until
+`releaseNarrative()` or a client abort — the deterministic in-flight
+window the cancel spec cancels into, with no sleep-based wait.
+
 Block-matching keys on the **auto** (prompt-injection) path the fixture
 uses — the only path E2E relies on. A `force-on` profile takes the
 native path instead, but the app doesn't set the openai-compatible

--- a/e2e/flows/create-story.ts
+++ b/e2e/flows/create-story.ts
@@ -3,6 +3,7 @@ import { expect, type Page } from '@playwright/test'
 import { wizard } from '../locators/wizard'
 
 export type NewAdventureStory = { lead: string; title: string; opening: string }
+export type NewCreativeStory = { title: string; opening: string }
 
 // Drive the wizard end-to-end to create an adventure story with a lead entity —
 // the path create-story.ts embeds the lead through the local embedder. Assumes
@@ -25,5 +26,24 @@ export async function createAdventureStory(page: Page, story: NewAdventureStory)
   await wizard.finish(page).click()
 
   // Finish commits the story and routes to the reader.
+  await page.waitForURL(/\/reader-composer\//, { timeout: 30_000 })
+}
+
+// Creative mode has no lead (needsLead false), so Finish never embeds. Steps
+// run 1 → 2 → 5, same as the adventure flow minus the lead field. Assumes the
+// wizard is open on step 1 (past the embedder gate).
+export async function createCreativeStory(page: Page, story: NewCreativeStory): Promise<void> {
+  await wizard.modeOption(page, 'creative').click()
+  await wizard.next(page).click()
+
+  // Step 2 — calendar defaults are valid; advance.
+  await wizard.next(page).click()
+
+  // Step 5 — opening + title are the remaining Finish requirements.
+  await expect(wizard.opening(page)).toBeVisible()
+  await wizard.opening(page).fill(story.opening)
+  await wizard.title(page).fill(story.title)
+
+  await wizard.finish(page).click()
   await page.waitForURL(/\/reader-composer\//, { timeout: 30_000 })
 }

--- a/e2e/harness/db.ts
+++ b/e2e/harness/db.ts
@@ -1,5 +1,31 @@
 import { DatabaseSync } from 'node:sqlite'
 
+import type { Page } from '@playwright/test'
+
+// Query the running app's own DB connection through the preload bridge
+// (window.aventurasDb). The faithful way to assert an in-app write: it reads
+// through the same main-process connection that just committed, whereas a
+// second file handle can miss a WAL-buffered write. sqlite-proxy hands rows
+// back as arrays-of-values. See docs/testing.md → Selector strategy, Tier 1.
+export async function queryApp(
+  page: Page,
+  sql: string,
+  params: unknown[] = [],
+): Promise<unknown[][]> {
+  const result = await page.evaluate(
+    ({ sql, params }) =>
+      (
+        window as unknown as {
+          aventurasDb: {
+            query: (s: string, p: unknown[], m: string) => Promise<{ rows: unknown[][] }>
+          }
+        }
+      ).aventurasDb.query(sql, params, 'all'),
+    { sql, params },
+  )
+  return result.rows
+}
+
 // Read-only assertion handle over the fixture DB file. E2E drives the app
 // through the UI and asserts the outcome here — the DB is the source of truth
 // for "did the write actually land" (docs/testing.md → Selector strategy,

--- a/e2e/harness/mock-llm.ts
+++ b/e2e/harness/mock-llm.ts
@@ -1,4 +1,4 @@
-import { createServer, type IncomingMessage } from 'node:http'
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
 import type { AddressInfo } from 'node:net'
 
 import { z } from 'zod'
@@ -45,6 +45,16 @@ export type MockLlm = {
   setNarrative: (content: string) => void
   /** Override a structured agent's reply (defaults to its schema-valid example). */
   setStructured: (agentName: string, value: unknown) => void
+  /** One-shot: the next narrative (streaming) call fails with HTTP 500. */
+  failNextNarrative: () => void
+  /**
+   * One-shot: the next narrative call opens its SSE stream but holds it open (no
+   * finish) until releaseNarrative() or a client abort — the deterministic
+   * in-flight window the cancel test needs.
+   */
+  holdNextNarrative: () => void
+  /** Finish any held narrative streams with the current narrative content. */
+  releaseNarrative: () => void
   /** Every completion request received, in order. */
   requests: MockRequest[]
   close: () => Promise<void>
@@ -57,17 +67,33 @@ function sse(obj: unknown): string {
   return `data: ${JSON.stringify(obj)}\n\n`
 }
 
-function narrativeSse(content: string): string {
-  const base = { id: 'chatcmpl-mock', object: 'chat.completion.chunk', created: 0, model: 'mock' }
+const CHUNK_BASE = {
+  id: 'chatcmpl-mock',
+  object: 'chat.completion.chunk',
+  created: 0,
+  model: 'mock',
+}
+
+// The opening role frame, emitted on its own to hold a stream open — a
+// started-but-unfinished narrative call, so the cancel test has an in-flight
+// window. The tail (content + stop + [DONE]) completes it.
+function narrativeRoleFrame(): string {
+  return sse({
+    ...CHUNK_BASE,
+    choices: [{ index: 0, delta: { role: 'assistant', content: '' }, finish_reason: null }],
+  })
+}
+
+function narrativeTail(content: string): string {
   const frames = [
-    {
-      ...base,
-      choices: [{ index: 0, delta: { role: 'assistant', content: '' }, finish_reason: null }],
-    },
-    { ...base, choices: [{ index: 0, delta: { content }, finish_reason: null }] },
-    { ...base, choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] },
+    { ...CHUNK_BASE, choices: [{ index: 0, delta: { content }, finish_reason: null }] },
+    { ...CHUNK_BASE, choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] },
   ]
   return frames.map(sse).join('') + 'data: [DONE]\n\n'
+}
+
+function narrativeSse(content: string): string {
+  return narrativeRoleFrame() + narrativeTail(content)
 }
 
 function structuredCompletion(value: unknown): string {
@@ -114,6 +140,11 @@ export async function startMockLlm(): Promise<MockLlm> {
   let narrative = DEFAULT_NARRATIVE
   const overrides = new Map<string, unknown>()
   const requests: MockRequest[] = []
+  let failNarrativeNext = false
+  let holdNarrativeNext = false
+  // Streams held open (hold mode): tracked so release/close can finish them and
+  // a client abort can drop them — an unfinished socket would hang server.close().
+  const heldResponses = new Set<ServerResponse>()
 
   // The renderer fetches cross-origin (its own origin → this server), which
   // triggers a CORS preflight; answer it and tag every response, so the call
@@ -140,12 +171,29 @@ export async function startMockLlm(): Promise<MockLlm> {
 
       if (streamed) {
         requests.push({ body, streamed, agent: null })
+        if (failNarrativeNext) {
+          failNarrativeNext = false
+          res.writeHead(500, { ...cors, 'content-type': 'application/json' })
+          res.end(
+            JSON.stringify({ error: { message: 'mock injected failure', type: 'server_error' } }),
+          )
+          return
+        }
         res.writeHead(200, {
           ...cors,
           'content-type': 'text/event-stream',
           'cache-control': 'no-cache',
           connection: 'keep-alive',
         })
+        if (holdNarrativeNext) {
+          holdNarrativeNext = false
+          // Open the stream but don't finish it: the run stays in-flight
+          // (isGenerating) until release or the client aborts on cancel.
+          res.write(narrativeRoleFrame())
+          heldResponses.add(res)
+          res.on('close', () => heldResponses.delete(res))
+          return
+        }
         res.end(narrativeSse(narrative))
         return
       }
@@ -170,7 +218,23 @@ export async function startMockLlm(): Promise<MockLlm> {
     setStructured: (agentName, value) => {
       overrides.set(agentName, value)
     },
+    failNextNarrative: () => {
+      failNarrativeNext = true
+    },
+    holdNextNarrative: () => {
+      holdNarrativeNext = true
+    },
+    releaseNarrative: () => {
+      for (const res of heldResponses) res.end(narrativeTail(narrative))
+      heldResponses.clear()
+    },
     requests,
-    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+    close: () =>
+      new Promise<void>((resolve) => {
+        // Finish held streams first, else an open socket hangs server.close().
+        for (const res of heldResponses) res.end(narrativeTail(narrative))
+        heldResponses.clear()
+        server.close(() => resolve())
+      }),
   }
 }

--- a/e2e/locators/reader.ts
+++ b/e2e/locators/reader.ts
@@ -1,0 +1,60 @@
+import type { Locator, Page } from '@playwright/test'
+
+import { t } from '../harness/i18n'
+
+// Reader/composer locators. Most resolve through the app's own i18n keys
+// (docs/testing.md → Selector strategy, Tier 2). The exceptions are the
+// EntryCard per-row action controls, which the component hardcodes in English
+// (not `t()` — see docs/implementation/triage.md). They're centralized here so
+// a future i18n pass is a one-line change, and the literals still match the
+// app's real accessible output today.
+const EDIT_ENTRY_LABEL = 'Edit entry'
+const DELETE_ENTRY_LABEL = 'Delete entry'
+const EDIT_TEXTAREA_LABEL = 'Edit entry content'
+const SAVE_LABEL = 'Save'
+const RETRY_LABEL = 'Retry'
+const DISMISS_LABEL = 'Dismiss'
+
+export const reader = {
+  composer: (page: Page): Locator => page.getByPlaceholder(t('reader:composerPlaceholder')),
+  send: (page: Page): Locator => page.getByRole('button', { name: t('reader:send') }),
+  // Composer swaps Send → Cancel (t('cancel')) while a turn is generating.
+  cancel: (page: Page): Locator => page.getByRole('button', { name: t('cancel') }),
+
+  // Composer mode dropdown (web: Radix Select). The trigger carries the "Mode"
+  // label; each option renders the mode label + its hint.
+  modeTrigger: (page: Page): Locator =>
+    page.getByRole('button', { name: new RegExp(t('reader:composerModeLabel')) }),
+  modeOption: (page: Page, mode: 'do' | 'say' | 'think' | 'free'): Locator =>
+    page.getByRole('option').filter({ hasText: t(`reader:composerMode.${mode}`) }),
+
+  // Each entry renders in a `data-entry-row` div (components/reader/reader-surface.tsx),
+  // a stable DOM scope anchor — no component change needed.
+  row: (page: Page, entryId: string): Locator => page.locator(`[data-entry-row="${entryId}"]`),
+  editEntry: (page: Page, entryId: string): Locator =>
+    reader.row(page, entryId).getByRole('button', { name: EDIT_ENTRY_LABEL }),
+  deleteEntry: (page: Page, entryId: string): Locator =>
+    reader.row(page, entryId).getByRole('button', { name: DELETE_ENTRY_LABEL }),
+  editTextarea: (page: Page): Locator => page.getByRole('textbox', { name: EDIT_TEXTAREA_LABEL }),
+  saveEdit: (page: Page): Locator => page.getByRole('button', { name: SAVE_LABEL }),
+
+  // System (turn-failure) entry actions.
+  retrySystemEntry: (page: Page): Locator => page.getByRole('button', { name: RETRY_LABEL }),
+  dismissSystemEntry: (page: Page): Locator => page.getByRole('button', { name: DISMISS_LABEL }),
+
+  // The chrome actions menu (IconAction trigger; on web the accessible name
+  // carries the "(Ctrl+K)" shortcut hint, so match on the base label). Undo /
+  // Redo live in its contextual group; their row labels are i18n-resolved.
+  actionsTrigger: (page: Page): Locator =>
+    page.getByRole('button', { name: new RegExp(t('chrome.actions')) }),
+  undoRow: (page: Page): Locator => page.getByText(t('reader:actions.undo'), { exact: true }),
+  redoRow: (page: Page): Locator => page.getByText(t('reader:actions.redo'), { exact: true }),
+
+  // Rollback (delete-to-entry) confirm modal.
+  rollbackConfirm: (page: Page): Locator =>
+    page.getByRole('button', { name: t('reader:rollbackConfirm.confirm') }),
+
+  // Bad-branch hydration failure state.
+  hydrationFailed: (page: Page): Locator =>
+    page.getByText(t('reader:hydrationFailedTitle'), { exact: false }),
+}

--- a/e2e/locators/wizard.ts
+++ b/e2e/locators/wizard.ts
@@ -22,4 +22,13 @@ export const wizard = {
   next: (page: Page): Locator => page.getByRole('button', { name: t('wizard:footer.next') }),
 
   finish: (page: Page): Locator => page.getByRole('button', { name: t('wizard:footer.finish') }),
+
+  saveDraft: (page: Page): Locator =>
+    page.getByRole('button', { name: t('wizard:footer.saveDraft') }),
+
+  // Hard entry gate (wizard.md → Embedder-unavailable): an AlertDialog over the
+  // shell when no usable embedder resolves. The title is reason-independent, so
+  // it's the stable assertion target.
+  embedGateTitle: (page: Page): Locator =>
+    page.getByText(t('wizard:embedGate.title'), { exact: false }),
 }

--- a/e2e/tests/classifier.spec.ts
+++ b/e2e/tests/classifier.spec.ts
@@ -1,5 +1,6 @@
-import { expect, test, type Page } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 
+import { queryApp } from '../harness/db'
 import { t } from '../harness/i18n'
 import { launchApp, type LaunchedApp } from '../harness/launch'
 import { startMockLlm, type MockLlm } from '../harness/mock-llm'
@@ -10,21 +11,6 @@ import {
   setProviderEndpoint,
 } from '../harness/seed'
 import { home } from '../locators/home'
-
-async function dbRows(page: Page, sql: string, params: unknown[] = []): Promise<unknown[][]> {
-  const result = await page.evaluate(
-    ({ sql, params }) =>
-      (
-        window as unknown as {
-          aventurasDb: {
-            query: (s: string, p: unknown[], m: string) => Promise<{ rows: unknown[][] }>
-          }
-        }
-      ).aventurasDb.query(sql, params, 'all'),
-    { sql, params },
-  )
-  return result.rows
-}
 
 // With piggyback disabled, a single turn fans out into TWO calls on the one
 // endpoint — the streaming narrative and the non-streaming fallback classifier
@@ -74,9 +60,9 @@ test.describe('turn fanning out to the fallback classifier', () => {
 
     // The AI reply still commits despite the extra classifier round-trip.
     const branchId = (
-      await dbRows(app.window, `SELECT current_branch_id FROM stories WHERE id = 'story_hero'`)
+      await queryApp(app.window, `SELECT current_branch_id FROM stories WHERE id = 'story_hero'`)
     )[0][0] as string
-    const reply = await dbRows(
+    const reply = await queryApp(
       app.window,
       `SELECT kind FROM story_entries WHERE branch_id = ? AND content LIKE '%E2E-CLASSIFIER-TURN%'`,
       [branchId],

--- a/e2e/tests/reader-cancel.spec.ts
+++ b/e2e/tests/reader-cancel.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from '@playwright/test'
+
+import { queryApp } from '../harness/db'
+import { launchApp, type LaunchedApp } from '../harness/launch'
+import { startMockLlm, type MockLlm } from '../harness/mock-llm'
+import { createSeededUserDataDir, removeUserDataDir, setProviderEndpoint } from '../harness/seed'
+import { home } from '../locators/home'
+import { reader } from '../locators/reader'
+
+// Cancel mid-turn (edge case): the mock holds the narrative stream open so the
+// turn is provably in-flight, then Cancel aborts it. Cancel reverses the whole
+// turn — the user action included (C6) — and hands the raw text back to the
+// composer for re-send. The hold makes this deterministic (no sleep/timing
+// race). See docs/testing.md → Coverage + Mock LLM.
+const RAW = 'E2E-CANCEL-USER I hesitate at the threshold.'
+
+test.describe('reader — cancel a turn mid-flight', () => {
+  let app: LaunchedApp
+  let mock: MockLlm
+  let userDataDir: string | undefined
+
+  test.beforeAll(async () => {
+    const seeded = createSeededUserDataDir()
+    userDataDir = seeded.userDataDir
+    mock = await startMockLlm()
+    setProviderEndpoint(seeded.dbPath, mock.url)
+    app = await launchApp({ userDataDir, cleanupUserData: true })
+  })
+
+  test.afterAll(async () => {
+    await app?.close()
+    await mock?.close()
+    removeUserDataDir(userDataDir)
+  })
+
+  test('cancel reverses the whole turn and restores the draft', async () => {
+    mock.holdNextNarrative()
+
+    await home.openStory(app.window, 'The Veilstone Courier').click()
+    await expect(reader.composer(app.window)).toBeVisible({ timeout: 20_000 })
+    await reader.composer(app.window).fill(RAW)
+    await reader.send(app.window).click()
+
+    // The held stream keeps the turn in-flight, so the composer shows Cancel.
+    await expect(reader.cancel(app.window)).toBeVisible({ timeout: 20_000 })
+    await reader.cancel(app.window).click()
+
+    // Generation ends: the composer returns to its Send state.
+    await expect(reader.send(app.window)).toBeVisible({ timeout: 20_000 })
+
+    // Nothing committed for this turn (user action reversed with it, C6).
+    const branchId = (
+      await queryApp(app.window, `SELECT current_branch_id FROM stories WHERE id = 'story_hero'`)
+    )[0][0] as string
+    await expect
+      .poll(
+        async () =>
+          (
+            (
+              await queryApp(
+                app.window,
+                `SELECT count(*) FROM story_entries WHERE branch_id = ? AND content LIKE '%E2E-CANCEL%'`,
+                [branchId],
+              )
+            )[0] as [number]
+          )[0],
+        { timeout: 15_000 },
+      )
+      .toBe(0)
+
+    // The raw draft is handed back for edit/re-send.
+    await expect(reader.composer(app.window)).toHaveValue(/E2E-CANCEL-USER/)
+  })
+})

--- a/e2e/tests/reader-composer-modes.spec.ts
+++ b/e2e/tests/reader-composer-modes.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from '@playwright/test'
+
+import { queryApp } from '../harness/db'
+import { launchApp, type LaunchedApp } from '../harness/launch'
+import { startMockLlm, type MockLlm } from '../harness/mock-llm'
+import { createSeededUserDataDir, removeUserDataDir, setProviderEndpoint } from '../harness/seed'
+import { home } from '../locators/home'
+import { reader } from '../locators/reader'
+
+// Composer modes (alternative flow): the hero story is adventure + has
+// composerModesEnabled, so the mode dropdown is live. "Say" wraps the raw input
+// into dialogue before submit (lib/composer-wrap), and the wrapped text is what
+// gets committed as the user_action. Deterministic (no conjugation), so the
+// committed content is exactly the wrapped shape. See docs/testing.md → Coverage.
+const MARKER = 'E2E-MODES the tide is turning'
+
+test.describe('reader — composer modes', () => {
+  let app: LaunchedApp
+  let mock: MockLlm
+  let userDataDir: string | undefined
+
+  test.beforeAll(async () => {
+    const seeded = createSeededUserDataDir()
+    userDataDir = seeded.userDataDir
+    mock = await startMockLlm()
+    mock.setNarrative('E2E-MODES-REPLY the courier answers.')
+    setProviderEndpoint(seeded.dbPath, mock.url)
+    app = await launchApp({ userDataDir, cleanupUserData: true })
+  })
+
+  test.afterAll(async () => {
+    await app?.close()
+    await mock?.close()
+    removeUserDataDir(userDataDir)
+  })
+
+  test('applies the selected mode wrap to the committed user action', async () => {
+    await home.openStory(app.window, 'The Veilstone Courier').click()
+    await expect(reader.composer(app.window)).toBeVisible({ timeout: 20_000 })
+
+    // Switch Free → Say (dialogue wrapper).
+    await reader.modeTrigger(app.window).click()
+    await reader.modeOption(app.window, 'say').click()
+
+    await reader.composer(app.window).fill(MARKER)
+    await reader.send(app.window).click()
+    await expect(app.window.getByText('E2E-MODES', { exact: false })).toBeVisible({
+      timeout: 30_000,
+    })
+
+    const branchId = (
+      await queryApp(app.window, `SELECT current_branch_id FROM stories WHERE id = 'story_hero'`)
+    )[0][0] as string
+    const rows = await queryApp(
+      app.window,
+      `SELECT content FROM story_entries WHERE branch_id = ? AND kind = 'user_action' AND content LIKE '%E2E-MODES%'`,
+      [branchId],
+    )
+    expect(rows.length, 'the wrapped user action committed').toBe(1)
+    const content = (rows[0] as [string])[0]
+    // "Say" wrap is: `"<text>" <lead> said.` — quoted, ending in `said.`, and no
+    // longer equal to the raw input.
+    expect(content).not.toBe(MARKER)
+    expect(content.startsWith('"')).toBe(true)
+    expect(content.trimEnd().endsWith('said.')).toBe(true)
+  })
+})

--- a/e2e/tests/reader-edit.spec.ts
+++ b/e2e/tests/reader-edit.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from '@playwright/test'
+
+import { queryApp } from '../harness/db'
+import { launchApp, type LaunchedApp } from '../harness/launch'
+import { createSeededUserDataDir, removeUserDataDir } from '../harness/seed'
+import { home } from '../locators/home'
+import { reader } from '../locators/reader'
+
+// Edit an existing entry (common reader mutation): the inline editor commits
+// through updateStoryEntryContent → the row's content changes in SQLite. No LLM
+// involved. See docs/testing.md → Coverage.
+const NEW_CONTENT = 'E2E-EDIT the passage was rewritten by the test.'
+
+test.describe('reader — edit an entry', () => {
+  let app: LaunchedApp
+  let userDataDir: string | undefined
+
+  test.beforeAll(async () => {
+    ;({ userDataDir } = createSeededUserDataDir())
+    app = await launchApp({ userDataDir, cleanupUserData: true })
+  })
+
+  test.afterAll(async () => {
+    await app?.close()
+    removeUserDataDir(userDataDir)
+  })
+
+  test('rewrites an entry and persists the new content', async () => {
+    await home.openStory(app.window, 'The Veilstone Courier').click()
+    await expect(reader.composer(app.window)).toBeVisible({ timeout: 20_000 })
+
+    const branchId = (
+      await queryApp(app.window, `SELECT current_branch_id FROM stories WHERE id = 'story_hero'`)
+    )[0][0] as string
+    // The most-recent ai_reply — recent, so it's inside the loaded window.
+    const entryId = (
+      await queryApp(
+        app.window,
+        `SELECT id FROM story_entries WHERE branch_id = ? AND kind = 'ai_reply' ORDER BY position DESC LIMIT 1`,
+        [branchId],
+      )
+    )[0][0] as string
+
+    await reader.row(app.window, entryId).scrollIntoViewIfNeeded()
+    await reader.editEntry(app.window, entryId).click()
+    await reader.editTextarea(app.window).fill(NEW_CONTENT)
+    await reader.saveEdit(app.window).click()
+
+    await expect
+      .poll(
+        async () =>
+          (
+            (
+              await queryApp(app.window, `SELECT content FROM story_entries WHERE id = ?`, [
+                entryId,
+              ])
+            )[0] as [string]
+          )[0],
+        { timeout: 15_000 },
+      )
+      .toBe(NEW_CONTENT)
+  })
+})

--- a/e2e/tests/reader-failure-retry.spec.ts
+++ b/e2e/tests/reader-failure-retry.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from '@playwright/test'
+
+import { queryApp } from '../harness/db'
+import { launchApp, type LaunchedApp } from '../harness/launch'
+import { startMockLlm, type MockLlm } from '../harness/mock-llm'
+import { createSeededUserDataDir, removeUserDataDir, setProviderEndpoint } from '../harness/seed'
+import { home } from '../locators/home'
+import { reader } from '../locators/reader'
+
+// Generation failure → retry (edge case): a failed narrative call surfaces a
+// system entry with a Retry action; retrying (with the failure cleared) commits
+// the reply and clears the system entry. The failure is injected at the mock's
+// transport, so the whole pipeline error path runs for real. See
+// docs/testing.md → Coverage + Mock LLM.
+const REPLY = 'E2E-FAILRETRY-REPLY the courier finally answers.'
+
+test.describe('reader — turn failure then retry', () => {
+  let app: LaunchedApp
+  let mock: MockLlm
+  let userDataDir: string | undefined
+
+  test.beforeAll(async () => {
+    const seeded = createSeededUserDataDir()
+    userDataDir = seeded.userDataDir
+    mock = await startMockLlm()
+    mock.setNarrative(REPLY)
+    setProviderEndpoint(seeded.dbPath, mock.url)
+    app = await launchApp({ userDataDir, cleanupUserData: true })
+  })
+
+  test.afterAll(async () => {
+    await app?.close()
+    await mock?.close()
+    removeUserDataDir(userDataDir)
+  })
+
+  async function systemCount(branchId: string): Promise<number> {
+    return (
+      (
+        await queryApp(
+          app.window,
+          `SELECT count(*) FROM story_entries WHERE branch_id = ? AND kind = 'system'`,
+          [branchId],
+        )
+      )[0] as [number]
+    )[0]
+  }
+
+  test('surfaces a retriable system entry on failure, then commits on retry', async () => {
+    mock.failNextNarrative()
+
+    await home.openStory(app.window, 'The Veilstone Courier').click()
+    await expect(reader.composer(app.window)).toBeVisible({ timeout: 20_000 })
+    await reader.composer(app.window).fill('E2E-FAILRETRY-USER I call out.')
+    await reader.send(app.window).click()
+
+    // The failed turn writes a system entry with a Retry action.
+    await expect(reader.retrySystemEntry(app.window)).toBeVisible({ timeout: 30_000 })
+    const branchId = (
+      await queryApp(app.window, `SELECT current_branch_id FROM stories WHERE id = 'story_hero'`)
+    )[0][0] as string
+    expect(await systemCount(branchId), 'system entry written on failure').toBe(1)
+
+    // Retry: the failure is one-shot, so the next narrative call succeeds.
+    await reader.retrySystemEntry(app.window).click()
+    await expect(app.window.getByText('E2E-FAILRETRY-REPLY', { exact: false })).toBeVisible({
+      timeout: 30_000,
+    })
+
+    const reply = await queryApp(
+      app.window,
+      `SELECT id FROM story_entries WHERE branch_id = ? AND content LIKE '%E2E-FAILRETRY-REPLY%'`,
+      [branchId],
+    )
+    expect(reply.length, 'reply committed on retry').toBe(1)
+    await expect.poll(() => systemCount(branchId), { timeout: 15_000 }).toBe(0)
+  })
+})

--- a/e2e/tests/reader-rollback.spec.ts
+++ b/e2e/tests/reader-rollback.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from '@playwright/test'
+
+import { queryApp } from '../harness/db'
+import { launchApp, type LaunchedApp } from '../harness/launch'
+import { createSeededUserDataDir, removeUserDataDir } from '../harness/seed'
+import { home } from '../locators/home'
+import { reader } from '../locators/reader'
+
+// Roll back (delete-to-entry), a common reader mutation: deleting an entry
+// removes it and every entry after it on the branch. Confirmed through the
+// modal, asserted by position in the DB. No LLM involved. See
+// docs/testing.md → Coverage.
+test.describe('reader — roll back to an entry', () => {
+  let app: LaunchedApp
+  let userDataDir: string | undefined
+
+  test.beforeAll(async () => {
+    ;({ userDataDir } = createSeededUserDataDir())
+    app = await launchApp({ userDataDir, cleanupUserData: true })
+  })
+
+  test.afterAll(async () => {
+    await app?.close()
+    removeUserDataDir(userDataDir)
+  })
+
+  test('deleting an entry removes it and all entries after it', async () => {
+    await home.openStory(app.window, 'The Veilstone Courier').click()
+    await expect(reader.composer(app.window)).toBeVisible({ timeout: 20_000 })
+
+    const branchId = (
+      await queryApp(app.window, `SELECT current_branch_id FROM stories WHERE id = 'story_hero'`)
+    )[0][0] as string
+    // Third from the tail: recent enough to be in the loaded window, with two
+    // successors to prove the cascade.
+    const tail = await queryApp(
+      app.window,
+      `SELECT id, position FROM story_entries WHERE branch_id = ? ORDER BY position DESC LIMIT 3`,
+      [branchId],
+    )
+    const [targetId, targetPos] = tail[2] as [string, number]
+
+    await reader.row(app.window, targetId).scrollIntoViewIfNeeded()
+    await reader.deleteEntry(app.window, targetId).click()
+    await reader.rollbackConfirm(app.window).click()
+
+    // Everything at or after the target is gone.
+    await expect
+      .poll(
+        async () =>
+          (
+            (
+              await queryApp(
+                app.window,
+                `SELECT count(*) FROM story_entries WHERE branch_id = ? AND position >= ?`,
+                [branchId, targetPos],
+              )
+            )[0] as [number]
+          )[0],
+        { timeout: 15_000 },
+      )
+      .toBe(0)
+  })
+})

--- a/e2e/tests/reader-undo-redo.spec.ts
+++ b/e2e/tests/reader-undo-redo.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from '@playwright/test'
+
+import { queryApp } from '../harness/db'
+import { launchApp, type LaunchedApp } from '../harness/launch'
+import { startMockLlm, type MockLlm } from '../harness/mock-llm'
+import { createSeededUserDataDir, removeUserDataDir, setProviderEndpoint } from '../harness/seed'
+import { home } from '../locators/home'
+import { reader } from '../locators/reader'
+
+// Reverse / re-apply a committed turn — the "regenerate / undo" alternative flow
+// (there is no wired regenerate control; undo is the reversal path). Undo of a
+// turn reverse-and-prunes its delta rows (the entries go with them); redo
+// re-applies the snapshot. Asserted through the DB. See docs/testing.md → Coverage.
+const REPLY = 'E2E-UNDO-REPLY the courier turns back into the rain.'
+
+test.describe('reader — undo / redo a turn', () => {
+  let app: LaunchedApp
+  let mock: MockLlm
+  let userDataDir: string | undefined
+
+  test.beforeAll(async () => {
+    const seeded = createSeededUserDataDir()
+    userDataDir = seeded.userDataDir
+    mock = await startMockLlm()
+    mock.setNarrative(REPLY)
+    setProviderEndpoint(seeded.dbPath, mock.url)
+    app = await launchApp({ userDataDir, cleanupUserData: true })
+  })
+
+  test.afterAll(async () => {
+    await app?.close()
+    await mock?.close()
+    removeUserDataDir(userDataDir)
+  })
+
+  async function replyCount(): Promise<number> {
+    const branchId = (
+      await queryApp(app.window, `SELECT current_branch_id FROM stories WHERE id = 'story_hero'`)
+    )[0][0] as string
+    const rows = await queryApp(
+      app.window,
+      `SELECT id FROM story_entries WHERE branch_id = ? AND content LIKE '%E2E-UNDO-REPLY%'`,
+      [branchId],
+    )
+    return rows.length
+  }
+
+  test('undo reverses the committed turn; redo re-applies it', async () => {
+    await home.openStory(app.window, 'The Veilstone Courier').click()
+    await expect(reader.composer(app.window)).toBeVisible({ timeout: 20_000 })
+    await reader.composer(app.window).fill('E2E-UNDO-USER I retreat a step.')
+    await reader.send(app.window).click()
+    await expect(app.window.getByText('E2E-UNDO-REPLY', { exact: false })).toBeVisible({
+      timeout: 30_000,
+    })
+    expect(await replyCount()).toBe(1)
+
+    // Undo through the chrome actions menu (the touch-tier path; the keyboard
+    // shortcut is intentionally inert while focus is in the composer).
+    await reader.actionsTrigger(app.window).click()
+    await reader.undoRow(app.window).click()
+    await expect.poll(replyCount, { timeout: 15_000 }).toBe(0)
+
+    // Redo re-applies the same turn — the row comes back.
+    await reader.actionsTrigger(app.window).click()
+    await reader.redoRow(app.window).click()
+    await expect.poll(replyCount, { timeout: 15_000 }).toBe(1)
+  })
+})

--- a/e2e/tests/turn.spec.ts
+++ b/e2e/tests/turn.spec.ts
@@ -1,25 +1,11 @@
-import { expect, test, type Page } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 
+import { queryApp } from '../harness/db'
 import { t } from '../harness/i18n'
 import { launchApp, type LaunchedApp } from '../harness/launch'
 import { startMockLlm, type MockLlm } from '../harness/mock-llm'
 import { createSeededUserDataDir, removeUserDataDir, setProviderEndpoint } from '../harness/seed'
 import { home } from '../locators/home'
-
-async function dbRows(page: Page, sql: string, params: unknown[] = []): Promise<unknown[][]> {
-  const result = await page.evaluate(
-    ({ sql, params }) =>
-      (
-        window as unknown as {
-          aventurasDb: {
-            query: (s: string, p: unknown[], m: string) => Promise<{ rows: unknown[][] }>
-          }
-        }
-      ).aventurasDb.query(sql, params, 'all'),
-    { sql, params },
-  )
-  return result.rows
-}
 
 // A distinctive marker so the reply is unambiguous in both DOM and DB.
 const REPLY = 'E2E-TURN-MARKER — the blade sings and the rain leans in.'
@@ -66,17 +52,17 @@ test.describe('reader turn against the mock LLM', () => {
 
     // Both the user action and the AI reply are committed to the branch.
     const branchId = (
-      await dbRows(app.window, `SELECT current_branch_id FROM stories WHERE id = 'story_hero'`)
+      await queryApp(app.window, `SELECT current_branch_id FROM stories WHERE id = 'story_hero'`)
     )[0][0] as string
 
-    const reply = await dbRows(
+    const reply = await queryApp(
       app.window,
       `SELECT kind FROM story_entries WHERE branch_id = ? AND content LIKE '%E2E-TURN-MARKER%'`,
       [branchId],
     )
     expect(reply.length, 'AI reply entry committed').toBe(1)
 
-    const userEntry = await dbRows(
+    const userEntry = await queryApp(
       app.window,
       `SELECT kind FROM story_entries WHERE branch_id = ? AND content LIKE '%E2E-USER-MARKER%'`,
       [branchId],

--- a/e2e/tests/wizard-creative.spec.ts
+++ b/e2e/tests/wizard-creative.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from '@playwright/test'
+
+import { createCreativeStory } from '../flows/create-story'
+import { queryApp } from '../harness/db'
+import { installEmbedderModel } from '../harness/embedder'
+import { launchApp, type LaunchedApp } from '../harness/launch'
+import { createSeededUserDataDir, removeUserDataDir } from '../harness/seed'
+import { home } from '../locators/home'
+import { wizard } from '../locators/wizard'
+
+// The common alternative to the adventure happy path: creative mode has no lead
+// (needsLead false), so Finish commits the story without an embed pass. Proves
+// the no-lead branch of finishWizard end-to-end. See docs/testing.md → Coverage.
+test.describe('create-story wizard — creative mode', () => {
+  let app: LaunchedApp
+  let userDataDir: string | undefined
+  const STORY = {
+    title: 'The Glass Orchard',
+    opening: 'Nothing in the orchard had borne fruit since the frost.',
+  }
+
+  test.beforeAll(async () => {
+    test.setTimeout(180_000)
+    ;({ userDataDir } = createSeededUserDataDir())
+    // A usable embedder clears the (mode-independent) entry gate; creative still
+    // embeds nothing on Finish.
+    await installEmbedderModel(userDataDir)
+    app = await launchApp({ userDataDir, cleanupUserData: true })
+  })
+
+  test.afterAll(async () => {
+    await app?.close()
+    removeUserDataDir(userDataDir)
+  })
+
+  test('commits a creative story with no lead and no embedding', async () => {
+    await home.newStory(app.window).click()
+    await expect(wizard.modeOption(app.window, 'creative')).toBeVisible({ timeout: 15_000 })
+
+    await createCreativeStory(app.window, STORY)
+
+    const storyRows = await queryApp(
+      app.window,
+      `SELECT current_branch_id, status FROM stories WHERE title = ?`,
+      [STORY.title],
+    )
+    expect(storyRows.length, 'exactly one story with the title').toBe(1)
+    const [branchId, status] = storyRows[0] as [string, string]
+    expect(status).toBe('active')
+
+    // No lead ⇒ no entity created ⇒ nothing embeddable. Zero entities on the
+    // branch is the direct, stable proof that the embed pass had no work.
+    const entityCount = await queryApp(
+      app.window,
+      `SELECT count(*) FROM entities WHERE branch_id = ?`,
+      [branchId],
+    )
+    expect((entityCount[0] as [number])[0], 'no entities on a creative branch').toBe(0)
+  })
+})

--- a/e2e/tests/wizard-embedder-gate.spec.ts
+++ b/e2e/tests/wizard-embedder-gate.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test'
+
+import { queryApp } from '../harness/db'
+import { launchApp, type LaunchedApp } from '../harness/launch'
+import { createSeededUserDataDir, removeUserDataDir } from '../harness/seed'
+import { home } from '../locators/home'
+import { wizard } from '../locators/wizard'
+
+// The hard entry gate (wizard.md → Embedder-unavailable): with no usable
+// embedder the wizard is blocked outright. This spec deliberately does NOT
+// install the fixture model — the inverse of every other wizard spec — so the
+// gate fires. A running app is the only place this seam (installed-list read →
+// gate resolve → blocking modal) is observable. See docs/testing.md → Coverage.
+test.describe('create-story wizard — embedder gate', () => {
+  let app: LaunchedApp
+  let userDataDir: string | undefined
+
+  test.beforeAll(async () => {
+    ;({ userDataDir } = createSeededUserDataDir())
+    app = await launchApp({ userDataDir, cleanupUserData: true })
+  })
+
+  test.afterAll(async () => {
+    await app?.close()
+    removeUserDataDir(userDataDir)
+  })
+
+  test('blocks the wizard and commits nothing when no embedder is installed', async () => {
+    const before = (await queryApp(app.window, `SELECT count(*) FROM stories`))[0] as [number]
+
+    await home.newStory(app.window).click()
+
+    // The gate modal lands over the shell; its title is reason-independent.
+    await expect(wizard.embedGateTitle(app.window)).toBeVisible({ timeout: 15_000 })
+
+    // Hard gate: no story is committed while it's up (the count is unchanged).
+    const after = (await queryApp(app.window, `SELECT count(*) FROM stories`))[0] as [number]
+    expect(after[0], 'no story created behind the gate').toBe(before[0])
+  })
+})

--- a/e2e/tests/wizard-resume-draft.spec.ts
+++ b/e2e/tests/wizard-resume-draft.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from '@playwright/test'
+
+import { queryApp } from '../harness/db'
+import { installEmbedderModel } from '../harness/embedder'
+import { launchApp, type LaunchedApp } from '../harness/launch'
+import { createSeededUserDataDir, removeUserDataDir } from '../harness/seed'
+import { home } from '../locators/home'
+import { wizard } from '../locators/wizard'
+
+// The real "resume a draft" round-trip: save a draft in-app (writes the stories
+// row + the wizard_sessions blob), return to the list, reopen it (hydrated from
+// that blob), and Finish. The seam under test is draft *promotion* — Finish
+// carries the sourceDraftId so it flips the existing row draft→active instead of
+// minting a duplicate. The seed has no wizard_sessions rows, so this is driven
+// entirely through the app. See docs/testing.md → Coverage.
+test.describe('create-story wizard — resume a draft', () => {
+  let app: LaunchedApp
+  let userDataDir: string | undefined
+  const STORY = {
+    title: 'The Tin Almanac',
+    opening: 'The almanac predicted rain for a year that never came.',
+  }
+
+  test.beforeAll(async () => {
+    test.setTimeout(180_000)
+    ;({ userDataDir } = createSeededUserDataDir())
+    await installEmbedderModel(userDataDir)
+    app = await launchApp({ userDataDir, cleanupUserData: true })
+  })
+
+  test.afterAll(async () => {
+    await app?.close()
+    removeUserDataDir(userDataDir)
+  })
+
+  test('promotes a resumed draft on Finish without duplicating it', async () => {
+    // Phase 1 — author a creative draft up to step 5, then Save as draft.
+    await home.newStory(app.window).click()
+    await expect(wizard.modeOption(app.window, 'creative')).toBeVisible({ timeout: 15_000 })
+    await wizard.modeOption(app.window, 'creative').click()
+    await wizard.next(app.window).click()
+    await wizard.next(app.window).click()
+    await expect(wizard.opening(app.window)).toBeVisible()
+    await wizard.opening(app.window).fill(STORY.opening)
+    await wizard.title(app.window).fill(STORY.title)
+    await wizard.saveDraft(app.window).click()
+
+    // Save-as-draft routes back to the story list.
+    await expect(home.newStory(app.window)).toBeVisible({ timeout: 15_000 })
+
+    const draftRows = await queryApp(app.window, `SELECT status FROM stories WHERE title = ?`, [
+      STORY.title,
+    ])
+    expect(draftRows.length, 'draft row written').toBe(1)
+    expect((draftRows[0] as [string])[0]).toBe('draft')
+    const totalAfterSave = (
+      (await queryApp(app.window, `SELECT count(*) FROM stories`))[0] as [number]
+    )[0]
+
+    // Phase 2 — reopen the draft (same storyCard.open affordance); it hydrates
+    // on the saved step (5), so Finish is immediately available.
+    await home.openStory(app.window, STORY.title).click()
+    await expect(wizard.finish(app.window)).toBeVisible({ timeout: 15_000 })
+    await wizard.finish(app.window).click()
+    await app.window.waitForURL(/\/reader-composer\//, { timeout: 30_000 })
+
+    // Promotion, not duplication: the same row flipped to active, total unchanged.
+    const finalRows = await queryApp(app.window, `SELECT status FROM stories WHERE title = ?`, [
+      STORY.title,
+    ])
+    expect(finalRows.length, 'no duplicate story minted').toBe(1)
+    expect((finalRows[0] as [string])[0]).toBe('active')
+    const totalAfterFinish = (
+      (await queryApp(app.window, `SELECT count(*) FROM stories`))[0] as [number]
+    )[0]
+    expect(totalAfterFinish, 'draft promoted in place').toBe(totalAfterSave)
+  })
+})

--- a/e2e/tests/wizard.spec.ts
+++ b/e2e/tests/wizard.spec.ts
@@ -1,30 +1,12 @@
-import { expect, test, type Page } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 
 import { createAdventureStory } from '../flows/create-story'
+import { queryApp } from '../harness/db'
 import { installEmbedderModel } from '../harness/embedder'
 import { launchApp, type LaunchedApp } from '../harness/launch'
 import { createSeededUserDataDir, removeUserDataDir } from '../harness/seed'
 import { home } from '../locators/home'
 import { wizard } from '../locators/wizard'
-
-// Query the fixture DB through the app's own bridge (window.aventurasDb) so the
-// read goes through the same main-process connection that just wrote — the
-// faithful outcome check (docs/testing.md → Selector strategy, Tier 1).
-// sqlite-proxy hands back rows as arrays-of-values.
-async function dbRows(page: Page, sql: string, params: unknown[] = []): Promise<unknown[][]> {
-  const result = await page.evaluate(
-    ({ sql, params }) =>
-      (
-        window as unknown as {
-          aventurasDb: {
-            query: (s: string, p: unknown[], m: string) => Promise<{ rows: unknown[][] }>
-          }
-        }
-      ).aventurasDb.query(sql, params, 'all'),
-    { sql, params },
-  )
-  return result.rows
-}
 
 test.describe('create-story wizard', () => {
   let app: LaunchedApp
@@ -55,7 +37,7 @@ test.describe('create-story wizard', () => {
     await createAdventureStory(app.window, STORY)
 
     // Story row committed and active.
-    const storyRows = await dbRows(
+    const storyRows = await queryApp(
       app.window,
       `SELECT id, current_branch_id, status FROM stories WHERE title = ?`,
       [STORY.title],
@@ -65,7 +47,7 @@ test.describe('create-story wizard', () => {
     expect(status).toBe('active')
 
     // Lead entity persisted on the story's branch.
-    const entityRows = await dbRows(
+    const entityRows = await queryApp(
       app.window,
       `SELECT id FROM entities WHERE branch_id = ? AND name = ? AND kind = 'character'`,
       [branchId, STORY.lead],
@@ -74,7 +56,7 @@ test.describe('create-story wizard', () => {
     const leadId = (entityRows[0] as [string])[0]
 
     // The real embed populated the vec0 table for the lead (dim 384).
-    const vecRows = await dbRows(
+    const vecRows = await queryApp(
       app.window,
       `SELECT count(*) FROM entities_vec_384 WHERE id = ? AND branch_id = ?`,
       [leadId, branchId],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added creative-mode story creation without requiring a lead entity.
  * Added draft saving and resume support, including promotion to active stories.
  * Added reader controls for editing, canceling, undoing, redoing, and rolling back entries.
  * Added composer modes for different response styles.
  * Added retry and dismiss actions when narrative generation fails.

* **Bug Fixes**
  * Prevented story creation when no usable embedder is available.
  * Improved recovery from interrupted narrative generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->