### PR TITLE
Per-story narration length, and one owner for orphaned scroll locks

### DIFF
--- a/src/lib/components/debug/DebugLogModal.svelte
+++ b/src/lib/components/debug/DebugLogModal.svelte
@@ -5,11 +5,16 @@
   import * as ResponsiveModal from '$lib/components/ui/responsive-modal'
   import { Button } from '$lib/components/ui/button'
   import DebugLogView from './DebugLogView.svelte'
+  import { MODAL_CLOSE_TRANSITION_MS } from '$lib/constants/layout'
 
-  // Throttled snapshot of logs - only updates every 500ms when modal is open
+  /** Throttle window. The snapshot is a whole copy of the log, so this is not free. */
+  const THROTTLE_MS = 1200
+
+  // Throttled snapshot of logs - only refreshed every THROTTLE_MS while the modal is open
   let throttledLogs = $state<DebugLogEntry[]>([])
   let lastUpdateTime = 0
   let pendingUpdate: ReturnType<typeof setTimeout> | null = null
+  let releaseTimer: ReturnType<typeof setTimeout> | null = null
   let showContent = $state(false)
 
   // Single effect to handle both modal opening and log updates
@@ -20,10 +25,24 @@
         clearTimeout(pendingUpdate)
         pendingUpdate = null
       }
-      showContent = false
-      lastUpdateTime = 0 // Reset to force immediate sync on next open
-      throttledLogs = [] // Clear stale snapshot
+      // The DOM has to stay put through the close transition, so the snapshot is dropped
+      // after it rather than here — it is every request and response of the session, and on
+      // Android the WebView heap is a hard cap. Re-checked in case the panel reopened.
+      if (releaseTimer) clearTimeout(releaseTimer)
+      releaseTimer = setTimeout(() => {
+        releaseTimer = null
+        if (debug.debugModalOpen) return
+        throttledLogs = []
+        showContent = false
+      }, MODAL_CLOSE_TRANSITION_MS)
+
+      lastUpdateTime = 0
       return
+    }
+
+    if (releaseTimer) {
+      clearTimeout(releaseTimer)
+      releaseTimer = null
     }
 
     // Track logsVersion to know when logs change
@@ -32,8 +51,8 @@
     const now = Date.now()
     const timeSinceLastUpdate = now - lastUpdateTime
 
-    // Immediate update if: first open (lastUpdateTime === 0) or throttle period elapsed
-    if (lastUpdateTime === 0 || timeSinceLastUpdate >= 500) {
+    // Immediate update if: first open (lastUpdateTime === 0) or the throttle window elapsed
+    if (lastUpdateTime === 0 || timeSinceLastUpdate >= THROTTLE_MS) {
       throttledLogs = debug.getSnapshot()
       lastUpdateTime = now
       if (pendingUpdate) {
@@ -47,10 +66,13 @@
     } else if (!pendingUpdate) {
       // Schedule update for remaining throttle time
       pendingUpdate = setTimeout(() => {
+        // Cleared before the early return: leaving it set wedges the throttle, since the
+        // branch that schedules a refresh is guarded on it being null.
+        pendingUpdate = null
+        if (!debug.debugModalOpen) return
         throttledLogs = debug.getSnapshot()
         lastUpdateTime = Date.now()
-        pendingUpdate = null
-      }, 500 - timeSinceLastUpdate)
+      }, THROTTLE_MS - timeSinceLastUpdate)
     }
   })
 

--- a/src/lib/components/layout/AppShell.svelte
+++ b/src/lib/components/layout/AppShell.svelte
@@ -18,11 +18,20 @@
   import SyncModal from '$lib/components/sync/SyncModal.svelte'
   import STChatImportModal from '$lib/components/modals/STChatImportModal.svelte'
   import { swipe } from '$lib/utils/swipe'
+  import { releaseOrphanScrollLock } from '$lib/utils/scrollLock'
+  import { createLogger } from '$lib/log'
   import { Bug } from '@lucide/svelte'
-  import { MIN_SIDEBAR_WIDTH, MAX_SIDEBAR_WIDTH, MAX_SIDEBAR_RATIO } from '$lib/constants/layout'
+  import {
+    MIN_SIDEBAR_WIDTH,
+    MAX_SIDEBAR_WIDTH,
+    MAX_SIDEBAR_RATIO,
+    MODAL_CLOSE_TRANSITION_MS,
+  } from '$lib/constants/layout'
   import type { Snippet } from 'svelte'
 
   let { children }: { children?: Snippet } = $props()
+
+  const log = createLogger('AppShell')
 
   // Swipe handlers for mobile sidebar toggle
   function handleSwipeLeft() {
@@ -161,6 +170,35 @@
       document.body.style.userSelect = ''
     }
   })
+
+  /**
+   * The single owner of orphaned-scroll-lock recovery, for the whole app: watches
+   * `document.body` for a lock and, once the close transition has had time to run, releases
+   * it if nothing on screen should be holding it. See `$lib/utils/scrollLock`.
+   */
+  $effect(() => {
+    if (typeof document === 'undefined') return
+
+    let settleTimer: ReturnType<typeof setTimeout> | null = null
+
+    const observer = new MutationObserver(() => {
+      const { pointerEvents, overflow } = document.body.style
+      if (pointerEvents !== 'none' && overflow !== 'hidden') return
+
+      if (settleTimer) clearTimeout(settleTimer)
+      settleTimer = setTimeout(() => {
+        settleTimer = null
+        if (releaseOrphanScrollLock()) log('Released an orphaned body scroll lock')
+      }, MODAL_CLOSE_TRANSITION_MS)
+    })
+
+    observer.observe(document.body, { attributes: true, attributeFilter: ['style'] })
+
+    return () => {
+      if (settleTimer) clearTimeout(settleTimer)
+      observer.disconnect()
+    }
+  })
 </script>
 
 <svelte:window
@@ -256,9 +294,10 @@
   <STChatImportModal />
 
   <!-- Floating Debug Button (when debug mode enabled) - draggable, high z-index -->
-  {#if settings.uiSettings.debugMode && !debug.debugModalOpen}
+  {#if settings.uiSettings.debugMode}
     <button
       class="fixed z-30 flex h-12 w-12 items-center justify-center rounded-full bg-amber-600 text-white shadow-lg transition-shadow hover:bg-amber-500 active:shadow-xl"
+      class:hidden={debug.debugModalOpen}
       class:cursor-grabbing={isDraggingDebug}
       class:cursor-grab={!isDraggingDebug}
       style="{debugBtnX !== null && debugBtnY !== null

--- a/src/lib/components/settings/tabs/story-settings.svelte
+++ b/src/lib/components/settings/tabs/story-settings.svelte
@@ -3,7 +3,13 @@
   import { story } from '$lib/stores/story.svelte'
   import { hasRequiredCredentials } from '$lib/services/ai/image'
   import { templateEngine } from '$lib/services/templates/engine'
-  import { PROMPT_TEMPLATES } from '$lib/services/prompts/templates'
+  import {
+    PROMPT_TEMPLATES,
+    LENGTH_INSTRUCTION_VAR,
+    templateUsesLengthInstruction,
+  } from '$lib/services/prompts/templates'
+  import { ContextBuilder } from '$lib/services/context'
+  import { database } from '$lib/services/database'
   import WritingStyleFields from '$lib/components/shared/WritingStyleFields.svelte'
   import { Textarea } from '$lib/components/ui/textarea'
   import { Button } from '$lib/components/ui/button'
@@ -109,6 +115,41 @@
   // ── Derived flags ─────────────────────────────────────────────────────────────
 
   const isActive = $derived(!!savedCustomPrompt)
+
+  /**
+   * Response Length only does anything if the prompt that will actually run renders
+   * `{{ lengthInstruction }}` — a per-story override replaces the pack template outright,
+   * and a pack created before the variable existed keeps its own copy of the body.
+   */
+  let lengthUnavailableReason = $state<string | undefined>(undefined)
+  $effect(() => {
+    const storyId = story.currentStory?.id
+    const override = savedCustomPrompt
+    const templateId =
+      story.currentStory?.mode === 'creative-writing' ? 'creative-writing' : 'adventure'
+    if (!storyId) return
+
+    let cancelled = false
+    const resolve = async () => {
+      if (override) return templateUsesLengthInstruction(override)
+      const packId = (await database.getStoryPackId(storyId)) || 'default-pack'
+      const template = await new ContextBuilder(packId).resolveTemplate(templateId)
+      return templateUsesLengthInstruction(template?.content)
+    }
+
+    resolve().then((supported) => {
+      if (cancelled) return
+      lengthUnavailableReason = supported
+        ? undefined
+        : `The active ${override ? 'custom prompt' : 'prompt pack template'} does not use ` +
+          `{{ ${LENGTH_INSTRUCTION_VAR} }}, so this setting would have no effect. Add it under ` +
+          `# Format${override ? '' : ', or switch the story to a pack that has it'}.`
+    })
+
+    return () => {
+      cancelled = true
+    }
+  })
   const isDirty = $derived(customPromptDraft !== (savedCustomPrompt ?? ''))
   const canSave = $derived(
     isDirty && (customPromptDraft.trim() === '' || (validationResult?.success ?? false)),
@@ -174,6 +215,8 @@
     imageGenerationMode={storySettings.imageGenerationMode ?? 'none'}
     backgroundImagesEnabled={storySettings.backgroundImagesEnabled ?? false}
     referenceMode={storySettings.referenceMode ?? false}
+    targetLength={storySettings.targetLength ?? 'dynamic'}
+    mode={story.currentStory?.mode === 'creative-writing' ? 'creative-writing' : 'adventure'}
     onPOVChange={(v) => story.updateStorySettings({ pov: v })}
     onTenseChange={(v) => story.updateStorySettings({ tense: v })}
     onToneChange={(v) => story.updateStorySettings({ tone: v })}
@@ -182,6 +225,8 @@
     onBackgroundImagesEnabledChange={(v) =>
       story.updateStorySettings({ backgroundImagesEnabled: v })}
     onReferenceModeChange={(v) => story.updateStorySettings({ referenceMode: v })}
+    onTargetLengthChange={(v) => story.updateStorySettings({ targetLength: v })}
+    targetLengthDisabledReason={lengthUnavailableReason}
     disabledFields={{ pov: true, tense: true, visualProseMode: true }}
     disabledReason="Cannot be changed mid-story. Set during story creation."
   />

--- a/src/lib/components/shared/WritingStyleFields.svelte
+++ b/src/lib/components/shared/WritingStyleFields.svelte
@@ -4,8 +4,8 @@
   import { Label } from '$lib/components/ui/label'
   import { Input } from '$lib/components/ui/input'
   import { Switch } from '$lib/components/ui/switch'
-  import { BookOpen, User, Eye } from '@lucide/svelte'
-  import type { POV, Tense } from '$lib/types'
+  import { BookOpen, User, Eye, AlignLeft } from '@lucide/svelte'
+  import type { POV, Tense, TargetLength } from '$lib/types'
 
   interface Props {
     selectedPOV: POV
@@ -16,6 +16,11 @@
     imageGenerationMode: 'none' | 'agentic' | 'inline'
     backgroundImagesEnabled: boolean
     referenceMode: boolean
+    targetLength?: TargetLength
+    /** Drives the paragraph counts shown for each length: they differ per mode. */
+    mode?: 'adventure' | 'creative-writing'
+    /** Set to disable the length control, e.g. a custom prompt that never renders it. */
+    targetLengthDisabledReason?: string
     onPOVChange: (v: POV) => void
     onTenseChange: (v: Tense) => void
     onToneChange: (v: string) => void
@@ -23,6 +28,7 @@
     onImageGenerationModeChange: (v: 'none' | 'agentic' | 'inline') => void
     onBackgroundImagesEnabledChange: (v: boolean) => void
     onReferenceModeChange: (v: boolean) => void
+    onTargetLengthChange?: (v: TargetLength) => void
     disabledFields?: {
       pov?: boolean
       tense?: boolean
@@ -40,6 +46,9 @@
     imageGenerationMode,
     backgroundImagesEnabled,
     referenceMode,
+    targetLength = 'dynamic',
+    mode = 'adventure',
+    targetLengthDisabledReason,
     onPOVChange,
     onTenseChange,
     onToneChange,
@@ -47,9 +56,56 @@
     onImageGenerationModeChange,
     onBackgroundImagesEnabledChange,
     onReferenceModeChange,
+    onTargetLengthChange,
     disabledFields,
     disabledReason,
   }: Props = $props()
+
+  /** Must match the ranges `formatLengthInstruction` asks for, which differ per mode. */
+  const LENGTH_RANGES = {
+    adventure: {
+      dynamic: {
+        short: 'Auto',
+        long: 'Adapts length naturally to scene pacing (1–2 paragraphs for action, up to 5–6 for atmosphere).',
+      },
+      short: { short: '1-3 para', long: 'Crisp and fast-paced narrative (1–3 paragraphs).' },
+      medium: { short: '2-4 para', long: 'Balanced storytelling momentum (2–4 paragraphs).' },
+      long: {
+        short: '3-6 para',
+        long: 'Detailed, expansive prose & environment (3–6 paragraphs).',
+      },
+    },
+    'creative-writing': {
+      dynamic: {
+        short: 'Auto',
+        long: 'Scales with the scene (2–3 paragraphs for rapid exchanges, 4–8 for chapter sections).',
+      },
+      short: {
+        short: '2-4 para',
+        long: 'Focused, economical prose with immediate momentum (2–4 paragraphs).',
+      },
+      medium: {
+        short: '3-6 para',
+        long: 'Balanced momentum, character voice and sensory detail (3–6 paragraphs).',
+      },
+      long: {
+        short: '5-8+ para',
+        long: 'Multi-layered literary prose, subtext and atmosphere (5–8+ paragraphs).',
+      },
+    },
+  } as const
+
+  const lengthRanges = $derived(LENGTH_RANGES[mode] ?? LENGTH_RANGES.adventure)
+  // Both come off disk, where the column is untyped text.
+  const selectedLength = $derived<TargetLength>(
+    targetLength && targetLength in lengthRanges ? targetLength : 'dynamic',
+  )
+  const lengthOptions: { id: TargetLength; label: string }[] = [
+    { id: 'dynamic', label: 'Dynamic' },
+    { id: 'short', label: 'Short' },
+    { id: 'medium', label: 'Medium' },
+    { id: 'long', label: 'Long' },
+  ]
 </script>
 
 <div class="space-y-4">
@@ -74,7 +130,7 @@
         {#each ['first', 'second', 'third'] as pov (pov)}
           <Label
             for={`pov-${pov}`}
-            class="border-muted bg-popover hover:bg-accent hover:text-accent-foreground has-[[data-state=checked]]:border-primary has-[[data-state=checked]]:bg-primary/5 flex cursor-pointer flex-col items-center justify-center rounded-md border-2 p-3 text-center"
+            class="border-muted bg-popover hover:bg-accent hover:text-accent-foreground has-[[data-state=checked]]:border-primary has-[[data-state=checked]]:bg-primary/5 has-[:focus-visible]:ring-ring flex cursor-pointer flex-col items-center justify-center rounded-md border-2 p-3 text-center has-[:focus-visible]:ring-2"
           >
             <RadioGroup.Item
               value={pov}
@@ -86,7 +142,7 @@
           </Label>
         {/each}
       </RadioGroup.Root>
-      <p class="text-muted-foreground h-4 text-xs">
+      <p class="text-muted-foreground min-h-[1.25rem] text-xs">
         {#if selectedPOV === 'first'}
           "I draw my sword..."
         {:else if selectedPOV === 'second'}
@@ -119,7 +175,7 @@
         {#each ['present', 'past'] as tense (tense)}
           <Label
             for={`tense-${tense}`}
-            class="border-muted bg-popover hover:bg-accent hover:text-accent-foreground has-[[data-state=checked]]:border-primary has-[[data-state=checked]]:bg-primary/5 flex cursor-pointer flex-col items-center justify-center rounded-md border-2 p-3 text-center"
+            class="border-muted bg-popover hover:bg-accent hover:text-accent-foreground has-[[data-state=checked]]:border-primary has-[[data-state=checked]]:bg-primary/5 has-[:focus-visible]:ring-ring flex cursor-pointer flex-col items-center justify-center rounded-md border-2 p-3 text-center has-[:focus-visible]:ring-2"
           >
             <RadioGroup.Item
               value={tense}
@@ -131,7 +187,7 @@
           </Label>
         {/each}
       </RadioGroup.Root>
-      <p class="text-muted-foreground h-4 text-xs">
+      <p class="text-muted-foreground min-h-[1.25rem] text-xs">
         {#if selectedTense === 'present'}
           Action happens now.
         {:else}
@@ -164,6 +220,43 @@
     </div>
   </section>
 
+  <!-- Response Length -->
+  {#if onTargetLengthChange}
+    {@const lengthDisabled = !!targetLengthDisabledReason}
+    <section class="space-y-2 pt-1">
+      <Label class="flex items-center gap-2 text-base font-semibold">
+        <AlignLeft class="h-4 w-4" />
+        Response Length
+      </Label>
+      <RadioGroup.Root
+        value={selectedLength}
+        onValueChange={(v) => onTargetLengthChange?.(v as TargetLength)}
+        disabled={lengthDisabled}
+        class="grid grid-cols-2 gap-2 sm:grid-cols-4 {lengthDisabled ? 'opacity-50' : ''}"
+      >
+        {#each lengthOptions as item (item.id)}
+          <Label
+            for={`length-${item.id}`}
+            class="border-muted bg-popover has-[[data-state=checked]]:border-primary has-[[data-state=checked]]:bg-primary/5 has-[:focus-visible]:ring-ring flex flex-col items-center justify-center rounded-md border-2 p-3 text-center has-[:focus-visible]:ring-2 {lengthDisabled
+              ? 'cursor-not-allowed'
+              : 'hover:bg-accent hover:text-accent-foreground cursor-pointer'}"
+          >
+            <RadioGroup.Item value={item.id} id={`length-${item.id}`} class="sr-only" />
+            <span class="font-medium">{item.label}</span>
+            <span class="text-muted-foreground text-xs">{lengthRanges[item.id].short}</span>
+          </Label>
+        {/each}
+      </RadioGroup.Root>
+      <p
+        class="min-h-[1.25rem] text-xs {lengthDisabled
+          ? 'text-amber-500'
+          : 'text-muted-foreground'}"
+      >
+        {targetLengthDisabledReason ?? lengthRanges[selectedLength].long}
+      </p>
+    </section>
+  {/if}
+
   <!-- Visuals Configuration -->
   {#if imageGenerationEnabled}
     <section class="space-y-2 pt-1">
@@ -181,7 +274,7 @@
         <div class="relative">
           <Label
             for="img-none"
-            class="border-muted bg-popover hover:bg-accent has-[[data-state=checked]]:border-primary has-[[data-state=checked]]:bg-primary/5 flex h-full cursor-pointer flex-col justify-between rounded-xl border-2 p-4"
+            class="border-muted bg-popover hover:bg-accent has-[[data-state=checked]]:border-primary has-[[data-state=checked]]:bg-primary/5 has-[:focus-visible]:ring-ring flex h-full cursor-pointer flex-col justify-between rounded-xl border-2 p-4 has-[:focus-visible]:ring-2"
           >
             <div class="mb-2 flex w-full items-start justify-between">
               <span class="font-semibold">Text Only</span>
@@ -197,7 +290,7 @@
         <div class="relative">
           <Label
             for="img-auto"
-            class="border-muted bg-popover hover:bg-accent has-[[data-state=checked]]:border-primary has-[[data-state=checked]]:bg-primary/5 flex h-full cursor-pointer flex-col justify-between rounded-xl border-2 p-4"
+            class="border-muted bg-popover hover:bg-accent has-[[data-state=checked]]:border-primary has-[[data-state=checked]]:bg-primary/5 has-[:focus-visible]:ring-ring flex h-full cursor-pointer flex-col justify-between rounded-xl border-2 p-4 has-[:focus-visible]:ring-2"
           >
             <div class="mb-2 flex w-full items-start justify-between">
               <span class="font-semibold">Agent Mode</span>
@@ -213,7 +306,7 @@
         <div class="relative">
           <Label
             for="img-inline"
-            class="border-muted bg-popover hover:bg-accent has-[[data-state=checked]]:border-primary has-[[data-state=checked]]:bg-primary/5 flex h-full cursor-pointer flex-col justify-between rounded-xl border-2 p-4"
+            class="border-muted bg-popover hover:bg-accent has-[[data-state=checked]]:border-primary has-[[data-state=checked]]:bg-primary/5 has-[:focus-visible]:ring-ring flex h-full cursor-pointer flex-col justify-between rounded-xl border-2 p-4 has-[:focus-visible]:ring-2"
           >
             <div class="mb-2 flex w-full items-start justify-between">
               <span class="font-semibold">Inline Mode</span>

--- a/src/lib/components/ui/responsive-modal/responsive-modal-content.svelte
+++ b/src/lib/components/ui/responsive-modal/responsive-modal-content.svelte
@@ -13,7 +13,19 @@
     {@render children?.()}
   </Drawer.Content>
 {:else}
-  <Dialog.Content class={className} {...props}>
+  <!--
+    Capped to the visible area, not the viewport: Android runs edge-to-edge, so `100vh`
+    spans the space behind the system bars and a centred `h-[90vh]` dialog can sit under
+    the navigation bar. `dvh` so the cap follows the soft keyboard too.
+
+    Inert on desktop, where every inset is 0, and a caller's own `max-h-*` still wins since
+    `className` is merged last. Height only — the matching `max-w` would be deleted by
+    every caller that sets its own, so it would only protect the modals that need it least.
+  -->
+  <Dialog.Content
+    class={cn('max-h-[calc(100dvh_-_var(--safe-top)_-_var(--safe-bottom)_-_2rem)]', className)}
+    {...props}
+  >
     {@render children?.()}
   </Dialog.Content>
 {/if}

--- a/src/lib/components/ui/responsive-modal/responsive-modal.svelte
+++ b/src/lib/components/ui/responsive-modal/responsive-modal.svelte
@@ -4,6 +4,7 @@
   import { createIsMobile } from '$lib/hooks/is-mobile.svelte'
   import type { Snippet } from 'svelte'
   import { setResponsiveModalContext } from './context'
+  import { blurFocusedElement } from '$lib/utils/scrollLock'
   import type { OnChangeFn } from 'vaul-svelte'
 
   type Props = {
@@ -17,14 +18,19 @@
 
   const isMobile = createIsMobile()
   setResponsiveModalContext({ isMobile })
+
+  function handleOpenChange(newOpen: boolean) {
+    if (!newOpen) blurFocusedElement(isMobile.current)
+    onOpenChange?.(newOpen)
+  }
 </script>
 
 {#if isMobile.current}
-  <Drawer.Root bind:open {onOpenChange} {...props}>
+  <Drawer.Root bind:open onOpenChange={handleOpenChange} {...props}>
     {@render children?.()}
   </Drawer.Root>
 {:else}
-  <Dialog.Root bind:open {onOpenChange} {...props}>
+  <Dialog.Root bind:open onOpenChange={handleOpenChange} {...props}>
     {@render children?.()}
   </Dialog.Root>
 {/if}

--- a/src/lib/components/wizard/STImportWizard.svelte
+++ b/src/lib/components/wizard/STImportWizard.svelte
@@ -4,6 +4,9 @@
   import { story } from '$lib/stores/story.svelte'
   import { hasRequiredCredentials } from '$lib/services/ai/image'
   import * as ResponsiveModal from '$lib/components/ui/responsive-modal'
+  import { releaseOrphanScrollLock, blurFocusedElement } from '$lib/utils/scrollLock'
+  import { MODAL_CLOSE_TRANSITION_MS } from '$lib/constants/layout'
+  import { createIsMobile } from '$lib/hooks/is-mobile.svelte'
   import { Button } from '$lib/components/ui/button'
   import { ChevronLeft, ChevronRight, Play } from '@lucide/svelte'
 
@@ -24,30 +27,24 @@
 
   let { onClose }: Props = $props()
 
+  const isMobile = createIsMobile()
+
   let isOpen = $state(true)
 
+  /**
+   * A close driven from this side never reaches `vaul`'s restore, and `onClose()` unmounts
+   * the component, so the teardown is done by hand. See `$lib/utils/scrollLock`.
+   */
   function handleClose() {
-    if (typeof document !== 'undefined' && document.activeElement instanceof HTMLElement) {
-      document.activeElement.blur()
-    }
+    blurFocusedElement(isMobile.current)
     isOpen = false
     setTimeout(() => {
-      if (typeof document !== 'undefined') {
-        document.body.style.pointerEvents = ''
-        document.body.style.overflow = ''
-        document.body.removeAttribute('data-scroll-locked')
-      }
+      releaseOrphanScrollLock()
       onClose()
-    }, 150)
+    }, MODAL_CLOSE_TRANSITION_MS)
   }
 
-  onDestroy(() => {
-    if (typeof document !== 'undefined') {
-      document.body.style.pointerEvents = ''
-      document.body.style.overflow = ''
-      document.body.removeAttribute('data-scroll-locked')
-    }
-  })
+  onDestroy(() => releaseOrphanScrollLock())
 
   const wizard = new STImportWizardStore(() => handleClose())
 

--- a/src/lib/components/wizard/SetupWizard.svelte
+++ b/src/lib/components/wizard/SetupWizard.svelte
@@ -2,6 +2,9 @@
   import { onDestroy } from 'svelte'
   import { WizardStore } from '$lib/stores/wizard/wizard.svelte'
   import * as ResponsiveModal from '$lib/components/ui/responsive-modal'
+  import { releaseOrphanScrollLock, blurFocusedElement } from '$lib/utils/scrollLock'
+  import { MODAL_CLOSE_TRANSITION_MS } from '$lib/constants/layout'
+  import { createIsMobile } from '$lib/hooks/is-mobile.svelte'
   import { Button } from '$lib/components/ui/button'
   import { ChevronLeft, ChevronRight, Play } from '@lucide/svelte'
   import { ui } from '$lib/stores/ui.svelte'
@@ -29,30 +32,24 @@
 
   let { onClose }: Props = $props()
 
+  const isMobile = createIsMobile()
+
   let isOpen = $state(true)
 
+  /**
+   * A close driven from this side never reaches `vaul`'s restore, and `onClose()` unmounts
+   * the component, so the teardown is done by hand. See `$lib/utils/scrollLock`.
+   */
   function handleClose() {
-    if (typeof document !== 'undefined' && document.activeElement instanceof HTMLElement) {
-      document.activeElement.blur()
-    }
+    blurFocusedElement(isMobile.current)
     isOpen = false
     setTimeout(() => {
-      if (typeof document !== 'undefined') {
-        document.body.style.pointerEvents = ''
-        document.body.style.overflow = ''
-        document.body.removeAttribute('data-scroll-locked')
-      }
+      releaseOrphanScrollLock()
       onClose()
-    }, 150)
+    }, MODAL_CLOSE_TRANSITION_MS)
   }
 
-  onDestroy(() => {
-    if (typeof document !== 'undefined') {
-      document.body.style.pointerEvents = ''
-      document.body.style.overflow = ''
-      document.body.removeAttribute('data-scroll-locked')
-    }
-  })
+  onDestroy(() => releaseOrphanScrollLock())
 
   // Initialize Wizard Store
   const wizard = new WizardStore(() => handleClose())
@@ -402,8 +399,11 @@
           onImageGenerationModeChange={(v) => (wizard.narrative.imageGenerationMode = v)}
           backgroundImagesEnabled={wizard.narrative.backgroundImagesEnabled}
           referenceMode={wizard.narrative.referenceMode}
+          targetLength={wizard.narrative.targetLength}
+          mode={wizard.narrative.selectedMode}
           onBackgroundImagesEnabledChange={(v) => (wizard.narrative.backgroundImagesEnabled = v)}
           onReferenceModeChange={(v) => (wizard.narrative.referenceMode = v)}
+          onTargetLengthChange={(v) => (wizard.narrative.targetLength = v)}
         />
       {:else if wizard.currentStep === 9}
         <Step8Opening

--- a/src/lib/components/wizard/steps/Step7WritingStyle.svelte
+++ b/src/lib/components/wizard/steps/Step7WritingStyle.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import WritingStyleFields from '$lib/components/shared/WritingStyleFields.svelte'
   import { ScrollArea } from '$lib/components/ui/scroll-area'
-  import type { POV, Tense } from '$lib/types'
+  import type { POV, Tense, TargetLength } from '$lib/types'
 
   interface Props {
     selectedPOV: POV
@@ -12,6 +12,8 @@
     imageGenerationMode: 'none' | 'agentic' | 'inline'
     backgroundImagesEnabled: boolean
     referenceMode: boolean
+    targetLength?: TargetLength
+    mode?: 'adventure' | 'creative-writing'
     onPOVChange: (v: POV) => void
     onTenseChange: (v: Tense) => void
     onToneChange: (v: string) => void
@@ -19,6 +21,7 @@
     onImageGenerationModeChange: (v: 'none' | 'agentic' | 'inline') => void
     onBackgroundImagesEnabledChange: (v: boolean) => void
     onReferenceModeChange: (v: boolean) => void
+    onTargetLengthChange?: (v: TargetLength) => void
   }
 
   let {
@@ -30,6 +33,8 @@
     imageGenerationMode,
     backgroundImagesEnabled,
     referenceMode,
+    targetLength = 'dynamic',
+    mode = 'adventure',
     onPOVChange,
     onTenseChange,
     onToneChange,
@@ -37,6 +42,7 @@
     onImageGenerationModeChange,
     onBackgroundImagesEnabledChange,
     onReferenceModeChange,
+    onTargetLengthChange,
   }: Props = $props()
 
   // Force "none" mode when image generation is disabled (wizard only)
@@ -67,6 +73,8 @@
       {imageGenerationMode}
       {backgroundImagesEnabled}
       {referenceMode}
+      {targetLength}
+      {mode}
       {onPOVChange}
       {onTenseChange}
       {onToneChange}
@@ -74,6 +82,7 @@
       {onImageGenerationModeChange}
       {onBackgroundImagesEnabledChange}
       {onReferenceModeChange}
+      {onTargetLengthChange}
     />
   </ScrollArea>
 </div>

--- a/src/lib/constants/layout.ts
+++ b/src/lib/constants/layout.ts
@@ -2,3 +2,12 @@ export const DESKTOP_BREAKPOINT = 768
 export const MIN_SIDEBAR_WIDTH = 250
 export const MAX_SIDEBAR_WIDTH = 800
 export const MAX_SIDEBAR_RATIO = 0.6
+
+/**
+ * How long a modal takes to leave the screen.
+ *
+ * Matches `vaul`'s own restore delay, so anything that has to happen *after* a close —
+ * unmounting the component, dropping a cached snapshot, checking for an orphaned body
+ * lock — waits the same amount everywhere.
+ */
+export const MODAL_CLOSE_TRANSITION_MS = 500

--- a/src/lib/services/ai/generation/NarrativeService.ts
+++ b/src/lib/services/ai/generation/NarrativeService.ts
@@ -13,6 +13,7 @@
 
 import { streamNarrative, generateNarrative } from '../sdk/generate'
 import { ContextBuilder } from '$lib/services/context'
+import { formatLengthInstruction } from '$lib/services/prompts/templates'
 import { StyleReviewerService } from './StyleReviewerService'
 import { templateEngine } from '$lib/services/templates/engine'
 import { createLogger } from '$lib/log'
@@ -412,6 +413,16 @@ export class NarrativeService {
       chapterSummaries: '',
       storyTime: (ctx.getContext().storyTime as string) ?? '',
     })
+
+    // `ContextBuilder.forStory` sets these; this covers contexts built another way, since
+    // the templates render `{{ lengthInstruction }}` bare.
+    if (!ctx.getContext().lengthInstruction) {
+      const targetLength = story?.settings?.targetLength || 'dynamic'
+      ctx.add({
+        targetLength,
+        lengthInstruction: formatLengthInstruction(targetLength, mode),
+      })
+    }
 
     // Add runtime variables for template rendering
     // These are pre-formatted blocks that templates inject via {{ variable }}

--- a/src/lib/services/ai/wizard/ScenarioService.ts
+++ b/src/lib/services/ai/wizard/ScenarioService.ts
@@ -5,7 +5,7 @@
  */
 
 import { settings } from '$lib/stores/settings.svelte'
-import type { StoryMode, POV, Character, Location, Item } from '$lib/types'
+import type { StoryMode, POV, TargetLength, Character, Location, Item } from '$lib/types'
 import { ContextBuilder } from '$lib/services/context'
 import { createLogger } from '$lib/log'
 import {
@@ -47,6 +47,7 @@ export interface WizardData {
     imageGenerationMode?: 'none' | 'agentic' | 'inline'
     backgroundImagesEnabled?: boolean
     referenceMode?: boolean
+    targetLength?: TargetLength
   }
   title: string
   openingGuidance?: string
@@ -784,6 +785,7 @@ class ScenarioService {
       imageGenerationMode?: 'none' | 'agentic' | 'inline'
       backgroundImagesEnabled?: boolean
       referenceMode?: boolean
+      targetLength?: TargetLength
     }
     protagonist: Partial<Character>
     startingLocation: Partial<Location>
@@ -809,6 +811,7 @@ class ScenarioService {
         imageGenerationMode: writingStyle.imageGenerationMode,
         backgroundImagesEnabled: writingStyle.backgroundImagesEnabled,
         referenceMode: writingStyle.referenceMode,
+        targetLength: writingStyle.targetLength,
       },
       protagonist: {
         name: protagonist?.name || (writingStyle.pov === 'second' ? 'You' : 'The Protagonist'),

--- a/src/lib/services/context/context-builder.ts
+++ b/src/lib/services/context/context-builder.ts
@@ -10,7 +10,7 @@
  */
 
 import { database } from '$lib/services/database'
-import { PROMPT_TEMPLATES } from '$lib/services/prompts/templates'
+import { PROMPT_TEMPLATES, formatLengthInstruction } from '$lib/services/prompts/templates'
 import { templateEngine } from '$lib/services/templates/engine'
 import { createLogger } from '$lib/log'
 import type { RenderResult } from './types'
@@ -41,9 +41,13 @@ export class ContextBuilder {
     const packId = packIdOverride || (await database.getStoryPackId(storyId)) || 'default-pack'
     const builder = new ContextBuilder(packId)
 
+    const mode = story.mode || 'adventure'
+    const targetLength = story.settings?.targetLength || 'dynamic'
+    const lengthInstruction = formatLengthInstruction(targetLength, mode)
+
     // Load story data into context
     builder.add({
-      mode: story.mode || 'adventure',
+      mode,
       pov: story.settings?.pov || 'second',
       tense: story.settings?.tense || 'present',
       genre: story.genre || '',
@@ -52,6 +56,8 @@ export class ContextBuilder {
       settingDescription: story.description || '',
       visualProseMode: story.settings?.visualProseMode || false,
       inlineImageMode: story.settings?.imageGenerationMode === 'inline',
+      targetLength,
+      lengthInstruction,
     })
 
     // Protagonist
@@ -144,7 +150,7 @@ export class ContextBuilder {
    * that renders as an empty prompt and the caller silently issues a contentless
    * request, which is far worse than using a slightly less customized template.
    */
-  private async resolveTemplate(templateId: string): Promise<{ content: string } | null> {
+  async resolveTemplate(templateId: string): Promise<{ content: string } | null> {
     const own = await database.getPackTemplate(this.packId, templateId)
     if (own) return own
 

--- a/src/lib/services/prompts/templates/index.ts
+++ b/src/lib/services/prompts/templates/index.ts
@@ -18,3 +18,9 @@ export const PROMPT_TEMPLATES: PromptTemplate[] = [
   ...translationTemplates,
   ...imageTemplates,
 ]
+
+export {
+  LENGTH_INSTRUCTION_VAR,
+  formatLengthInstruction,
+  templateUsesLengthInstruction,
+} from './lengthInstruction'

--- a/src/lib/services/prompts/templates/lengthInstruction.ts
+++ b/src/lib/services/prompts/templates/lengthInstruction.ts
@@ -1,0 +1,38 @@
+/**
+ * The `# Format` length line the narrative templates render as `{{ lengthInstruction }}`.
+ *
+ * Total by design — it returns a sentence for every input, including `undefined` — so the
+ * templates can render the variable bare, with no `{% if %}` and no duplicated default.
+ */
+
+/** The template variable this feeds. A prompt without it cannot honour a length setting. */
+export const LENGTH_INSTRUCTION_VAR = 'lengthInstruction'
+
+export function formatLengthInstruction(targetLength?: string, mode: string = 'adventure'): string {
+  const isCreative = mode === 'creative-writing'
+
+  switch (targetLength) {
+    case 'short':
+      return isCreative
+        ? "Length: Compact Beat (2–4 paragraphs). Deliver focused, evocative prose that executes the author's direction with economy and immediate momentum."
+        : 'Length: Concise (1–3 paragraphs). Keep the prose crisp and fast-paced, focusing on immediate sensory feedback and prompt player agency.'
+    case 'medium':
+      return isCreative
+        ? 'Length: Standard Scene (3–6 paragraphs). Balance narrative momentum with rich character voice, sensory detail, and natural scene progression.'
+        : 'Length: Balanced (2–4 paragraphs). Provide immersive detail and NPC reactions while maintaining a steady narrative momentum.'
+    case 'long':
+      return isCreative
+        ? 'Length: Full Scene / Chapter Pass (5–8+ paragraphs). Craft immersive, multi-layered literary prose, thoroughly expanding on character internalities, subtext, and vivid atmospheric texture.'
+        : 'Length: Expansive (3–6 paragraphs). Develop rich environmental detail, deep character subtext, and layered narrative beats.'
+    case 'dynamic':
+    default:
+      return isCreative
+        ? "Length: Dynamic (2–8 paragraphs). Scale the depth of narration to serve the scene's momentum: brief and direct (2–3 paragraphs) during rapid back-and-forth interactions; lush and comprehensive (4–8 paragraphs) when crafting immersive chapter sections, character reflections, or evocative environment setups."
+        : "Length: Dynamic (1–6 paragraphs). Adapt the response length naturally to the scene's pacing: write concise, punchy narration (1–2 paragraphs) during fast-paced action, quick dialogue exchanges, or key decision points; expand into richer, atmospheric prose (up to 5–6 paragraphs) during quiet exploration, scene transitions, or emotional beats."
+  }
+}
+
+/** Whether a template body would render the length line at all. */
+export function templateUsesLengthInstruction(content: string | null | undefined): boolean {
+  return !!content && new RegExp(`{{\\s*${LENGTH_INSTRUCTION_VAR}\\b`).test(content)
+}

--- a/src/lib/services/prompts/templates/narrative.ts
+++ b/src/lib/services/prompts/templates/narrative.ts
@@ -90,7 +90,7 @@ When [LOREBOOK CONTEXT] is provided, treat it as canonical:
 - Dialogue tag overload: "said" is invisible; use fancy tags sparingly
 
 # Format
-- Length: Around 250 words per response
+- {{ lengthInstruction }}
 - Build each response toward one crystallizing moment—the image or line the player ({{ protagonistName }}) remembers
 - End at a moment of potential action—an NPC awaiting response, a door to open, a sound demanding investigation
 - Create a pregnant pause that naturally invites the player's next move
@@ -264,7 +264,7 @@ When [LOREBOOK CONTEXT] is provided, treat it as canonical:
 - Banned names: Elara, Kael, Lyra, Seraphina, Thorne, Astra, Zephyr, Caelan, Rowan (when male), Kai—use more distinctive names
 
 # Format
-- Length: Up to 500 words per response
+- {{ lengthInstruction }}
 - End at natural narrative beats; preserve tension rather than resolving it artificially
 - Balance action, dialogue, and description
 

--- a/src/lib/stores/wizard/narrativeStore.svelte.ts
+++ b/src/lib/stores/wizard/narrativeStore.svelte.ts
@@ -7,7 +7,7 @@ import {
 import { aiService } from '$lib/services/ai'
 import { TranslationService } from '$lib/services/ai/utils/TranslationService'
 import { settings } from '$lib/stores/settings.svelte'
-import type { StoryMode, POV, VaultLorebook } from '$lib/types'
+import type { StoryMode, POV, TargetLength, VaultLorebook } from '$lib/types'
 import type { ImportedLorebookItem } from '$lib/components/wizard/wizardTypes'
 import type { GeneratedOpening } from '$lib/services/ai/sdk'
 
@@ -31,6 +31,7 @@ export class NarrativeStore {
   imageGenerationMode = $state<'none' | 'agentic' | 'inline'>('none')
   backgroundImagesEnabled = $state(false)
   referenceMode = $state(false)
+  targetLength = $state<TargetLength>('dynamic')
 
   // Step 9: Opening
   storyTitle = $state('')

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -109,6 +109,9 @@ export interface MemoryConfig {
   summaryDetail?: SummaryDetail // Detail level for chapter summaries (default: 'auto')
 }
 
+/** Target narration length for a turn. Drives `{{ lengthInstruction }}` in the prompt. */
+export type TargetLength = 'short' | 'medium' | 'long' | 'dynamic'
+
 export interface StorySettings {
   model?: string
   temperature?: number
@@ -121,6 +124,7 @@ export interface StorySettings {
   imageGenerationMode?: 'none' | 'agentic' | 'inline' // Image generation strategy
   backgroundImagesEnabled?: boolean
   referenceMode?: boolean
+  targetLength?: TargetLength
   customSystemPrompt?: string // Per-story Liquid template override; bypasses pack template when set
 }
 

--- a/src/lib/utils/scrollLock.ts
+++ b/src/lib/utils/scrollLock.ts
@@ -1,0 +1,64 @@
+/**
+ * Teardown a closing modal can leave behind: a body scroll lock, and a focused field.
+ *
+ * Both modal libraries lock `document.body` while something is open and clean up on the
+ * path they expect. The path they do not expect is the component being unmounted while
+ * still open, which is how several modals here close — `SetupWizard.handleClose()` flips
+ * `isOpen` and then calls `onClose()`, which removes the whole thing from the tree.
+ *
+ * `vaul-svelte` restores from the setter of its `open` box, so a close driven from the
+ * other side never reaches it and `body` keeps `pointer-events: none` for the rest of the
+ * session — an app that renders perfectly and ignores every tap.
+ *
+ * Nothing here is a substitute for closing a modal properly. It is the net under it.
+ */
+
+/**
+ * Everything in this stack that legitimately holds a body lock, as it appears in the DOM.
+ *
+ * Only `preventScroll` defaults to true in `bits-ui` — dialog, alert-dialog and
+ * context-menu; select, popover and dropdown-menu never lock. A missing selector here
+ * would unlock the page under an open modal.
+ */
+const OPEN_OVERLAY_SELECTOR = [
+  '[role="dialog"][data-state="open"]',
+  '[role="alertdialog"][data-state="open"]',
+  '[role="menu"][data-state="open"]',
+  '[data-vaul-drawer][data-state="open"]',
+].join(', ')
+
+/** Is anything on screen entitled to be holding the body lock right now? */
+function hasOpenOverlay(): boolean {
+  return document.querySelector(OPEN_OVERLAY_SELECTOR) !== null
+}
+
+/**
+ * Drop the body lock, but only if nothing open should be holding it.
+ *
+ * Returns whether it released anything, which is what makes it safe to call from a modal's
+ * own teardown: a modal closing on top of another finds the one underneath and leaves the
+ * lock alone.
+ *
+ * `document.body` only — neither library writes the equivalent on `documentElement`, and
+ * `data-scroll-locked` is a Radix attribute this app never sets.
+ */
+export function releaseOrphanScrollLock(): boolean {
+  if (typeof document === 'undefined') return false
+  if (hasOpenOverlay()) return false
+
+  document.body.style.pointerEvents = ''
+  document.body.style.overflow = ''
+  return true
+}
+
+/**
+ * Drop focus, so the Android soft keyboard goes down with the modal that raised it.
+ *
+ * Mobile only: on desktop both libraries return focus to whatever opened the modal, and
+ * blurring first sends it to `<body>` instead — Tab restarts from the top of the document
+ * and a screen reader loses its place. There is no keyboard there to buy that back.
+ */
+export function blurFocusedElement(isMobile: boolean): void {
+  if (!isMobile || typeof document === 'undefined') return
+  if (document.activeElement instanceof HTMLElement) document.activeElement.blur()
+}


### PR DESCRIPTION
> **Rescoped.** This PR previously carried a batch of unrelated work. That work is now split
> across four branches; this one keeps the narration-length and modal/scroll changes. The
> others are #416, #417 and #418.

## Narration length

A per-story **target length** — short / medium / long / dynamic — set in the setup wizard
and changeable in Story Settings, rendered into the narrator prompt as
`{{ lengthInstruction }}`.

It replaces the hardcoded "around 250 words" and "up to 500 words" lines the two narrative
templates carried, which were not adjustable and were the same in both story modes.

- `WritingStyleFields` takes a `mode` prop. The paragraph counts it displayed were the
  adventure ones only, so a Creative Writing story advertised ranges its own prompt does
  not ask for. One table now covers both modes, and both call sites pass their mode.
- Story Settings **disables the control, with the reason**, when the prompt that will
  actually run does not render the variable. A per-story override replaces the pack
  template outright, and a pack created before the variable existed keeps its own copy of
  the body — in both cases the setting would silently do nothing. That check is why
  `ContextBuilder.resolveTemplate` is no longer private.
- `NarrativeService` fills the variable itself for contexts not built by
  `ContextBuilder.forStory`, since the templates render it bare.
- Visible focus ring on the sr-only radio labels, via `has-[:focus-visible]:` — the items
  are children, not peers.

## Orphaned scroll locks

Both modal libraries lock `document.body` while something is open and clean up on the path
they expect. The path they do not expect is the component being unmounted while still open,
which is how several modals here close: `SetupWizard.handleClose()` flips `isOpen` and then
calls `onClose()`, which removes the whole thing from the tree. `vaul-svelte` restores from
the setter of its `open` box, so a close driven from the other side never reaches it and
`body` keeps `pointer-events: none` for the rest of the session — an app that renders
perfectly and ignores every tap.

- Recovery now has **one owner**: `AppShell` watches `document.body` and releases an orphan
  once the close transition has had time to run, replacing four ad-hoc recoveries.
- `releaseOrphanScrollLock` checks whether anything on screen is entitled to hold the lock
  before releasing, so a modal closing on top of another leaves it alone. The selector list
  covers exactly what `bits-ui` locks for (`preventScroll` defaults to true only on dialog,
  alert-dialog and context-menu) plus `vaul`'s drawer.
- `MODAL_CLOSE_TRANSITION_MS` is stated once instead of guessed per call site.

## Debug log modal

- The log snapshot is a whole copy of the session's requests and responses, so it is dropped
  **after** the close transition rather than while the DOM still needs it.
- The pending-refresh timer is cleared before its early return. Leaving it set wedged the
  throttle, since the branch that schedules a refresh is guarded on it being null.
- Throttle window 500ms → 1200ms; the snapshot is not free.
- The floating debug button is hidden with a class rather than unmounted, so opening and
  closing the panel no longer resets its dragged position.

---

Base: `upstream/master`. `check`, `lint` and the full Vitest suite pass.
