### PR TITLE
fix: consolidate onlyBuiltDependencies into pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -247,10 +247,5 @@
     "node": ">=24",
     "pnpm": ">=10.0.0"
   },
-  "packageManager": "pnpm@10.33.1",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3"
-    ]
-  }
+  "packageManager": "pnpm@10.33.1"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 nodeLinker: hoisted
 onlyBuiltDependencies:
+  - better-sqlite3
   - electron
   - electron-winstaller
   - esbuild


### PR DESCRIPTION
package.json's pnpm.onlyBuiltDependencies:[better-sqlite3] overrode (didn't merge with) the workspace list, so electron, electron-winstaller, esbuild, lefthook, and unrs-resolver were silently skipped at install; move better-sqlite3 into the workspace list and drop the package.json block so one authoritative list allows all six. pnpm ignored-builds now reports only onnxruntime-node/protobufjs/sharp (which Electron rebuilds separately).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package installation settings to consistently allow the required native database component to build.
  * Simplified package manager configuration while preserving the existing workspace setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->