### PR TITLE
fix(db): open the database from the app config dir, not the app data dir

### DIFF
--- a/src-tauri/src/avt_import.rs
+++ b/src-tauri/src/avt_import.rs
@@ -333,8 +333,8 @@ impl<'de, F: FnMut(ImageRow) -> Result<(), String>> Visitor<'de> for ImportRootS
 async fn open_rw_pool(app: &AppHandle) -> Result<SqlitePool, String> {
     let db = app
         .path()
-        .app_data_dir()
-        .map_err(|e| format!("failed to resolve app data dir: {e}"))?
+        .app_config_dir()
+        .map_err(|e| format!("failed to resolve app config dir: {e}"))?
         .join("aventura.db");
 
     let options = SqliteConnectOptions::new()

--- a/src-tauri/src/backup.rs
+++ b/src-tauri/src/backup.rs
@@ -18,12 +18,12 @@ use tauri::{AppHandle, Manager};
 use zip::write::SimpleFileOptions;
 use zip::{CompressionMethod, ZipArchive, ZipWriter};
 
-/// Path to the live application database (app_data_dir/aventura.db).
+/// Path to the live application database (app_config_dir/aventura.db).
 fn db_path(app: &AppHandle) -> Result<PathBuf, String> {
     Ok(app
         .path()
-        .app_data_dir()
-        .map_err(|e| format!("failed to resolve app data dir: {e}"))?
+        .app_config_dir()
+        .map_err(|e| format!("failed to resolve app config dir: {e}"))?
         .join("aventura.db"))
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -252,8 +252,8 @@ pub fn run() {
         .setup(|app| {
             let db_path = app
                 .path()
-                .app_data_dir()
-                .expect("failed to get app data dir")
+                .app_config_dir()
+                .expect("failed to get app config dir")
                 .join("aventura.db");
 
             if db_path.try_exists().expect("failed to check db path") {


### PR DESCRIPTION
Small fix, and I may well be missing context on why it was written this way — happy to be told otherwise.

`tauri-plugin-sql` resolves `sqlite:aventura.db` against Tauri's **app config dir**. Three places in the Rust layer open the same file directly, and they all resolve `app_data_dir()`:

- `backup.rs` — `db_path()`, used by backup, restore and image export
- `avt_import.rs` — `open_rw_pool()`, the `.avt` image import pass
- `lib.rs` — the setup hook that patches the stored `sqlx` migration checksums

On Linux those are two different directories (`~/.config/<bundle-id>` vs `~/.local/share/<bundle-id>`), so these paths point at a file that does not exist. The checksum patch is guarded by `try_exists()` and so just silently does nothing; the backup and `.avt` paths hit the missing file directly.

This changes the three call sites to `app_config_dir()` (and the matching error strings / doc comment), nothing else.

On testing: I looked at covering this, but every version I tried ended up asserting Tauri's own path resolver rather than the property that matters — that these agree with wherever `tauri-plugin-sql` opens the database. If you would like a test anyway, tell me the shape you would prefer and I will add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database location handling by consistently using the application’s configuration directory.
  * Updated database access, backup, and migration checks to use the corrected location.
  * Updated related error messaging to reflect the new database path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->