### PR TITLE
Retrieval: word-budget tiers, retrieval snapshots, and a correct Tier 3 selection cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,47 @@ join Tier 2/3 in the relevance sections.
 Anything in the result's `all` must be renderable somewhere in the block, because `all` is what the
 retrieval agent is told the narrator already has. `WorldStateInjector.test.ts` pins that invariant.
 
-Both services implement a three-tier injection architecture (Tier 1: sticky/always-on, Tier 2: name/keyword fuzzy matching, Tier 3: LLM candidate selection via `src/lib/services/ai/retrieval/tier3Selection.ts`) and are independently configurable in Advanced Settings.
+Both services implement a three-tier injection architecture (Tier 1: sticky/always-on, Tier 2:
+name/keyword fuzzy matching, Tier 3: the leftover) and are independently configurable in Advanced
+Settings.
+
+**Tier 3 is two branches, and the volume question is asked before the relevance one.** A leftover
+small enough to send whole is sent whole, uncapped and with no LLM call; only one too big is worth
+asking a model about, via `src/lib/services/ai/retrieval/tier3Selection.ts`. The boundary is a
+**word budget on the candidate text** (`tier3WholesaleWordBudget`), the same unit on both sides —
+but not the same number: a live world-state record runs ~16 words and a lorebook entry ~69, so the
+budgets are 500 and 1000. A record count could not express that difference, which is why the
+world state's old `llmThreshold` is gone rather than converted. Switching LLM selection off removes
+the call, not the tier: a leftover under the budget still goes in.
+
+**Only a leftover the model _chose_ counts as an activation.** Wholesale inclusion means "there was
+little of it", which says nothing about relevance — and since the branch holds every uncovered
+record, recording it would make the entire pool sticky on every turn of any story under the budget,
+so Tier 1 would absorb it and stickiness would never expire. Both services exclude it; the world
+state side once claimed to and did not.
+
+**Tier 2 runs twice, and the second pass is where indirect relevance lives.** The first pass matches
+what the scene _says_ — the player's action and the recent story. The second matches whatever is
+left against _names_: those the first pass found (`retrieval/tier2SecondPass.ts`), plus what World
+State Injection put in the scene. That second source is a **one-way handover**: `WorldStateInjector`
+publishes its Tier 1 + Tier 2 via `onSceneEntities` before its own Tier 3 runs, so the lorebook pass
+starts from what is present without waiting on an LLM call. It never travels back — lore names read
+as scene state would have the narrator acting on characters who are not there. It is a second-pass
+seed rather than a first-pass one because a lore entry that matched only because someone is standing
+in the room is relevance at one remove, and ranking it with a word the player typed made it
+indistinguishable from one. Governed by **Match Against What Is in the Scene** (on by default): the
+seed set is every active character, item, quest and the current location, which on a mature story is
+most of what a lorebook is about.
+
+`tier3Selection.ts` caches the last selection per caller. The key is complete by content — caller,
+candidate pool in order, player action, and the ids of the recent entries the prompt was built from
+— because two situations sharing a repeated action and an unmoved pool are otherwise the same
+question as far as a cache can see, which is reachable across consecutive turns and across a branch
+switch. It is also cleared on story load and branch switch.
+
+What each tier actually contributed is recorded on the narration entry as
+`metadata.retrievalSnapshot` (`retrieval/retrievalSnapshot.ts`) and shown in the **Active Context**
+panel. Diagnostic only: nothing reads it back into a prompt.
 
 **Agentic Retrieval** (`src/lib/services/ai/retrieval/AgenticRetrievalService.ts`) is an alternative
 to the static chapter memory fill (`TimelineFillService`). Which one runs is decided by
@@ -534,8 +574,16 @@ activated, so context does not vanish the instant its "always include" condition
 The fading priority band is shared (`retrieval/stickiness.ts`); the durations per type are not.
 
 The unit is **story positions, not turns** — positions come from `story.entries.length`, and a
-turn appends both an action and a narration, so a duration of N covers roughly N/2 turns.
+turn appends both an action and a narration, so a duration of N covers roughly N/2 turns. The UI
+converts for display; the services stay in positions because that is what they measure.
 Activations are persisted per story under `lorebook_activation_<storyId>` and restored on load.
+
+What creates an activation is Tier 2 and a _chosen_ Tier 3 — see the Tier 3 note above for why the
+wholesale branch does not. The timer is **not** refreshed while an entry is sticky, and cannot be: a
+sticky entry sits in Tier 1, Tier 1 is excluded from the candidate pool, and only Tier 2/3 record.
+So an entry named every single turn still drops out when its window expires and is re-matched the
+turn after. That is deliberate — it is what stops a once-relevant entry pinning itself in the prompt
+forever — but it makes the duration a hard ceiling on continuous presence, not a sliding one.
 
 ### Generation Pipeline
 

--- a/src/lib/components/debug/LorebookDebugPanel.svelte
+++ b/src/lib/components/debug/LorebookDebugPanel.svelte
@@ -1,27 +1,194 @@
 <script lang="ts">
   import { ui } from '$lib/stores/ui.svelte'
-  import { BookOpen, Users, MapPin, Package, Shield, Lightbulb, Calendar } from '@lucide/svelte'
+  import { story } from '$lib/stores/story.svelte'
+  import {
+    toRetrievalSnapshot,
+    positionsToTurns,
+    splitTier1,
+    splitTier2,
+    splitTier3,
+    type RetrievalSnapshot,
+    type RetrievalSnapshotEntry,
+  } from '$lib/services/ai/retrieval'
+  import { Button } from '$lib/components/ui/button'
+  import {
+    BookOpen,
+    Globe,
+    Users,
+    MapPin,
+    Package,
+    Shield,
+    Lightbulb,
+    Calendar,
+    SquarePen,
+    PanelRight,
+    PinOff,
+    X,
+    ChevronDown,
+  } from '@lucide/svelte'
 
   import * as ResponsiveModal from '$lib/components/ui/responsive-modal'
+  import * as Collapsible from '$lib/components/ui/collapsible'
   import { ScrollArea } from '$lib/components/ui/scroll-area'
   import { Badge } from '$lib/components/ui/badge'
   import { Card, CardContent } from '$lib/components/ui/card'
   import { Separator } from '$lib/components/ui/separator'
   import { cn } from '$lib/utils/cn'
+  import type { SidebarTab } from '$lib/types'
+  import { countTokens } from '$lib/services/tokenizer'
 
-  const tierLabels: Record<number, string> = {
-    1: 'Always Active',
-    2: 'Keyword Matched',
-    3: 'LLM Selected',
+  /**
+   * Live for the turn that just ran, persisted for every other case.
+   *
+   * The in-memory copy belongs to this session, so on a fresh start — or after a story
+   * switch — it is the snapshot on the last narration that has the answer. The live branch
+   * counts its own tokens here, from blocks it still holds; the persisted one carries the
+   * count taken when those blocks were built, since they are not stored.
+   */
+  const snapshot = $derived<RetrievalSnapshot | null>(
+    toRetrievalSnapshot(ui.lastLorebookRetrieval, ui.lastWorldStateRetrieval, countTokens) ??
+      story.entries.findLast((e) => e.type === 'narration')?.metadata?.retrievalSnapshot ??
+      null,
+  )
+
+  const sections = $derived(
+    snapshot
+      ? [
+          {
+            title: 'Lorebook',
+            icon: BookOpen,
+            entries: snapshot.lorebook,
+            tokens: snapshot.tokens?.lorebook ?? 0,
+          },
+          {
+            title: 'World State',
+            icon: Globe,
+            entries: snapshot.worldState,
+            tokens: snapshot.tokens?.worldState ?? 0,
+          },
+        ].filter((s) => s.entries.length > 0)
+      : [],
+  )
+
+  const total = $derived(sections.reduce((sum, s) => sum + s.entries.length, 0))
+  const totalTokens = $derived(sections.reduce((sum, s) => sum + s.tokens, 0))
+
+  /**
+   * Tier 1 is three different things wearing one label, so it is shown as three.
+   *
+   * The distinction is the whole reason to open this panel: an always-inject entry is in
+   * every prompt until someone changes it, a carry-over leaves on its own in a few turns,
+   * and live state comes and goes with the scene. Only the first is a standing cost.
+   */
+  const groupLabels: Record<string, { label: string; description: string }> = {
+    always: {
+      label: 'Always Inject',
+      description: 'Pinned by the author — in every prompt until the mode is changed',
+    },
+    carried: {
+      label: 'Carried Over',
+      description: 'Recently relevant; leaves on its own when the countdown runs out',
+    },
+    state: {
+      label: 'Live State',
+      description: "Where you are, who's present, what you're carrying, active quests",
+    },
+    matched: { label: 'Keyword Matched', description: 'Named directly by the scene' },
+    viaScene: {
+      label: 'Matched Through the Scene',
+      description: 'Named by something the scene already pulled in, not by the scene itself',
+    },
+    wholesale: {
+      label: 'Included Whole',
+      description: 'The leftover fit within budget, so all of it went in — no LLM call needed',
+    },
+    selected: {
+      label: 'LLM Selected',
+      description: 'The leftover was over budget, so the LLM picked from it',
+    },
   }
 
-  const tierDescriptions: Record<number, string> = {
-    1: 'State-based or always-inject entries',
-    2: 'Matched by name, alias, or keyword',
-    3: 'Contextually relevant (AI selected)',
+  /** Tiers 1 and 3 each cover more than one behaviour, so both are shown split. */
+  function groupsOf(entries: RetrievalSnapshotEntry[]) {
+    const { always, carried, pinnedByState } = splitTier1(entries)
+    const { direct, viaScene } = splitTier2(entries)
+    const { wholesale, selected } = splitTier3(entries)
+    return [
+      { key: 'always', tier: 1, entries: always },
+      { key: 'carried', tier: 1, entries: carried },
+      { key: 'state', tier: 1, entries: pinnedByState },
+      { key: 'matched', tier: 2, entries: direct },
+      { key: 'viaScene', tier: 2, entries: viaScene },
+      { key: 'wholesale', tier: 3, entries: wholesale },
+      { key: 'selected', tier: 3, entries: selected },
+    ].filter((g) => g.entries.length > 0)
   }
 
-  // Modern colors compatible with light/dark modes
+  /** Leave the panel for the entry itself, which is where keywords and text are edited. */
+  function openEntry(entryId: string) {
+    ui.lorebookDebugOpen = false
+    ui.setActivePanel('lorebook')
+    ui.selectLorebookEntry(entryId)
+  }
+
+  /**
+   * World state has no per-entity view, only the four sidebar tabs, so this opens the tab
+   * the entity lives in rather than the entity itself.
+   */
+  const SIDEBAR_TAB_FOR_TYPE: Record<string, SidebarTab> = {
+    character: 'characters',
+    location: 'locations',
+    item: 'inventory',
+    storyBeat: 'quests',
+  }
+
+  function openInSidebar(type: string) {
+    const tab = SIDEBAR_TAB_FOR_TYPE[type]
+    if (!tab) return
+    ui.lorebookDebugOpen = false
+    ui.setSidebarTab(tab)
+    ui.sidebarOpen = true
+  }
+
+  /**
+   * A carry-over as "turns left of the window it started with".
+   *
+   * Both numbers are story positions on the way in — two per turn — so both are converted.
+   * Reads `n/n` on the turn it was activated and `0/n` on its last one: zero margin left,
+   * still in this prompt, gone from the next.
+   */
+  function carryOver(entry: RetrievalSnapshotEntry) {
+    const left = positionsToTurns(entry.stickyPositionsLeft ?? 0)
+    const total = positionsToTurns(entry.stickyPositionsTotal ?? entry.stickyPositionsLeft ?? 0)
+    return { left, total, ratio: total > 0 ? left / total : 0 }
+  }
+
+  /** Fills as the window runs out, so it reads at a glance rather than by arithmetic. */
+  function carryOverStyle(ratio: number): { text: string; bar: string } {
+    if (ratio <= 0.34) return { text: 'text-rose-500', bar: 'bg-rose-500' }
+    if (ratio <= 0.67) return { text: 'text-amber-500', bar: 'bg-amber-500' }
+    return { text: 'text-emerald-500', bar: 'bg-emerald-500' }
+  }
+
+  /** End a carry-over now rather than waiting for its countdown. */
+  function clearCarryOver(entryId: string) {
+    ui.clearActivationFor(entryId)
+  }
+
+  /** Rounded for the header: the point is the order of magnitude, not the last digit. */
+  function formatTokens(count: number): string {
+    return count >= 1000 ? `${(count / 1000).toFixed(1)}k` : String(count)
+  }
+
+  /** Demote an always-inject entry to keyword matching, from where its cost is visible. */
+  async function makeKeywordMatched(entryId: string) {
+    const entry = story.lorebookEntries.find((e) => e.id === entryId)
+    if (!entry) return
+    await story.updateLorebookEntry(entryId, {
+      injection: { ...entry.injection, mode: 'keyword' },
+    })
+  }
+
   const tierColors: Record<number, string> = {
     1: 'text-green-600 dark:text-green-400 border-green-500/20 bg-green-500/5',
     2: 'text-amber-600 dark:text-amber-400 border-amber-500/20 bg-amber-500/5',
@@ -38,6 +205,7 @@
     character: Users,
     location: MapPin,
     item: Package,
+    storyBeat: Calendar,
     faction: Shield,
     concept: Lightbulb,
     event: Calendar,
@@ -46,142 +214,273 @@
   function getIcon(type: string) {
     return typeIcons[type] || BookOpen
   }
+
+  function tierCount(entries: RetrievalSnapshotEntry[], tier: number): number {
+    return entries.filter((e) => e.tier === tier).length
+  }
 </script>
+
+{#snippet tierBadges(entries: RetrievalSnapshotEntry[])}
+  <div class="flex flex-wrap gap-2">
+    <Badge
+      variant="outline"
+      class="border-green-500/40 bg-green-500/5 text-green-700 dark:text-green-400"
+      >Tier 1: {tierCount(entries, 1)}</Badge
+    >
+    <Badge
+      variant="outline"
+      class="border-amber-500/40 bg-amber-500/5 text-amber-700 dark:text-amber-400"
+      >Tier 2: {tierCount(entries, 2)}</Badge
+    >
+    <Badge
+      variant="outline"
+      class="border-purple-500/40 bg-purple-500/5 text-purple-700 dark:text-purple-400"
+      >Tier 3: {tierCount(entries, 3)}</Badge
+    >
+  </div>
+{/snippet}
+
+{#snippet tierGroup(
+  key: string,
+  tier: number,
+  entries: RetrievalSnapshotEntry[],
+  canDemote: boolean,
+)}
+  <div class="space-y-1.5">
+    <div class="flex items-baseline gap-2">
+      <div
+        class={cn('h-2 w-2 shrink-0 translate-y-[-1px] rounded-full', tierIndicatorColors[tier])}
+      ></div>
+      <h4 class="text-sm font-semibold">
+        {groupLabels[key].label}
+        <span class="text-muted-foreground ml-1 font-normal">({entries.length})</span>
+      </h4>
+      <span class="text-muted-foreground/60 truncate text-[11px]"
+        >{groupLabels[key].description}</span
+      >
+    </div>
+
+    <div class="grid gap-1">
+      {#each entries as entry, index (`${entry.type}-${entry.name}-${index}`)}
+        {@const Icon = getIcon(entry.type)}
+        <div
+          class={cn(
+            'flex items-center gap-2 rounded-md border px-2 py-1.5 text-sm',
+            tierColors[tier],
+          )}
+        >
+          <Icon class="h-3.5 w-3.5 shrink-0 opacity-70" />
+          <span class="truncate font-medium">{entry.name}</span>
+
+          <span
+            class="text-muted-foreground shrink-0 text-[10px] tracking-wide uppercase opacity-70"
+            >{entry.type}</span
+          >
+
+          {#if entry.reason && entry.stickyPositionsLeft === undefined}
+            <span class="text-muted-foreground min-w-0 truncate text-xs" title={entry.reason}>
+              {entry.reason.replace(/^matched:\s*/i, '')}
+            </span>
+          {/if}
+
+          <span class="ml-auto flex shrink-0 items-center gap-1">
+            {#if entry.stickyPositionsLeft !== undefined}
+              {@const carry = carryOver(entry)}
+              {@const style = carryOverStyle(carry.ratio)}
+              <span
+                class="flex shrink-0 items-center gap-1.5"
+                title={`${carry.left} of ${carry.total} turns of carry-over left`}
+              >
+                <span class="bg-muted h-1 w-8 overflow-hidden rounded-full">
+                  <span
+                    class={cn('block h-full rounded-full transition-all', style.bar)}
+                    style={`width: ${Math.max(8, carry.ratio * 100)}%`}
+                  ></span>
+                </span>
+                <span class={cn('font-mono text-xs whitespace-nowrap', style.text)}>
+                  {carry.left}/{carry.total}
+                </span>
+              </span>
+              {#if canDemote}
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  class="h-6 w-6"
+                  title="Drop the carry-over now"
+                  onclick={() => clearCarryOver(entry.id)}
+                >
+                  <X class="h-3.5 w-3.5" />
+                </Button>
+              {/if}
+            {/if}
+            {#if canDemote && entry.alwaysInject}
+              <Button
+                variant="ghost"
+                size="icon"
+                class="h-6 w-6"
+                title="Switch to keyword matching"
+                onclick={() => makeKeywordMatched(entry.id)}
+              >
+                <PinOff class="h-3.5 w-3.5" />
+              </Button>
+            {/if}
+            {#if canDemote}
+              <Button
+                variant="ghost"
+                size="icon"
+                class="h-6 w-6"
+                title="Open this entry in the Lorebook"
+                onclick={() => openEntry(entry.id)}
+              >
+                <SquarePen class="h-3.5 w-3.5" />
+              </Button>
+            {:else if SIDEBAR_TAB_FOR_TYPE[entry.type]}
+              <Button
+                variant="ghost"
+                size="icon"
+                class="h-6 w-6"
+                title="Show this in the sidebar"
+                onclick={() => openInSidebar(entry.type)}
+              >
+                <PanelRight class="h-3.5 w-3.5" />
+              </Button>
+            {/if}
+          </span>
+        </div>
+      {/each}
+    </div>
+  </div>
+{/snippet}
 
 <ResponsiveModal.Root bind:open={ui.lorebookDebugOpen}>
   <ResponsiveModal.Content class="flex h-[80vh] max-w-2xl flex-col gap-0 overflow-hidden p-0">
-    <ResponsiveModal.Header class="shrink-0 border-b px-6 py-4" title="Active Lorebook Entries" />
+    <ResponsiveModal.Header class="shrink-0 border-b px-6 py-4" title="Active Context" />
 
     <ScrollArea class="min-h-0 flex-1">
       <div class="space-y-6 p-6">
-        {#if ui.lastLorebookRetrieval}
-          {@const result = ui.lastLorebookRetrieval}
-          {@const totalCount = result.tier1.length + result.tier2.length + result.tier3.length}
-
-          <!-- Summary Card -->
+        {#if total > 0}
+          <p class="text-muted-foreground/80 text-xs leading-relaxed">
+            What the narrator was given for the <strong>last response</strong>, not a forecast of
+            the next one. Counts and token totals are that turn's; carry-over countdowns are
+            measured from it.
+          </p>
           <Card class="bg-muted/40 shadow-sm">
-            <CardContent class="p-4">
-              <div class="mb-4 flex items-center justify-between text-sm">
+            <CardContent class="space-y-4 p-4">
+              <div class="flex items-center justify-between text-sm">
                 <span class="text-muted-foreground font-medium">Total Active Entries</span>
-                <span
-                  class="text-foreground bg-background rounded border px-2.5 py-0.5 font-mono font-bold"
-                  >{totalCount}</span
-                >
+                <div class="flex items-center gap-2">
+                  {#if totalTokens > 0}
+                    <span
+                      class="text-muted-foreground bg-background rounded border px-2.5 py-0.5 font-mono text-xs"
+                      title="Tokens these two blocks cost in the prompt, counted when they were built"
+                      >~{formatTokens(totalTokens)} tok</span
+                    >
+                  {/if}
+                  <span
+                    class="text-foreground bg-background rounded border px-2.5 py-0.5 font-mono font-bold"
+                    >{total}</span
+                  >
+                </div>
               </div>
-              <div class="flex flex-wrap gap-2">
-                <Badge
-                  variant="outline"
-                  class="border-green-500/40 bg-green-500/5 text-green-700 transition-colors hover:bg-green-500/10 dark:text-green-400"
-                  >Tier 1: {result.tier1.length}</Badge
-                >
-                <Badge
-                  variant="outline"
-                  class="border-amber-500/40 bg-amber-500/5 text-amber-700 transition-colors hover:bg-amber-500/10 dark:text-amber-400"
-                  >Tier 2: {result.tier2.length}</Badge
-                >
-                <Badge
-                  variant="outline"
-                  class="border-purple-500/40 bg-purple-500/5 text-purple-700 transition-colors hover:bg-purple-500/10 dark:text-purple-400"
-                  >Tier 3: {result.tier3.length}</Badge
-                >
-              </div>
+              {#each sections as section (section.title)}
+                {@const SectionIcon = section.icon}
+                <div class="space-y-2">
+                  <div class="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
+                    <SectionIcon class="h-3.5 w-3.5" />
+                    {section.title}
+                  </div>
+                  {@render tierBadges(section.entries)}
+                  {#if section.tokens > 0}
+                    <p class="text-muted-foreground/75 text-[11px]">
+                      ~{formatTokens(section.tokens)} tokens in the prompt
+                    </p>
+                  {/if}
+                </div>
+              {/each}
             </CardContent>
           </Card>
 
-          {#if totalCount === 0}
-            <div class="text-muted-foreground flex flex-col items-center justify-center py-12">
-              <BookOpen class="mb-4 h-12 w-12 opacity-10" />
-              <p class="font-medium">No active entries</p>
-              <p class="mt-1 text-sm opacity-70">Generate a response to populate the lorebook.</p>
-            </div>
-          {:else}
-            <!-- Tier Sections -->
-            {#each [1, 2, 3] as tier (tier)}
-              {@const tierEntries =
-                tier === 1 ? result.tier1 : tier === 2 ? result.tier2 : result.tier3}
-              {#if tierEntries.length > 0}
-                <div class="space-y-3">
-                  <div class="flex items-center gap-2">
-                    <div
-                      class={cn(
-                        'h-2.5 w-2.5 rounded-full shadow-sm',
-                        tierIndicatorColors[tier as 1 | 2 | 3],
-                      )}
-                    ></div>
-                    <h3 class="text-sm font-semibold">
-                      Tier {tier}: {tierLabels[tier as 1 | 2 | 3]}
-                      <span class="text-muted-foreground ml-1 font-normal"
-                        >({tierEntries.length})</span
-                      >
-                    </h3>
-                  </div>
-                  <p class="text-muted-foreground pl-5 text-xs">
-                    {tierDescriptions[tier as 1 | 2 | 3]}
-                  </p>
-
-                  <div class="grid gap-3">
-                    {#each tierEntries as retrieved (retrieved.entry.id)}
-                      {@const Icon = getIcon(retrieved.entry.type)}
-                      <Card
-                        class={cn(
-                          'overflow-hidden transition-all hover:shadow-md',
-                          tierColors[tier as 1 | 2 | 3],
-                        )}
-                      >
-                        <CardContent class="flex items-start gap-3.5 p-3.5">
-                          <div
-                            class="bg-background/60 mt-0.5 shrink-0 rounded-md border border-transparent p-1.5 shadow-sm backdrop-blur-sm"
-                          >
-                            <Icon class="h-4 w-4" />
-                          </div>
-                          <div class="min-w-0 flex-1 space-y-1.5">
-                            <div class="flex items-center justify-between gap-2">
-                              <span class="truncate text-sm font-semibold"
-                                >{retrieved.entry.name}</span
-                              >
-                              <Badge
-                                variant="secondary"
-                                class="bg-background/60 hover:bg-background/90 h-5 px-1.5 text-[10px] font-medium tracking-wide uppercase"
-                                >{retrieved.entry.type}</Badge
-                              >
-                            </div>
-                            {#if retrieved.matchReason}
-                              <div
-                                class="bg-background/40 inline-block rounded border border-black/5 px-2 py-1 text-xs dark:border-white/5"
-                              >
-                                <span class="font-medium opacity-70">Match:</span>
-                                {retrieved.matchReason.replace(/^matched:\s*/i, '')}
-                              </div>
-                            {/if}
-                            <p class="line-clamp-2 text-xs leading-relaxed opacity-80">
-                              {retrieved.entry.description}
-                            </p>
-                          </div>
-                        </CardContent>
-                      </Card>
-                    {/each}
-                  </div>
-                </div>
-              {/if}
-            {/each}
-          {/if}
-
-          <!-- Context Block Preview -->
-          {#if result.contextBlock}
-            <Separator class="my-6" />
-            <div class="space-y-3">
-              <h3 class="text-foreground/80 flex items-center gap-2 text-sm font-medium">
-                <Package class="h-4 w-4" />
-                Injected Context Block
+          {#each sections as section, sectionIndex (section.title)}
+            {@const SectionIcon = section.icon}
+            {#if sectionIndex > 0}
+              <Separator class="my-6" />
+            {/if}
+            <div class="space-y-4">
+              <h3 class="flex items-center gap-2 text-base font-semibold">
+                <SectionIcon class="h-4 w-4" />
+                {section.title}
               </h3>
-              <div class="bg-muted/30 relative rounded-lg border">
-                <ScrollArea class="h-48 w-full rounded-lg">
-                  <div class="p-4">
-                    <pre
-                      class="text-muted-foreground font-mono text-xs break-words whitespace-pre-wrap">{result.contextBlock}</pre>
-                  </div>
-                </ScrollArea>
-              </div>
+              {#each groupsOf(section.entries) as group (group.key)}
+                {@render tierGroup(
+                  group.key,
+                  group.tier,
+                  group.entries,
+                  section.title === 'Lorebook',
+                )}
+              {/each}
+            </div>
+          {/each}
+
+          {#if ui.lastWorldStateRetrieval?.contextBlock || ui.lastLorebookRetrieval?.contextBlock}
+            <Separator class="my-6" />
+            <div class="space-y-4">
+              <h3 class="text-muted-foreground text-xs font-semibold tracking-wider uppercase">
+                Injected Prompt Blocks
+              </h3>
+
+              {#if ui.lastWorldStateRetrieval?.contextBlock}
+                <Collapsible.Root class="bg-muted/20 rounded-lg border">
+                  <Collapsible.Trigger
+                    class="group hover:bg-muted/30 flex w-full items-center justify-between rounded-lg p-3 text-left transition-colors"
+                  >
+                    <div class="text-foreground/90 flex items-center gap-2 text-sm font-medium">
+                      <Globe class="h-4 w-4 text-emerald-500" />
+                      <span>Injected World State</span>
+                    </div>
+                    <ChevronDown
+                      class="text-muted-foreground h-4 w-4 transition-transform duration-200 group-data-[state=open]:rotate-180"
+                    />
+                  </Collapsible.Trigger>
+                  <Collapsible.Content>
+                    <div class="bg-muted/30 border-t">
+                      <ScrollArea class="h-48 w-full">
+                        <div class="p-4">
+                          <pre
+                            class="text-muted-foreground font-mono text-xs break-words whitespace-pre-wrap">{ui
+                              .lastWorldStateRetrieval.contextBlock}</pre>
+                        </div>
+                      </ScrollArea>
+                    </div>
+                  </Collapsible.Content>
+                </Collapsible.Root>
+              {/if}
+
+              {#if ui.lastLorebookRetrieval?.contextBlock}
+                <Collapsible.Root class="bg-muted/20 rounded-lg border">
+                  <Collapsible.Trigger
+                    class="group hover:bg-muted/30 flex w-full items-center justify-between rounded-lg p-3 text-left transition-colors"
+                  >
+                    <div class="text-foreground/90 flex items-center gap-2 text-sm font-medium">
+                      <BookOpen class="h-4 w-4 text-purple-500" />
+                      <span>Injected Lorebook Block</span>
+                    </div>
+                    <ChevronDown
+                      class="text-muted-foreground h-4 w-4 transition-transform duration-200 group-data-[state=open]:rotate-180"
+                    />
+                  </Collapsible.Trigger>
+                  <Collapsible.Content>
+                    <div class="bg-muted/30 border-t">
+                      <ScrollArea class="h-48 w-full">
+                        <div class="p-4">
+                          <pre
+                            class="text-muted-foreground font-mono text-xs break-words whitespace-pre-wrap">{ui
+                              .lastLorebookRetrieval.contextBlock}</pre>
+                        </div>
+                      </ScrollArea>
+                    </div>
+                  </Collapsible.Content>
+                </Collapsible.Root>
+              {/if}
             </div>
           {/if}
         {:else}
@@ -189,9 +488,9 @@
             <div class="bg-muted/30 mb-6 flex h-20 w-20 items-center justify-center rounded-full">
               <BookOpen class="h-10 w-10 opacity-20" />
             </div>
-            <p class="text-lg font-semibold">No Data Available</p>
+            <p class="text-base font-medium">No retrieval data yet</p>
             <p class="mt-2 max-w-xs text-center text-sm opacity-70">
-              Generate a story response to see active lorebook entries populated here.
+              Generate a response to see what the narrator was given.
             </p>
           </div>
         {/if}

--- a/src/lib/components/layout/Header.svelte
+++ b/src/lib/components/layout/Header.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte'
   import { ui } from '$lib/stores/ui.svelte'
   import { story } from '$lib/stores/story.svelte'
+  import { toRetrievalSnapshot, snapshotSize } from '$lib/services/ai/retrieval'
   import { settings } from '$lib/stores/settings.svelte'
   import { exportService, gatherStoryData } from '$lib/services/export'
   import { errMessage } from '$lib/utils/error'
@@ -32,6 +33,15 @@
     MessageSquare,
     AlertTriangle,
   } from '@lucide/svelte'
+
+  // Same source as the Active Context panel: this turn's retrieval, or the snapshot the
+  // last narration carries when the in-memory one is gone.
+  const activeContextCount = $derived(
+    snapshotSize(
+      toRetrievalSnapshot(ui.lastLorebookRetrieval, ui.lastWorldStateRetrieval) ??
+        story.entries.findLast((e) => e.type === 'narration')?.metadata?.retrievalSnapshot,
+    ),
+  )
 
   let showExportMenu = $state(false)
   let showMobileMenu = $state(false)
@@ -325,6 +335,18 @@
           <DropdownMenu.Separator />
           {@render importExportMenuItems()}
           <DropdownMenu.Separator />
+          <!-- The toolbar button beside this menu is desktop-only; on a narrow screen the
+               menu is where it lives instead. -->
+          <DropdownMenu.Item class="sm:hidden" onclick={() => ui.toggleLorebookDebug()}>
+            <Bug class="text-muted-foreground h-4 w-4" />
+            Active Context
+            {#if activeContextCount > 0}
+              <span class="text-muted-foreground ml-auto font-mono text-xs"
+                >{activeContextCount}</span
+              >
+            {/if}
+          </DropdownMenu.Item>
+          <DropdownMenu.Separator class="sm:hidden" />
         {/if}
         <DropdownMenu.Item onclick={() => ui.openSettings()}>
           <Settings class="text-muted-foreground h-4 w-4" />
@@ -336,19 +358,23 @@
       </DropdownMenu.Content>
     </DropdownMenu.Root>
 
-    {#if story.currentStory && story.lorebookEntries.length > 0}
+    <!-- Not gated on the lorebook having entries: the panel covers live world state too,
+         which every story has. -->
+    {#if story.currentStory}
       <Button
         variant="text"
         class="text-muted-foreground hover:text-primary relative hidden min-h-11 min-w-11 sm:flex"
         onclick={() => ui.toggleLorebookDebug()}
-        title="View active lorebook entries"
+        title="View active context"
       >
         <Bug class="h-5 w-5" />
-        {#if ui.lastLorebookRetrieval && ui.lastLorebookRetrieval.all.length > 0}
+        {#if activeContextCount > 0}
+          <!-- `min-w` with padding rather than a fixed circle: this counts lorebook and
+               world state together and reaches three digits on a mature story. -->
           <span
-            class="bg-accent-500 absolute top-1 right-1 flex h-3 w-3 items-center justify-center rounded-full text-[9px] font-medium text-white"
+            class="bg-accent-500 absolute top-1 right-1 flex h-3.5 min-w-3.5 items-center justify-center rounded-full px-1 text-[9px] leading-none font-medium text-white"
           >
-            {ui.lastLorebookRetrieval.all.length}
+            {activeContextCount > 99 ? '99+' : activeContextCount}
           </span>
         {/if}
       </Button>

--- a/src/lib/components/settings/AdvancedSettings.svelte
+++ b/src/lib/components/settings/AdvancedSettings.svelte
@@ -21,6 +21,10 @@
   import * as Collapsible from '$lib/components/ui/collapsible'
   import { Separator } from '$lib/components/ui/separator'
   import { advancedPanelView } from './advancedPanelView'
+  import {
+    ENTRY_RETRIEVAL_DEFAULTS,
+    WORLD_STATE_INJECTION_DEFAULTS,
+  } from '$lib/services/ai/core/defaults'
   import { AGENTIC_RETRIEVAL_DEFAULTS } from '$lib/services/ai/core/defaults'
 
   // Open/closed state for every collapsible section, keyed by id so `sectionHeader` can
@@ -287,9 +291,68 @@
               but does not choose which ones reach the narrator — that is decided here, and only here.
             </p>
 
+            {@render sliderRow({
+              label: 'Recent Entries Window',
+              value: system.entryRetrieval?.recentEntriesCount ?? 5,
+              display: `${system.entryRetrieval?.recentEntriesCount ?? 5} entries`,
+              min: 2,
+              max: 15,
+              step: 1,
+              help: view.help.entryRecentEntries,
+              onChange: (v) => {
+                system.entryRetrieval.recentEntriesCount = v
+                saveSystem()
+              },
+            })}
+
+            {@render sliderRow({
+              label: 'Max Matched Entries',
+              value: system.entryRetrieval?.maxTier2Entries ?? 20,
+              display: `${system.entryRetrieval?.maxTier2Entries ?? 20} entries`,
+              min: 5,
+              max: 40,
+              step: 5,
+              help: 'Cap on entries pulled in by name, alias or keyword. Lower than the World State cap on purpose: a lorebook entry is a paragraph, a world-state record is a sentence.',
+              onChange: (v) => {
+                system.entryRetrieval.maxTier2Entries = v
+                saveSystem()
+              },
+            })}
+
             {@render switchRow({
-              label: 'Enable LLM Selection',
-              description: 'Use LLM to intelligently select lorebook entries',
+              label: 'Match Against What Is in the Scene',
+              description:
+                'Also look for lore about whatever World State Injection says is present — the current location, the characters in the scene, your inventory, the active quests — not only what the text names. These arrive as second-pass matches, ranked below anything named directly, so a cap drops them first. Turn it off if a dense lorebook is spending its Max Matched Entries on things nobody mentioned.',
+              checked: system.entryRetrieval?.useSceneEntities ?? true,
+              onChange: (v) => {
+                system.entryRetrieval.useSceneEntities = v
+                saveSystem()
+              },
+            })}
+
+            {@render sliderRow({
+              label: 'Include-All Budget',
+              value:
+                system.entryRetrieval?.tier3WholesaleWordBudget ??
+                ENTRY_RETRIEVAL_DEFAULTS.tier3WholesaleWordBudget,
+              display: `${
+                system.entryRetrieval?.tier3WholesaleWordBudget ??
+                ENTRY_RETRIEVAL_DEFAULTS.tier3WholesaleWordBudget
+              } words`,
+              min: 100,
+              max: 2500,
+              step: 100,
+              help: 'How much unmatched lore can still go in whole. If the leftover fits this budget, all of it is included and no LLM is called; if it is larger, the LLM picks from it — or, with the switch below off, none of it goes in. Raising this trades a longer prompt for one fewer LLM call per turn.',
+              onChange: (v) => {
+                system.entryRetrieval.tier3WholesaleWordBudget = v
+                saveSystem()
+              },
+            })}
+
+            {@render switchRow({
+              label: 'Use the LLM to Pick Entries Above the Budget',
+              description:
+                'When the leftover is larger than the budget, let the LLM choose which entries matter. With this off, an oversized leftover is dropped instead — a leftover that fits the budget still goes in either way.',
               checked: view.entryLLMOn,
               onChange: (v) => {
                 system.entryRetrieval.enableLLMSelection = v
@@ -298,27 +361,13 @@
             })}
 
             {@render sliderRow({
-              label: 'Max Tier 2 Entries',
-              value: system.entryRetrieval?.maxTier2Entries ?? 20,
-              display: `${system.entryRetrieval?.maxTier2Entries ?? 20} entries`,
-              min: 5,
-              max: 40,
-              step: 5,
-              help: 'Cap on entries pulled in by keyword matching. Lower than the World State caps on purpose: a lorebook entry is a paragraph, a world-state record is a sentence.',
-              onChange: (v) => {
-                system.entryRetrieval.maxTier2Entries = v
-                saveSystem()
-              },
-            })}
-
-            {@render sliderRow({
-              label: 'Max Tier 3 Entries',
+              label: 'Max LLM-Selected Entries',
               value: system.entryRetrieval?.maxTier3Entries ?? 30,
               display: `${system.entryRetrieval?.maxTier3Entries ?? 30} entries`,
               min: 5,
               max: 50,
               step: 5,
-              help: 'Cap on entries the LLM picked.',
+              help: 'Cap on what the LLM picked. Applies only above the budget — below it the whole leftover goes in uncapped.',
               inactiveReason: view.inactive.maxTier3Entries,
               onChange: (v) => {
                 system.entryRetrieval.maxTier3Entries = v
@@ -337,22 +386,9 @@
               max: 500,
               step: 50,
               ends: ['Unlimited', '500 Words'],
+              help: 'Truncates each description when the block is written, whichever tier it came from.',
               onChange: (v) => {
                 system.entryRetrieval.maxWordsPerEntry = v
-                saveSystem()
-              },
-            })}
-
-            {@render sliderRow({
-              label: 'Recent Entries Window',
-              value: system.entryRetrieval?.recentEntriesCount ?? 5,
-              display: `${system.entryRetrieval?.recentEntriesCount ?? 5} entries`,
-              min: 2,
-              max: 15,
-              step: 1,
-              help: view.help.entryRecentEntries,
-              onChange: (v) => {
-                system.entryRetrieval.recentEntriesCount = v
                 saveSystem()
               },
             })}
@@ -388,34 +424,22 @@
               never live World State, so there is nothing here for it to stand in for.
             </p>
 
-            {@render switchRow({
-              label: 'Enable LLM Selection',
-              description:
-                'Above the threshold below, have the LLM pick which leftover characters/locations/items/quests matter. With this off, a leftover that large is left out instead — smaller ones are still included either way.',
-              checked: view.worldStateLLMOn,
+            {@render sliderRow({
+              label: 'Recent Entries Window',
+              value: system.worldStateInjection?.recentEntriesCount ?? 5,
+              display: `${system.worldStateInjection?.recentEntriesCount ?? 5} entries`,
+              min: 2,
+              max: 15,
+              step: 1,
+              help: view.help.worldStateRecentEntries,
               onChange: (v) => {
-                system.worldStateInjection.enableLLMSelection = v
+                system.worldStateInjection.recentEntriesCount = v
                 saveSystem()
               },
             })}
 
             {@render sliderRow({
-              label: 'LLM Selection Threshold',
-              value: system.worldStateInjection?.llmThreshold ?? 30,
-              display: `${system.worldStateInjection?.llmThreshold ?? 30} entities`,
-              min: 10,
-              max: 100,
-              step: 10,
-              help: 'Where "include it all" turns into "pick the relevant ones". At or below this many not-yet-selected entities, all of them go into the prompt as-is; above it, the LLM selects.',
-              inactiveReason: view.inactive.llmThreshold,
-              onChange: (v) => {
-                system.worldStateInjection.llmThreshold = v
-                saveSystem()
-              },
-            })}
-
-            {@render sliderRow({
-              label: 'Max Tier 2 Entities',
+              label: 'Max Matched Entities',
               value: system.worldStateInjection?.maxTier2Entries ?? 40,
               display: `${system.worldStateInjection?.maxTier2Entries ?? 40} entities`,
               min: 5,
@@ -429,30 +453,46 @@
             })}
 
             {@render sliderRow({
-              label: 'Max Tier 3 Entities',
-              value: system.worldStateInjection?.maxTier3Entries ?? 50,
-              display: `${system.worldStateInjection?.maxTier3Entries ?? 50} entities`,
-              min: 5,
-              max: 80,
-              step: 5,
-              help: "Cap on entities the LLM picked. Applies only above the threshold — below it the whole leftover goes in uncapped. Always-included state (where you are, who's present, what you're carrying, active quests) and the recently-mentioned carry-over are never capped.",
-              inactiveReason: view.inactive.worldStateMaxTier3,
+              label: 'Include-All Budget',
+              value:
+                system.worldStateInjection?.tier3WholesaleWordBudget ??
+                WORLD_STATE_INJECTION_DEFAULTS.tier3WholesaleWordBudget,
+              display: `${
+                system.worldStateInjection?.tier3WholesaleWordBudget ??
+                WORLD_STATE_INJECTION_DEFAULTS.tier3WholesaleWordBudget
+              } words`,
+              min: 100,
+              max: 2500,
+              step: 100,
+              help: 'How much not-yet-selected world state can still go in whole. If the leftover fits this budget, all of it is included and no LLM is called; if it is larger, the LLM picks from it — or, with the switch below off, none of it goes in. A live record runs about 16 words, so 500 is roughly 30 of them.',
               onChange: (v) => {
-                system.worldStateInjection.maxTier3Entries = v
+                system.worldStateInjection.tier3WholesaleWordBudget = v
+                saveSystem()
+              },
+            })}
+
+            {@render switchRow({
+              label: 'Use the LLM to Pick Entities Above the Budget',
+              description:
+                'When the leftover is larger than the budget, let the LLM choose which characters, locations, items and quests matter. With this off, an oversized leftover is dropped instead — a leftover that fits the budget still goes in either way.',
+              checked: view.worldStateLLMOn,
+              onChange: (v) => {
+                system.worldStateInjection.enableLLMSelection = v
                 saveSystem()
               },
             })}
 
             {@render sliderRow({
-              label: 'Recent Entries Window',
-              value: system.worldStateInjection?.recentEntriesCount ?? 5,
-              display: `${system.worldStateInjection?.recentEntriesCount ?? 5} entries`,
-              min: 2,
-              max: 15,
-              step: 1,
-              help: view.help.worldStateRecentEntries,
+              label: 'Max LLM-Selected Entities',
+              value: system.worldStateInjection?.maxTier3Entries ?? 50,
+              display: `${system.worldStateInjection?.maxTier3Entries ?? 50} entities`,
+              min: 5,
+              max: 80,
+              step: 5,
+              help: "Cap on what the LLM picked. Applies only above the budget — below it the whole leftover goes in uncapped. Always-included state (where you are, who's present, what you're carrying, active quests) and the recently-mentioned carry-over are never capped.",
+              inactiveReason: view.inactive.worldStateMaxTier3,
               onChange: (v) => {
-                system.worldStateInjection.recentEntriesCount = v
+                system.worldStateInjection.maxTier3Entries = v
                 saveSystem()
               },
             })}

--- a/src/lib/components/settings/advancedPanelView.test.ts
+++ b/src/lib/components/settings/advancedPanelView.test.ts
@@ -27,33 +27,24 @@ describe('advancedPanelView — defaults', () => {
 })
 
 describe('advancedPanelView — inactive controls', () => {
-  it('deactivates Max Tier 3 Entries when Entry Retrieval LLM selection is off', () => {
+  it('deactivates Max LLM-Selected Entries when Entry Retrieval selection is off', () => {
     const v = view({ entryRetrieval: { enableLLMSelection: false } })
 
-    expect(v.inactive.maxTier3Entries).toBe('LLM Selection is off, so there is no Tier 3')
-    // The other sections are untouched: they have their own switch.
-    expect(v.inactive.llmThreshold).toBeUndefined()
+    expect(v.inactive.maxTier3Entries).toBe(
+      'LLM Selection is off; the leftover is included whole or not at all',
+    )
+    // The other section is untouched: it has its own switch.
+    expect(v.inactive.worldStateMaxTier3).toBeUndefined()
   })
 
-  it('deactivates the World State Tier 3 cap, but never its threshold', () => {
+  it('deactivates the World State selection cap, but never the budget', () => {
     const v = view({ worldStateInjection: { enableLLMSelection: false } })
 
     // The cap applies only to what the model chose, so with selection off it does nothing.
     expect(v.inactive.worldStateMaxTier3).toBe(
       'LLM Selection is off; the leftover is included whole or not at all',
     )
-    // The threshold, though, is the boundary between "include the whole leftover" and
-    // "ask the model" -- with selection off it is the only thing still deciding how much
-    // world state reaches the narrator. It used to be greyed out as inactive, which was
-    // backwards: it matters more in that configuration, not less.
-    expect(v.inactive.llmThreshold).toBeUndefined()
     expect(v.inactive.maxTier3Entries).toBeUndefined()
-  })
-
-  it('keeps the World State threshold live with LLM selection on, too', () => {
-    expect(
-      view({ worldStateInjection: { enableLLMSelection: true } }).inactive.llmThreshold,
-    ).toBeUndefined()
   })
 
   it('reports the Style Reviewer as off, so its controls can be hidden rather than dimmed', () => {

--- a/src/lib/components/settings/advancedPanelView.ts
+++ b/src/lib/components/settings/advancedPanelView.ts
@@ -56,7 +56,6 @@ export interface AdvancedPanelView {
      * World State Injection's threshold. Always live -- see `advancedPanelView` for why
      * switching LLM selection off makes it matter *more*, not less.
      */
-    llmThreshold?: string
     /** World State Injection's Tier 3 cap, which applies only to the LLM-chosen branch. */
     worldStateMaxTier3?: string
   }
@@ -110,14 +109,15 @@ export function advancedPanelView(settings: AdvancedPanelSettings): AdvancedPane
     },
 
     inactive: {
-      maxTier3Entries: entryLLMOn ? undefined : 'LLM Selection is off, so there is no Tier 3',
-      // `llmThreshold` is NOT reported inactive when LLM selection is off, and this is the
-      // second control in this panel to have claimed it was. It is the boundary between
-      // "include the whole leftover" and "ask the model which of it matters", and only the
-      // second branch needs the model -- so with selection off it is the *only* thing
-      // deciding how much world state reaches the narrator, not a dead control.
-      llmThreshold: undefined,
-      // Its companion cap, on the other hand, only applies in the branch that asks.
+      // Not "there is no Tier 3": a leftover under the word budget is still included
+      // whole without asking the model, so turning selection off removes the call.
+      maxTier3Entries: entryLLMOn
+        ? undefined
+        : 'LLM Selection is off; the leftover is included whole or not at all',
+      // The Include-All Budget is never reported inactive: it is the boundary between
+      // "include the whole leftover" and "ask the model", and only the second branch needs
+      // the model. With selection off it is the only thing deciding how much reaches the
+      // narrator. Its companion cap, on the other hand, only applies in the branch that asks.
       worldStateMaxTier3: worldStateLLMOn
         ? undefined
         : 'LLM Selection is off; the leftover is included whole or not at all',

--- a/src/lib/components/story/ActionInput.svelte
+++ b/src/lib/components/story/ActionInput.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { tick } from 'svelte'
-  import { ui } from '$lib/stores/ui.svelte'
+  import { ui, type RetrievalCacheKey } from '$lib/stores/ui.svelte'
+  import { toRetrievalSnapshot } from '$lib/services/ai/retrieval'
+  import { countTokens } from '$lib/services/tokenizer'
   import { story } from '$lib/stores/story.svelte'
   import { settings } from '$lib/stores/settings.svelte'
   import type { EntryMetadata } from '$lib/types'
@@ -248,15 +250,8 @@
           story.getChapterEntries.bind(story),
           story.chapterReadBudget,
         ),
-      buildWorldStateContext: (worldState, userInput, recentEntries, signal, activationTracker) =>
-        aiService.buildWorldStateContext(
-          worldState,
-          userInput,
-          recentEntries,
-          undefined,
-          signal,
-          activationTracker,
-        ),
+      buildWorldStateContext: (worldState, userInput, recentEntries, options) =>
+        aiService.buildWorldStateContext(worldState, userInput, recentEntries, undefined, options),
       getRelevantLorebookEntries: aiService.getRelevantLorebookEntries.bind(aiService),
       streamNarrative: aiService.streamNarrative.bind(aiService),
       classifyResponse: aiService.classifyResponse.bind(aiService),
@@ -423,6 +418,26 @@
       settings.experimentalFeatures.generationNotifications
     ) {
       await sendGenerationNotification('', false)
+    }
+  }
+
+  /**
+   * The key a retrieval result would be stored under right now.
+   *
+   * Call it once the entries are in the state generation will run from, which always means
+   * *after* the user action row exists: the write site captures `story.entries.length`
+   * inside `generateResponse`, by which point `addEntry` (fresh turn) or the restore
+   * (retry, regenerate) has already put it there. Called any earlier it computes a position
+   * one lower than the stored key and can never match.
+   */
+  function retrievalKeyFor(actionContent: string): RetrievalCacheKey | null {
+    const current = story.currentStory
+    if (!current) return null
+    return {
+      storyId: current.id,
+      branchId: current.currentBranchId ?? null,
+      position: story.entries.length,
+      actionContent,
     }
   }
 
@@ -608,8 +623,23 @@
 
         if (event.type === 'phase_complete' && event.phase === 'retrieval') {
           const retrievalResult = event.result as RetrievalResult | undefined
-          ui.setLastLorebookRetrieval(retrievalResult?.lorebookRetrievalResult ?? null)
-          ui.setLastRetrievalResult(retrievalResult ?? null)
+          ui.setLastLorebookRetrieval(
+            retrievalResult?.lorebookRetrievalResult ?? null,
+            retrievalResult?.worldStateRetrievalResult ?? null,
+          )
+          // Kept for the narration entry below: the in-memory copy dies with the session.
+          generationMeta.retrievalSnapshot =
+            toRetrievalSnapshot(
+              retrievalResult?.lorebookRetrievalResult,
+              retrievalResult?.worldStateRetrievalResult,
+              countTokens,
+            ) ?? undefined
+          ui.setLastRetrievalResult(retrievalResult ?? null, {
+            storyId: currentStoryRef.id,
+            branchId: currentStoryRef.currentBranchId ?? null,
+            position: storyPosition,
+            actionContent: userActionContent,
+          })
         }
 
         if (event.type === 'narrative_chunk') {
@@ -964,7 +994,11 @@
     emitUserInput(content, isCreativeMode ? 'direction' : forceFreeMode ? 'free' : actionType)
     await tick()
 
-    await generateResponse(userActionEntry.id, content)
+    // `promptContent`, not the raw `content`: with translation on the two differ, and the
+    // entry the narrator reads holds `promptContent`. Passing the raw text here left
+    // retrieval and classification working from a different wording than the narration —
+    // and the retry path already passes `promptContent`, so the two disagreed.
+    await generateResponse(userActionEntry.id, promptContent)
   }
 
   async function handleStopGeneration() {
@@ -1081,9 +1115,14 @@
       )
     }
 
+    // The rewind above put the story back exactly where the previous turn's retrieval was
+    // computed, so that result is still the right one — same branch, same position, same
+    // action. Read after the undo, since the key is position-sensitive.
+    const cachedRetrieval = retrievalKeyFor(userActionEntry.content)
     await generateResponse(userActionEntry.id, userActionEntry.content, {
       countStyleReview: false,
       styleReviewSource: 'regenerate',
+      cachedRetrievalResult: cachedRetrieval ? ui.retrievalResultFor(cachedRetrieval) : null,
     })
   }
 
@@ -1101,18 +1140,9 @@
 
     const storyId = story.currentStory.id
 
-    // Captured before the clear below, which is what makes the reuse at the bottom of this
-    // function possible at all: `ui.lastRetrievalResult` is read there, and nothing between
-    // here and there ever writes it back (retryService is handed setLastLorebookRetrieval,
-    // not setLastRetrievalResult). Reading the store at the call site returned the null set
-    // on the next line, so every retry silently re-ran retrieval from scratch -- an entire
-    // agentic loop, now that agentic is the default mode.
-    const cachedRetrieval = ui.lastRetrievalResult
-
     ui.clearGenerationError()
     ui.clearSuggestions(storyId)
     ui.clearActionChoices(storyId)
-    ui.setLastRetrievalResult(null)
 
     const result = await retryService.handleRetryLastMessage(
       backup,
@@ -1153,12 +1183,16 @@
     emitUserInput(backup.userActionContent, isCreativeMode ? 'direction' : backup.actionType)
     await tick()
 
+    // Read here rather than before the rewind: the key carries the position, so it only
+    // matches once the restore has put the story back where retrieval ran.
+    const cacheKey = retrievalKeyFor(promptContent)
+
     ui.setRetryingLastMessage(true)
     try {
       await generateResponse(userActionEntry.id, promptContent, {
         countStyleReview: false,
         styleReviewSource: 'retry-last-message',
-        cachedRetrievalResult: cachedRetrieval,
+        cachedRetrievalResult: cacheKey ? ui.retrievalResultFor(cacheKey) : null,
       })
     } finally {
       ui.setRetryingLastMessage(false)

--- a/src/lib/services/ai/core/defaults.ts
+++ b/src/lib/services/ai/core/defaults.ts
@@ -14,10 +14,11 @@
 /** Selection limits for `WorldStateInjector`. All exposed as Advanced Settings sliders. */
 export const WORLD_STATE_INJECTION_DEFAULTS = {
   /**
-   * Where "include the whole leftover" turns into "ask the model which of it matters".
-   * See `WorldStateInjector.buildContext`.
+   * Where "include the whole leftover" turns into "ask the model which of it matters",
+   * in words of candidate text. Measured on a 101-record world state: a live record runs
+   * ~16 words, so 500 is about the 30 records this replaced.
    */
-  llmThreshold: 30,
+  tier3WholesaleWordBudget: 500,
   /** Cap on Tier 2 (name matched). */
   maxTier2Entries: 40,
   /** Cap on Tier 3, in the branch where the LLM had to choose. */
@@ -37,7 +38,27 @@ export const ENTRY_RETRIEVAL_DEFAULTS = {
   maxTier2Entries: 20,
   /** Cap on Tier 3 (LLM selected). */
   maxTier3Entries: 30,
+  /**
+   * Where "include the whole leftover" turns into "ask the model which of it matters",
+   * in words of entry text.
+   *
+   * Higher than the world state's because a lorebook entry is a paragraph, not a line:
+   * measured at ~69 words against ~16. At 1000 a leftover of roughly fifteen entries still
+   * goes in whole, which is cheaper in latency than the call it replaces.
+   */
+  tier3WholesaleWordBudget: 1000,
 } as const
+
+/**
+ * How far the story may move before a cached Tier 3 selection is asked again, in story
+ * positions. Exclusive: a distance of exactly this many misses.
+ *
+ * The cache key already pins the caller, the candidate pool and the player's action, so a
+ * hit is the same question being asked twice — a retry, or a second pass in one turn. This
+ * only bounds how long that stays true, and a turn is exactly two positions, so 2-exclusive
+ * is "within the turn the answer was given for" and nothing beyond it.
+ */
+export const TIER3_SELECTION_CACHE_POSITIONS = 2
 
 /** Limits for the agentic retrieval loop. Exposed as an Advanced Settings slider. */
 export const AGENTIC_RETRIEVAL_DEFAULTS = {

--- a/src/lib/services/ai/generation/WorldStateInjector.test.ts
+++ b/src/lib/services/ai/generation/WorldStateInjector.test.ts
@@ -22,7 +22,7 @@ vi.mock('$lib/stores/settings.svelte', () => ({
     getServicePresetId: () => 'context',
     systemServicesSettings: {
       worldStateInjection: {
-        llmThreshold: 10,
+        tier3WholesaleWordBudget: 500,
         maxEntriesPerTier: 5,
         enableLLMSelection: false,
         recentEntriesCount: 5,
@@ -140,10 +140,13 @@ describe('WorldStateInjector', () => {
 
     beforeEach(() => runTier3Selection.mockReset())
 
-    it('includes everything left over when it fits under the threshold', async () => {
+    it('includes everything left over when it fits under the budget', async () => {
       // The whole point of the fix: a small leftover used to be dropped outright, so a
       // small story was served *worse* than a large one.
-      const small = new WorldStateInjector({ llmThreshold: 30, enableLLMSelection: true })
+      const small = new WorldStateInjector({
+        tier3WholesaleWordBudget: 1000,
+        enableLLMSelection: true,
+      })
 
       const result = await small.buildContext(worldState, '', [])
 
@@ -153,7 +156,10 @@ describe('WorldStateInjector', () => {
 
     it('does so without an LLM call even when LLM selection is switched off', async () => {
       // Including what is already in hand is not a selection, so the switch does not gate it.
-      const off = new WorldStateInjector({ llmThreshold: 30, enableLLMSelection: false })
+      const off = new WorldStateInjector({
+        tier3WholesaleWordBudget: 1000,
+        enableLLMSelection: false,
+      })
 
       const result = await off.buildContext(worldState, '', [])
 
@@ -161,11 +167,41 @@ describe('WorldStateInjector', () => {
       expect(runTier3Selection).not.toHaveBeenCalled()
     })
 
-    it('asks the model which of the leftovers matter once there are too many to include', async () => {
-      runTier3Selection.mockResolvedValue({ selectedIds: new Set(['c2']) })
-      const over = new WorldStateInjector({ llmThreshold: 2, enableLLMSelection: true })
+    const worldStateLarge = {
+      ...worldState,
+      items: [
+        ...items,
+        {
+          id: 'i3',
+          name: 'Ring of Power',
+          location: 'ground',
+          equipped: false,
+          description: 'Gold ring',
+        },
+        {
+          id: 'i4',
+          name: 'Magic Wand',
+          location: 'ground',
+          equipped: false,
+          description: 'Wood wand',
+        },
+        {
+          id: 'i5',
+          name: 'Iron Helmet',
+          location: 'ground',
+          equipped: false,
+          description: 'Steel cap',
+        },
+      ] as Item[],
+    }
 
-      const result = await over.buildContext(worldState, '', [])
+    it('asks the model which of the leftovers matter once there are too many to include', async () => {
+      // '0' is an index into the candidate list, which `collectRemainingCandidates`
+      // groups by type: [Borin, Iron Mountain, Shield of Dawn, Ring, Wand, Helmet].
+      runTier3Selection.mockResolvedValue({ selectedIndices: new Set(['0']) })
+      const over = new WorldStateInjector({ tier3WholesaleWordBudget: 5, enableLLMSelection: true })
+
+      const result = await over.buildContext(worldStateLarge, '', [])
 
       expect(runTier3Selection).toHaveBeenCalledTimes(1)
       expect(result.tier3.map((e) => e.name)).toEqual(['Borin'])
@@ -174,17 +210,20 @@ describe('WorldStateInjector', () => {
     it('labels its debug entries distinctly from the lorebook selection', async () => {
       // Both selections used to log under one name, so the API Debug Logs could not tell
       // them apart -- and the view filters by that name, so neither could be read alone.
-      runTier3Selection.mockResolvedValue({ selectedIds: new Set() })
-      const over = new WorldStateInjector({ llmThreshold: 2, enableLLMSelection: true })
+      runTier3Selection.mockResolvedValue({ selectedIndices: new Set() })
+      const over = new WorldStateInjector({ tier3WholesaleWordBudget: 5, enableLLMSelection: true })
 
-      await over.buildContext(worldState, '', [])
+      await over.buildContext(worldStateLarge, '', [])
 
       expect(runTier3Selection.mock.calls[0][0].serviceLabel).toBe('tier3-world-state-selection')
     })
 
     it('drops the leftovers when there are too many and selection is off', async () => {
       // No third option: too much to include, and no permission to choose.
-      const over = new WorldStateInjector({ llmThreshold: 2, enableLLMSelection: false })
+      const over = new WorldStateInjector({
+        tier3WholesaleWordBudget: 5,
+        enableLLMSelection: false,
+      })
 
       const result = await over.buildContext(worldState, '', [])
 
@@ -194,7 +233,10 @@ describe('WorldStateInjector', () => {
 
     it('leaves Tier 3 empty when tiers 1 and 2 covered everything', async () => {
       const covered = { characters: [], locations: [], items: [], storyBeats: [] }
-      const injector3 = new WorldStateInjector({ llmThreshold: 30, enableLLMSelection: true })
+      const injector3 = new WorldStateInjector({
+        tier3WholesaleWordBudget: 1000,
+        enableLLMSelection: true,
+      })
 
       const result = await injector3.buildContext(covered, '', [])
 
@@ -236,7 +278,7 @@ describe('WorldStateInjector', () => {
       // Below the threshold the leftover goes in as-is: "include what is left over" and
       // "the first N of it" cannot both be true.
       const injector2 = new WorldStateInjector({
-        llmThreshold: 30,
+        tier3WholesaleWordBudget: 1000,
         maxTier3Entries: 5,
         enableLLMSelection: true,
       })
@@ -260,8 +302,8 @@ describe('WorldStateInjector', () => {
       const injector2 = new WorldStateInjector({ maxTier2Entries: 40, maxTier3Entries: 50 })
 
       // Turn 1 activates all 20 through Tier 2; turn 2 mentions none of them.
-      await injector2.buildContext(pool, mentions, [], undefined, tracker)
-      const result = await injector2.buildContext(pool, '', [], undefined, tracker)
+      await injector2.buildContext(pool, mentions, [], { activationTracker: tracker })
+      const result = await injector2.buildContext(pool, '', [], { activationTracker: tracker })
 
       expect(result.tier1.filter((e) => e.metadata?.sticky)).toHaveLength(20)
     })
@@ -316,6 +358,11 @@ describe('WorldStateInjector', () => {
   })
 
   describe('sticky entries are relevance, not state', () => {
+    /** Left uncovered by tiers 1 and 2 in this fixture. */
+    const uncoveredNames = ['Borin', 'Iron Mountain', 'Shield of Dawn']
+
+    beforeEach(() => runTier3Selection.mockReset())
+
     /** Activate `names` on one turn, then run a turn mentioning nothing. */
     async function afterStickyTurn(state: typeof worldState, names: string) {
       const positions = new Map<string, number>()
@@ -324,9 +371,12 @@ describe('WorldStateInjector', () => {
         recordActivation: (id: string, p: number) => positions.set(id, p),
         currentPosition: 0,
       }
-      const local = new WorldStateInjector({ enableLLMSelection: false, llmThreshold: 0 })
-      await local.buildContext(state, names, [], undefined, tracker)
-      return local.buildContext(state, '', [], undefined, tracker)
+      const local = new WorldStateInjector({
+        enableLLMSelection: false,
+        tier3WholesaleWordBudget: 0,
+      })
+      await local.buildContext(state, names, [], { activationTracker: tracker })
+      return local.buildContext(state, '', [], { activationTracker: tracker })
     }
 
     it('never lists a sticky item as carried', async () => {
@@ -369,6 +419,90 @@ describe('WorldStateInjector', () => {
       expect(result.contextBlock).toContain('[INVENTORY]\nSunblade')
       expect(result.contextBlock).toContain('[ACTIVE THREADS]')
       expect(result.contextBlock).toContain('Save the village')
+    })
+
+    // The helper above pins `tier3WholesaleWordBudget: 0`, so it can never reach the
+    // wholesale branch — which is where the whole leftover lands on any story under the
+    // budget, i.e. on most of them.
+    it('does not make a wholesale Tier 3 sticky', async () => {
+      // Wholesale means "the leftover was small", which says nothing about relevance.
+      // Recording it would activate every uncovered entity on every turn, so Tier 1 would
+      // swallow the pool and stickiness would never expire. `EntryRetrievalService` has
+      // always excluded it; this side used to say it mirrored that, and did not.
+      const positions = new Map<string, number>()
+      const tracker = {
+        getLastActivation: (id: string) => positions.get(id) ?? null,
+        recordActivation: (id: string, p: number) => positions.set(id, p),
+        currentPosition: 4,
+      }
+      const generous = new WorldStateInjector({
+        tier3WholesaleWordBudget: 1000,
+        enableLLMSelection: true,
+      })
+
+      const first = await generous.buildContext(worldState, '', [], {
+        activationTracker: tracker,
+      })
+
+      expect(first.tier3.map((e) => e.name).sort()).toEqual([...uncoveredNames].sort())
+      expect(runTier3Selection).not.toHaveBeenCalled()
+      for (const entry of first.tier3) {
+        expect(positions.has(entry.id)).toBe(false)
+      }
+
+      // And so nothing carries into the next turn as Tier 1 sticky.
+      const next = await generous.buildContext(worldState, '', [], { activationTracker: tracker })
+      expect(next.tier1.filter((e) => e.metadata?.sticky)).toHaveLength(0)
+    })
+
+    // The wholesale branch is the only place the Tier 2 list is used on its own, so a
+    // regression that recorded *nothing* there would satisfy the test above and go unseen.
+    it('still records Tier 2 in the wholesale branch', async () => {
+      const positions = new Map<string, number>()
+      const tracker = {
+        getLastActivation: (id: string) => positions.get(id) ?? null,
+        recordActivation: (id: string, p: number) => positions.set(id, p),
+        currentPosition: 4,
+      }
+      const generous = new WorldStateInjector({
+        tier3WholesaleWordBudget: 1000,
+        enableLLMSelection: true,
+      })
+
+      // Naming Borin pulls him into Tier 2; the rest of the leftover goes in wholesale.
+      const result = await generous.buildContext(worldState, 'Borin, are you ready?', [], {
+        activationTracker: tracker,
+      })
+
+      expect(result.tier2.map((e) => e.name)).toContain('Borin')
+      expect(result.tier3.length).toBeGreaterThan(0)
+      for (const entry of result.tier2) {
+        expect(positions.get(entry.id)).toBe(4)
+      }
+      for (const entry of result.tier3) {
+        expect(positions.has(entry.id)).toBe(false)
+      }
+    })
+
+    it('still makes an LLM-selected Tier 3 sticky', async () => {
+      // The other half of the rule: a model was paid to call this relevant, and stickiness
+      // is what makes relevance outlive the turn that noticed it.
+      const positions = new Map<string, number>()
+      const tracker = {
+        getLastActivation: (id: string) => positions.get(id) ?? null,
+        recordActivation: (id: string, p: number) => positions.set(id, p),
+        currentPosition: 4,
+      }
+      runTier3Selection.mockResolvedValue({ selectedIndices: new Set(['0']) })
+      const tight = new WorldStateInjector({
+        tier3WholesaleWordBudget: 0,
+        enableLLMSelection: true,
+      })
+
+      const result = await tight.buildContext(worldState, '', [], { activationTracker: tracker })
+
+      expect(result.tier3).toHaveLength(1)
+      expect(positions.get(result.tier3[0].id)).toBe(4)
     })
   })
 })

--- a/src/lib/services/ai/generation/WorldStateInjector.ts
+++ b/src/lib/services/ai/generation/WorldStateInjector.ts
@@ -9,7 +9,7 @@
  *   see `WORLD_STATE_STICKINESS_BY_TYPE`) when an `ActivationTracker` is provided
  * - Tier 2: Name matching (fuzzy match against recent input)
  * - Tier 3: everything tiers 1-2 left uncovered -- included as-is when there is little of
- *   it, narrowed by LLM selection when there is more than `llmThreshold`
+ *   it, narrowed by LLM selection when it is bigger than `tier3WholesaleWordBudget`
  *
  * Counterpart to ClassifierService ("World State Classifier" in Agent Profiles), which extracts
  * WorldState changes from the narrative response after generation; this service injects
@@ -42,6 +42,7 @@ import { entityNameMatches } from '$lib/utils/text'
 import {
   runTier3Selection,
   resolveTier3Selection,
+  countWholesaleWords,
   type Tier3Candidate,
 } from '../retrieval/tier3Selection'
 
@@ -50,6 +51,7 @@ type WorldStateCandidate = Tier3Candidate<WorldStateContextEntry['type']>
 import type { ActivationTracker } from '../retrieval/EntryRetrievalService'
 import { resolveStickiness } from '../retrieval/stickiness'
 import { recentContent, AS_HAYSTACK } from '$lib/utils/recentContent'
+import { secondPassHaystack } from '../retrieval/tier2SecondPass'
 
 const log = createLogger('WorldStateInjector')
 
@@ -60,14 +62,14 @@ const log = createLogger('WorldStateInjector')
  * faction/concept/event instead of storyBeat. The fading priority both maps feed is shared
  * -- see `retrieval/stickiness.ts`.
  *
- * The numbers are deliberately kept identical to the lorebook map rather than doubled;
- * changing the scale is a tuning decision for both at once.
+ * The numbers are deliberately kept identical to the lorebook map; changing the scale is a
+ * tuning decision for both at once.
  */
 const WORLD_STATE_STICKINESS_BY_TYPE: Record<WorldStateContextEntry['type'], number> = {
-  character: 3,
-  location: 3,
-  item: 2,
-  storyBeat: 3,
+  character: 6,
+  location: 6,
+  item: 6,
+  storyBeat: 6,
 }
 
 export interface WorldStateInjectorInput {
@@ -80,7 +82,8 @@ export interface WorldStateInjectorInput {
 
 export interface WorldStateInjectorConfig {
   /** Threshold for triggering LLM selection (Tier 3) */
-  llmThreshold: number
+  /** Words of leftover that still go in whole, above which the LLM is asked instead. */
+  tier3WholesaleWordBudget: number
   /** Maximum entities to include from Tier 2 (name matched) */
   maxTier2Entries: number
   /** Maximum entities to include from Tier 3, when the LLM had to choose */
@@ -91,8 +94,29 @@ export interface WorldStateInjectorConfig {
   recentEntriesCount: number
 }
 
+/** How far a second-pass Tier 2 hit ranks below the same entity found directly. */
+const SECOND_PASS_PRIORITY_PENALTY = 10
+
+/** One entity already in the scene, as handed to the lorebook pass. */
+export interface SceneEntity {
+  type: string
+  name: string
+}
+
+export interface WorldStateInjectorOptions {
+  signal?: AbortSignal
+  activationTracker?: ActivationTracker
+  /** The entry `userInput` came from, so Tier 3 does not see the action twice. */
+  userActionEntryId?: string
+  /**
+   * Called with Tier 1 + Tier 2 as soon as they are known, before Tier 3 runs. Lets the
+   * lorebook pass start from what is in the scene without waiting on an LLM call.
+   */
+  onSceneEntities?: (entities: SceneEntity[]) => void
+}
+
 export const DEFAULT_WORLD_STATE_INJECTOR_CONFIG: WorldStateInjectorConfig = {
-  llmThreshold: WORLD_STATE_INJECTION_DEFAULTS.llmThreshold,
+  tier3WholesaleWordBudget: WORLD_STATE_INJECTION_DEFAULTS.tier3WholesaleWordBudget,
   maxTier2Entries: WORLD_STATE_INJECTION_DEFAULTS.maxTier2Entries,
   maxTier3Entries: WORLD_STATE_INJECTION_DEFAULTS.maxTier3Entries,
   enableLLMSelection: true,
@@ -106,7 +130,8 @@ export const DEFAULT_WORLD_STATE_INJECTOR_CONFIG: WorldStateInjectorConfig = {
 export function getWorldStateInjectorConfigFromSettings(): Partial<WorldStateInjectorConfig> {
   const s = settings.systemServicesSettings.worldStateInjection
   return {
-    llmThreshold: s?.llmThreshold ?? WORLD_STATE_INJECTION_DEFAULTS.llmThreshold,
+    tier3WholesaleWordBudget:
+      s?.tier3WholesaleWordBudget ?? WORLD_STATE_INJECTION_DEFAULTS.tier3WholesaleWordBudget,
     maxTier2Entries: s?.maxTier2Entries ?? WORLD_STATE_INJECTION_DEFAULTS.maxTier2Entries,
     maxTier3Entries: s?.maxTier3Entries ?? WORLD_STATE_INJECTION_DEFAULTS.maxTier3Entries,
     enableLLMSelection: s?.enableLLMSelection ?? true,
@@ -121,6 +146,14 @@ export interface WorldStateContextEntry {
   description: string | null
   tier: 1 | 2 | 3
   priority: number
+  /** Story positions of carry-over left, when Tier 1 carried this over. Two per turn. */
+  stickyPositionsLeft?: number
+  /** The full window for this entity's type, so the panel can show progress, not just a count. */
+  stickyPositionsTotal?: number
+  /** Tier 3 only: the model picked this, rather than it fitting under the budget. */
+  llmSelected?: boolean
+  /** Tier 2 only: matched on the second pass, through something the first pass found. */
+  viaScene?: boolean
   metadata?: Record<string, any>
 }
 
@@ -161,9 +194,9 @@ export class WorldStateInjector extends BaseAIService {
     worldState: WorldStateInjectorInput,
     userInput: string,
     recentEntries: StoryEntry[],
-    signal?: AbortSignal,
-    activationTracker?: ActivationTracker,
+    options: WorldStateInjectorOptions = {},
   ): Promise<WorldStateInjectionResult> {
+    const { signal, activationTracker, userActionEntryId, onSceneEntities } = options
     const currentPosition = activationTracker?.currentPosition ?? recentEntries.length
 
     log('buildContext called', {
@@ -191,58 +224,78 @@ export class WorldStateInjector extends BaseAIService {
     // Get IDs in tier 1 + 2
     const tier12Ids = new Set([...tier1Ids, ...tier2.map((e) => e.id)])
 
+    // Handed over before Tier 3, which is the point: Tier 3 may be an LLM call, and the
+    // lorebook pass waiting on this must not wait on that too.
+    onSceneEntities?.([...tier1, ...tier2].map((e) => ({ type: e.type, name: e.name })))
+
     // Tier 3: what tiers 1 and 2 left uncovered.
     //
-    // `llmThreshold` is an overflow valve, and now actually works like one. It used to gate
-    // *whether Tier 3 ran at all*, with nothing below the threshold: a leftover of 5
-    // entities was dropped outright while a leftover of 40 got an LLM pass and up to
-    // `maxEntriesPerTier` of them injected. That inverted the thing it was meant to protect
-    // -- a bigger pool made any given entity *more* likely to reach the narrator, so a small
-    // story was served worse than a large one -- and it was backwards on cost too, skipping
-    // the cheap calls and paying for the expensive ones.
+    // The volume question first, the relevance question only if it has to be asked:
     //
-    // The volume question and the relevance question are now separate:
-    //   - small leftover  -> include all of it, no LLM call, nothing dropped
-    //   - large leftover  -> too much to include, so ask the model which of it matters
-    // The threshold is the boundary between the two, which is what its name says.
+    //   - leftover small enough to send whole -> send it, no LLM call, nothing dropped
+    //   - leftover too big                    -> ask the model which of it matters
     //
-    // Not capped by `maxEntriesPerTier` in the wholesale branch: "include what is left over"
-    // and "the first N of what is left over" cannot both be true, and there is no ranking
-    // signal here to make a cap non-arbitrary. Same reasoning as Tier 1's always-inject
-    // entries. The threshold is the ceiling in that branch, by construction.
+    // Measured in words rather than records, the same unit `EntryRetrievalService` uses, so
+    // the two budgets mean the same thing at different scales. Not capped by
+    // `maxTier3Entries` in the wholesale branch: "include what is left over" and "the first
+    // N of what is left over" cannot both be true, and there is no ranking signal here to
+    // make a cap non-arbitrary.
     let tier3: WorldStateContextEntry[] = []
+
+    /** Whether Tier 3 got there by being cheap rather than by being chosen. */
+    let tier3IsWholesale = false
+
     const candidates = this.collectRemainingCandidates(worldState, tier12Ids)
+    const wholesaleWords = countWholesaleWords(candidates)
 
     if (candidates.length === 0) {
       // Nothing uncovered.
-    } else if (candidates.length <= this.config.llmThreshold) {
-      tier3 = candidates.map((candidate) => this.asTier3Entry(candidate))
+    } else if (wholesaleWords <= this.config.tier3WholesaleWordBudget) {
+      tier3IsWholesale = true
+      tier3 = candidates.map((candidate) => this.asTier3Entry(candidate, false))
       log('Tier 3 included wholesale', {
         entries: tier3.length,
-        threshold: this.config.llmThreshold,
+        words: wholesaleWords,
+        budget: this.config.tier3WholesaleWordBudget,
       })
     } else if (this.config.enableLLMSelection) {
       log('Tier 3 LLM selection triggered', {
         candidates: candidates.length,
-        threshold: this.config.llmThreshold,
+        words: wholesaleWords,
+        budget: this.config.tier3WholesaleWordBudget,
       })
-      tier3 = await this.selectTier3WithLLM(candidates, userInput, recentEntries, signal)
+      tier3 = await this.selectTier3WithLLM(
+        candidates,
+        userInput,
+        recentEntries,
+        currentPosition,
+        signal,
+        userActionEntryId,
+      )
       log('Tier 3 entries:', tier3.length)
     } else {
-      // Too many to include, and selection is switched off: there is no third option.
-      log('Tier 3 dropped -- over threshold with LLM selection off', {
+      // Too much to include, and selection is switched off: there is no third option.
+      log('Tier 3 dropped -- over budget with LLM selection off', {
         candidates: candidates.length,
-        threshold: this.config.llmThreshold,
+        words: wholesaleWords,
+        budget: this.config.tier3WholesaleWordBudget,
       })
     }
 
     // Record Tier 2 and Tier 3 activations for stickiness (mirrors EntryRetrievalService).
     //
-    // After Tier 3, not between the tiers: an entity the LLM picked is as much "relevant
+    // After Tier 3, not between the tiers: an entity the LLM *picked* is as much "relevant
     // this turn" as one matched by name, and recording only Tier 2 made the expensive
     // signal the shorter-lived one.
+    //
+    // A *wholesale* Tier 3 is excluded, exactly as in `EntryRetrievalService`. It means the
+    // leftover was small, which says nothing about relevance — and since every uncovered
+    // entity is in it, recording it would make the entire world state sticky on every turn
+    // of any story under the budget, i.e. on most stories. Stickiness would then never
+    // expire and Tier 1 would absorb the whole pool.
+    const activated = tier3IsWholesale ? tier2 : [...tier2, ...tier3]
     if (activationTracker) {
-      for (const entry of [...tier2, ...tier3]) {
+      for (const entry of activated) {
         activationTracker.recordActivation(entry.id, currentPosition)
       }
     }
@@ -441,7 +494,9 @@ export class WorldStateInjector extends BaseAIService {
           ...candidate,
           tier: 1,
           priority: carried.priority,
-          metadata: { sticky: true, turnsLeft: carried.turnsLeft },
+          stickyPositionsLeft: carried.positionsLeft,
+          stickyPositionsTotal: WORLD_STATE_STICKINESS_BY_TYPE[candidate.type],
+          metadata: { sticky: true, positionsLeft: carried.positionsLeft },
         })
         includedIds.add(candidate.id)
       }
@@ -458,8 +513,12 @@ export class WorldStateInjector extends BaseAIService {
   }
 
   /**
-   * Tier 2: Name matching against user input and recent entries.
-   * Uses fuzzy matching to find references to characters, locations, items.
+   * Tier 2, in two passes.
+   *
+   * The first matches names against the scene; the second matches what is left against the
+   * names the first pass found, so an entity referred to only through another one still
+   * arrives. Second-pass hits rank a step below their first-pass equivalents, so a cap
+   * drops relevance-at-one-remove first.
    */
   private getTier2Entries(
     worldState: WorldStateInjectorInput,
@@ -467,11 +526,46 @@ export class WorldStateInjector extends BaseAIService {
     recentEntries: StoryEntry[],
     excludeIds: Set<string>,
   ): WorldStateContextEntry[] {
-    const entries: WorldStateContextEntry[] = []
-
-    // Combine user input with recent entry content for matching
     const searchText =
       `${userInput} ${recentContent(recentEntries, this.config.recentEntriesCount, AS_HAYSTACK)}`.toLowerCase()
+
+    const firstPass = this.matchEntities(worldState, searchText, excludeIds, 0)
+
+    const seeds = secondPassHaystack(firstPass.map((e) => e.name))
+    const secondPass = seeds
+      ? this.matchEntities(
+          worldState,
+          seeds,
+          new Set([...excludeIds, ...firstPass.map((e) => e.id)]),
+          SECOND_PASS_PRIORITY_PENALTY,
+        )
+      : []
+
+    if (secondPass.length > 0) {
+      log(
+        'Tier 2 second pass matched',
+        secondPass.length,
+        secondPass.map((e) => e.name),
+      )
+    }
+
+    // Ranked before capping. Built in type order (characters, then locations, then items,
+    // then beats), so slicing that order straight through meant a low cap dropped whole
+    // categories -- with maxEntriesPerTier at its minimum of 3, no story beat could ever
+    // survive Tier 2, whatever the narrative was about.
+    return [...firstPass, ...secondPass]
+      .sort((a, b) => b.priority - a.priority)
+      .slice(0, this.config.maxTier2Entries)
+  }
+
+  /** One matching pass. `priorityPenalty` is what separates a second-pass hit from a first. */
+  private matchEntities(
+    worldState: WorldStateInjectorInput,
+    searchText: string,
+    excludeIds: Set<string>,
+    priorityPenalty: number,
+  ): WorldStateContextEntry[] {
+    const entries: WorldStateContextEntry[] = []
 
     // Match characters not in Tier 1
     for (const char of worldState.characters) {
@@ -483,7 +577,8 @@ export class WorldStateInjector extends BaseAIService {
           name: char.name,
           description: char.description,
           tier: 2,
-          priority: 60,
+          priority: 60 - priorityPenalty,
+          viaScene: priorityPenalty > 0,
           metadata: {
             relationship: char.relationship,
             traits: char.traits,
@@ -503,7 +598,8 @@ export class WorldStateInjector extends BaseAIService {
           name: loc.name,
           description: loc.description,
           tier: 2,
-          priority: 50,
+          priority: 50 - priorityPenalty,
+          viaScene: priorityPenalty > 0,
           metadata: { visited: loc.visited },
         })
       }
@@ -519,7 +615,8 @@ export class WorldStateInjector extends BaseAIService {
           name: item.name,
           description: item.description,
           tier: 2,
-          priority: 40,
+          priority: 40 - priorityPenalty,
+          viaScene: priorityPenalty > 0,
           metadata: { quantity: item.quantity, location: item.location },
         })
       }
@@ -535,17 +632,14 @@ export class WorldStateInjector extends BaseAIService {
           name: beat.title,
           description: beat.description,
           tier: 2,
-          priority: 45,
+          priority: 45 - priorityPenalty,
+          viaScene: priorityPenalty > 0,
           metadata: { type: beat.type, status: beat.status },
         })
       }
     }
 
-    // Ranked before capping. Built in type order (characters, then locations, then items,
-    // then beats), so slicing that order straight through meant a low cap dropped whole
-    // categories -- with maxEntriesPerTier at its minimum of 3, no story beat could ever
-    // survive Tier 2, whatever the narrative was about.
-    return entries.sort((a, b) => b.priority - a.priority).slice(0, this.config.maxTier2Entries)
+    return entries
   }
 
   private candidatesOf<T>(
@@ -600,19 +694,24 @@ export class WorldStateInjector extends BaseAIService {
     ]
   }
 
-  private asTier3Entry(candidate: WorldStateCandidate): WorldStateContextEntry {
-    return { ...candidate, tier: 3, priority: 30 }
+  private asTier3Entry(
+    candidate: WorldStateCandidate,
+    llmSelected: boolean,
+  ): WorldStateContextEntry {
+    return { ...candidate, tier: 3, priority: 30, llmSelected }
   }
 
   /**
-   * Ask the LLM which of the leftovers matter. Only reached when there are more of them
-   * than `llmThreshold` -- below that they are all included and no call is made.
+   * Ask the LLM which of the leftovers matter. Only reached when they run to more words
+   * than `tier3WholesaleWordBudget` -- below that they are all included and no call is made.
    */
   private async selectTier3WithLLM(
     candidates: WorldStateCandidate[],
     userInput: string,
     recentEntries: StoryEntry[],
+    currentPosition: number,
     signal?: AbortSignal,
+    userActionEntryId?: string,
   ): Promise<WorldStateContextEntry[]> {
     const result = await runTier3Selection({
       candidates,
@@ -621,13 +720,15 @@ export class WorldStateInjector extends BaseAIService {
       recentEntriesCount: this.config.recentEntriesCount,
       presetId: this.presetId,
       serviceLabel: 'tier3-world-state-selection',
+      userActionEntryId,
+      currentPosition,
       signal,
     })
     if (!result) {
       return []
     }
 
-    const entries = resolveTier3Selection(candidates, result).map((c) => this.asTier3Entry(c))
+    const entries = resolveTier3Selection(candidates, result).map((c) => this.asTier3Entry(c, true))
 
     log('Tier 3 LLM selection complete', {
       candidates: candidates.length,

--- a/src/lib/services/ai/generation/index.ts
+++ b/src/lib/services/ai/generation/index.ts
@@ -52,5 +52,6 @@ export {
   type WorldStateInjectionResult,
   type WorldStateInjectorConfig,
   type WorldStateInjectorInput,
+  type WorldStateInjectorOptions,
   type WorldStateContextEntry,
 } from './WorldStateInjector'

--- a/src/lib/services/ai/index.ts
+++ b/src/lib/services/ai/index.ts
@@ -72,13 +72,15 @@ import {
 import type {
   ClassificationContext,
   WorldStateInjectorConfig,
+  WorldStateInjectorOptions,
   WorldStateInjectionResult,
   RetrievalContext,
   StyleReviewResult,
   WorldStateContext,
 } from './generation'
 import { EntryRetrievalService, getEntryRetrievalConfigFromSettings } from './retrieval'
-import type { TimelineFillResult, EntryRetrievalResult, ActivationTracker } from './retrieval'
+export { clearTier3SelectionCache } from './retrieval'
+import type { TimelineFillResult, EntryRetrievalResult, EntryRetrievalOptions } from './retrieval'
 import type {
   RetrievalResult as AgenticRetrievalResult,
   RetrievalContext as AgenticRetrievalContext,
@@ -536,13 +538,12 @@ class AIService {
     userInput: string,
     recentEntries: StoryEntry[],
     config?: Partial<WorldStateInjectorConfig>,
-    signal?: AbortSignal,
-    activationTracker?: ActivationTracker,
+    options: WorldStateInjectorOptions = {},
   ): Promise<WorldStateInjectionResult> {
     log('buildWorldStateContext called', {
       userInputLength: userInput.length,
       recentEntriesCount: recentEntries.length,
-      hasActivationTracker: !!activationTracker,
+      hasActivationTracker: !!options.activationTracker,
     })
 
     // Read from settings when the caller does not override, same as
@@ -552,13 +553,7 @@ class AIService {
     const injector = serviceFactory.createWorldStateInjector(
       config ?? getWorldStateInjectorConfigFromSettings(),
     )
-    const result = await injector.buildContext(
-      worldState,
-      userInput,
-      recentEntries,
-      signal,
-      activationTracker,
-    )
+    const result = await injector.buildContext(worldState, userInput, recentEntries, options)
 
     log('buildWorldStateContext complete', {
       tier1: result.tier1.length,
@@ -577,13 +572,12 @@ class AIService {
     entries: Entry[],
     userInput: string,
     recentStoryEntries: StoryEntry[],
-    activationTracker?: ActivationTracker,
-    signal?: AbortSignal,
+    options: EntryRetrievalOptions = {},
   ): Promise<EntryRetrievalResult> {
     log('getRelevantLorebookEntries called', {
       totalEntries: entries.length,
       userInputLength: userInput.length,
-      hasActivationTracker: !!activationTracker,
+      hasActivationTracker: !!options.activationTracker,
     })
 
     const config = getEntryRetrievalConfigFromSettings()
@@ -592,8 +586,7 @@ class AIService {
       entries,
       userInput,
       recentStoryEntries,
-      activationTracker,
-      signal,
+      options,
     )
 
     log('getRelevantLorebookEntries complete', {

--- a/src/lib/services/ai/retrieval/EntryRetrievalService.test.ts
+++ b/src/lib/services/ai/retrieval/EntryRetrievalService.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { EntryRetrievalService } from './EntryRetrievalService'
+import { EntryRetrievalService, SimpleActivationTracker } from './EntryRetrievalService'
 import type { Entry, StoryEntry } from '$lib/types'
 
 vi.mock('$lib/stores/debug.svelte', () => ({
@@ -159,6 +159,263 @@ describe('EntryRetrievalService', () => {
       const result = await capped.getRelevantEntries(pool, 'the beacon', [])
 
       expect(result.tier2.map((r) => r.entry.name)).toEqual(['Keyed 0', 'Keyed 1', 'Keyed 2'])
+    })
+  })
+
+  describe('Tier 2 — scene crossfeed and second pass', () => {
+    const entry = (id: string, name: string, keywords: string[] = []): Entry =>
+      ({
+        id,
+        name,
+        type: 'concept',
+        description: 'Lore.',
+        aliases: [],
+        injection: { mode: 'keyword', priority: 10, keywords },
+      }) as unknown as Entry
+
+    // 'Rusthaven' matches the action; 'Siren Docks' names Rusthaven and nothing else, so it
+    // can only arrive on the second pass.
+    const linkedEntries = [
+      entry('l1', 'Rusthaven', ['harbour']),
+      entry('l2', 'Siren Docks', ['Rusthaven']),
+    ]
+    const action = 'We reach the harbour.'
+
+    it('matches lore against what the world state put in the scene', async () => {
+      // Nobody typed "Morvana", but she is standing there, so her house entry is relevant.
+      const entries = [entry('l1', 'House of Stone', ['Morvana'])]
+
+      const result = await service.getRelevantEntries(entries, 'I look around.', [], {
+        sceneEntities: [{ type: 'character', name: 'Morvana' }],
+      })
+
+      expect(result.tier2.map((r) => r.entry.name)).toEqual(['House of Stone'])
+    })
+
+    it('reports a scene match as second-pass, not as something the text named', async () => {
+      // It arrived because a character happens to be standing there, which is relevance at
+      // one remove — the same thing `viaScene` marks for a name-chained hit. Folded into
+      // the first-pass haystack it was indistinguishable from a word the player typed:
+      // same priority, same "matched:" reason, and invisible to the panel's split.
+      const entries = [
+        entry('l1', 'House of Stone', ['Morvana']),
+        entry('l2', 'The Harbour', ['harbour']),
+      ]
+
+      const result = await service.getRelevantEntries(entries, 'We reach the harbour.', [], {
+        sceneEntities: [{ type: 'character', name: 'Morvana' }],
+      })
+
+      const byName = new Map(result.tier2.map((r) => [r.entry.name, r]))
+      expect(byName.get('House of Stone')?.viaScene).toBe(true)
+      expect(byName.get('The Harbour')?.viaScene).toBe(false)
+      expect(byName.get('The Harbour')!.priority).toBeGreaterThan(
+        byName.get('House of Stone')!.priority,
+      )
+    })
+
+    it('ignores the scene entirely when the crossfeed is switched off', async () => {
+      const entries = [entry('l1', 'House of Stone', ['Morvana'])]
+      const noCrossfeed = new EntryRetrievalService({
+        enableLLMSelection: false,
+        useSceneEntities: false,
+      })
+
+      const result = await noCrossfeed.getRelevantEntries(entries, 'I look around.', [], {
+        sceneEntities: [{ type: 'character', name: 'Morvana' }],
+      })
+
+      expect(result.tier2).toEqual([])
+    })
+
+    it('still runs the name-chained second pass with the crossfeed off', async () => {
+      // The switch governs one seed source, not the pass itself.
+      const noCrossfeed = new EntryRetrievalService({
+        enableLLMSelection: false,
+        useSceneEntities: false,
+      })
+
+      const result = await noCrossfeed.getRelevantEntries(linkedEntries, action, [])
+
+      expect(result.tier2.map((r) => r.entry.name).sort()).toEqual(['Rusthaven', 'Siren Docks'])
+    })
+
+    it('finds an entry named only by another entry the first pass matched', async () => {
+      const result = await service.getRelevantEntries(linkedEntries, action, [])
+
+      expect(result.tier2.map((r) => r.entry.name).sort()).toEqual(['Rusthaven', 'Siren Docks'])
+    })
+
+    it('ranks a second-pass hit below the first-pass one that led to it', async () => {
+      const result = await service.getRelevantEntries(linkedEntries, action, [])
+
+      const [first, second] = result.tier2
+      expect(first.entry.name).toBe('Rusthaven')
+      expect(first.priority).toBeGreaterThan(second.priority)
+      expect(second.viaScene).toBe(true)
+      expect(first.viaScene).toBe(false)
+    })
+
+    it('does not run a third pass: a second-pass hit is not a seed', async () => {
+      // Otherwise a dense lorebook pulls itself in entirely, one reference at a time.
+      const result = await service.getRelevantEntries(
+        [...linkedEntries, entry('l3', 'Harbour Watch', ['Siren Docks'])],
+        action,
+        [],
+      )
+
+      expect(result.tier2.map((r) => r.entry.name)).not.toContain('Harbour Watch')
+    })
+
+    it('does not seed on a name too short to mean anything', async () => {
+      // 'Zyl' would match wherever those three letters fall inside a longer word.
+      const result = await service.getRelevantEntries(
+        [entry('s1', 'Zyl', ['archivist']), entry('s2', 'Zyl Archive', ['Zyl'])],
+        'The archivist arrives.',
+        [],
+      )
+
+      expect(result.tier2.map((r) => r.entry.name)).toEqual(['Zyl'])
+    })
+  })
+
+  describe('Tier 3 — the volume question, before the relevance one', () => {
+    /** Pinned so the fixtures do not have to track the shipped default. */
+    const BUDGET = 400
+
+    /** `count` unmatched entries, each carrying `words` words of description. */
+    const uncovered = (count: number, words: number) =>
+      Array.from({ length: count }, (_, i) => ({
+        id: `u${i}`,
+        name: `Unmatched${i}`,
+        type: 'concept',
+        description: Array.from({ length: words }, () => 'lore').join(' '),
+        aliases: [],
+        injection: { mode: 'keyword', priority: 10, keywords: ['nothing-matches-this'] },
+      })) as unknown as Entry[]
+
+    it('includes a cheap leftover wholesale, without an LLM call', async () => {
+      // Two entries of 40 words each are well under the budget, so the call the
+      // model would have been paid for buys nothing that including them does not.
+      const service = new EntryRetrievalService({
+        enableLLMSelection: true,
+        tier3WholesaleWordBudget: BUDGET,
+      })
+      const llm = vi.spyOn(
+        service as unknown as { getLLMSelectedEntries: () => Promise<[]> },
+        'getLLMSelectedEntries',
+      )
+
+      const result = await service.getRelevantEntries(uncovered(2, 40), '', [])
+
+      expect(result.tier3.map((r) => r.entry.name)).toEqual(['Unmatched0', 'Unmatched1'])
+      expect(llm).not.toHaveBeenCalled()
+    })
+
+    it('measures the leftover in words, not in entries', async () => {
+      // The distinction the old `remaining < 3` rule could not make: three entries is a
+      // small leftover by count and an expensive one by content.
+      const service = new EntryRetrievalService({
+        enableLLMSelection: true,
+        tier3WholesaleWordBudget: BUDGET,
+      })
+      const llm = vi
+        .spyOn(
+          service as unknown as { getLLMSelectedEntries: () => Promise<[]> },
+          'getLLMSelectedEntries',
+        )
+        .mockResolvedValue([])
+
+      await service.getRelevantEntries(uncovered(3, 300), '', [])
+
+      expect(llm).toHaveBeenCalled()
+    })
+
+    it('charges for bare names too, so a description-free pool cannot slip through', async () => {
+      // Counting descriptions alone priced these at zero words, so all 500 fitted any
+      // budget and went into the prompt wholesale. One name is one word.
+      const service = new EntryRetrievalService({
+        enableLLMSelection: true,
+        tier3WholesaleWordBudget: BUDGET,
+      })
+      const llm = vi
+        .spyOn(
+          service as unknown as { getLLMSelectedEntries: () => Promise<[]> },
+          'getLLMSelectedEntries',
+        )
+        .mockResolvedValue([])
+
+      await service.getRelevantEntries(uncovered(500, 0), '', [])
+
+      expect(llm).toHaveBeenCalled()
+    })
+
+    it('drops an over-budget leftover when LLM selection is switched off', async () => {
+      // There is no third option: too much to include, and nobody to ask.
+      const off = new EntryRetrievalService({
+        enableLLMSelection: false,
+        tier3WholesaleWordBudget: BUDGET,
+      })
+
+      const result = await off.getRelevantEntries(uncovered(3, 300), '', [])
+
+      expect(result.tier3).toEqual([])
+    })
+
+    it('still includes a cheap leftover when LLM selection is switched off', async () => {
+      // Including what is already in hand is not a selection, so the switch does not gate
+      // it -- the coverage rule this replaced could drop a leftover on either setting.
+      const off = new EntryRetrievalService({
+        enableLLMSelection: false,
+        tier3WholesaleWordBudget: BUDGET,
+      })
+
+      const result = await off.getRelevantEntries(uncovered(2, 40), '', [])
+
+      expect(result.tier3).toHaveLength(2)
+    })
+
+    it('does not activate a wholesale leftover, because cheap is not relevant', async () => {
+      // Stickiness carries an entry forward *because something noticed it*. Wholesale
+      // inclusion notices nothing -- it means the leftover was small. Recording it made
+      // every uncovered entry sticky every turn on any story under the budget, which
+      // promotes the whole lorebook into Tier 1 and empties the word "always" of meaning.
+      const service = new EntryRetrievalService({
+        enableLLMSelection: true,
+        tier3WholesaleWordBudget: BUDGET,
+      })
+      const tracker = new SimpleActivationTracker(10)
+      const record = vi.spyOn(tracker, 'recordActivation')
+
+      const result = await service.getRelevantEntries(uncovered(2, 40), '', [], {
+        activationTracker: tracker,
+      })
+
+      expect(result.tier3).toHaveLength(2)
+      expect(record).not.toHaveBeenCalled()
+    })
+
+    it('does activate a leftover the model actually chose', async () => {
+      // The other half of the same rule: a Tier 3 pick is as much a relevance signal as a
+      // Tier 2 keyword match, and used to be strictly less durable than one.
+      const service = new EntryRetrievalService({
+        enableLLMSelection: true,
+        tier3WholesaleWordBudget: BUDGET,
+      })
+      const entries = uncovered(3, 300)
+      vi.spyOn(
+        service as unknown as {
+          getLLMSelectedEntries: () => Promise<{ entry: Entry; tier: number; priority: number }[]>
+        },
+        'getLLMSelectedEntries',
+      ).mockResolvedValue([{ entry: entries[1], tier: 3, priority: 60 }])
+
+      const tracker = new SimpleActivationTracker(10)
+      const record = vi.spyOn(tracker, 'recordActivation')
+
+      await service.getRelevantEntries(entries, '', [], { activationTracker: tracker })
+
+      expect(record).toHaveBeenCalledWith(entries[1].id, 10)
     })
   })
 })

--- a/src/lib/services/ai/retrieval/EntryRetrievalService.ts
+++ b/src/lib/services/ai/retrieval/EntryRetrievalService.ts
@@ -6,12 +6,10 @@ import { settings, type ServiceId } from '$lib/stores/settings.svelte'
  * Implements three tiers of entry injection for lorebook entries:
  * - Tier 1: Always inject (injection.mode === 'always', or state-based like isPresent)
  * - Tier 2: Keyword matching (match name/aliases/keywords against user input & recent story)
- * - Tier 3: LLM selection (see `getLLMSelectedEntries`, shared with `WorldStateInjector`
- *   via `./tier3Selection.ts`) -- on a different trigger, for a reason: here it runs
- *   whenever any candidate is uncovered, because a lorebook entry is long-form authored
- *   prose and including uncovered ones wholesale is not an option. The injector's
- *   candidates are one-line entity records, so below `llmThreshold` it includes them
- *   instead of asking. Neither drops a small leftover on the floor.
+ * - Tier 3: LLM selection (shared with `WorldStateInjector` via `./tier3Selection.ts`),
+ *   on a different trigger: "how much leftover is too much to just include" is a question
+ *   about words here and about record count in the injector, whose candidates are one
+ *   line each. Neither drops a leftover on the floor.
  *
  * Selects from authored Lorebook `Entry[]` records only. The live-tracked
  * `Character`/`Location`/`Item`/`StoryBeat` state is `WorldStateInjector`'s job and is
@@ -30,7 +28,8 @@ import { entityNameMatches } from '$lib/utils/text'
 import type { Entry, EntryType, StoryEntry } from '$lib/types'
 import { BaseAIService } from '../BaseAIService'
 import { createLogger } from '$lib/log'
-import { runTier3Selection, resolveTier3Selection } from './tier3Selection'
+import { runTier3Selection, resolveTier3Selection, countWholesaleWords } from './tier3Selection'
+import { secondPassHaystack } from './tier2SecondPass'
 import { resolveStickiness } from './stickiness'
 import { ENTRY_RETRIEVAL_DEFAULTS } from '../core/defaults'
 import { recentContent, AS_HAYSTACK } from '$lib/utils/recentContent'
@@ -50,13 +49,16 @@ const log = createLogger('EntryRetrieval')
  * duration is a hard ceiling on continuous presence, not a sliding one.
  */
 export const STICKINESS_BY_TYPE: Record<EntryType, number> = {
-  concept: 5, // Magic systems, world rules - foundational context
-  faction: 4, // Faction dynamics persist during dealings
-  character: 3, // Recently mentioned NPCs stay in context
-  location: 3, // Nearby/mentioned locations
-  event: 2, // Historical references fade quickly
-  item: 2, // Items are situational
+  concept: 10, // Magic systems, world rules - foundational context
+  faction: 8, // Faction dynamics persist during dealings
+  character: 6, // Recently mentioned NPCs stay in context
+  location: 6, // Nearby/mentioned locations
+  event: 4, // Historical references fade quickly
+  item: 6, // Items are situational, but a carried one stays relevant
 }
+
+/** The longest window any type can have, on either map. Bounds activation pruning. */
+export const MAX_STICKINESS_POSITIONS = 10
 
 /**
  * Section headings for the lorebook context block, in the order they are emitted.
@@ -90,12 +92,49 @@ export interface EntryRetrievalConfig {
   maxTier2Entries: number
   /** Maximum entries to include from Tier 3 (LLM selected) */
   maxTier3Entries: number
+  /** Words of leftover that still go in whole, above which the LLM is asked instead */
+  tier3WholesaleWordBudget: number
   /** Maximum words per lorebook entry (0 = unlimited) */
   maxWordsPerEntry: number
   /** Enable LLM selection for Tier 3 */
   enableLLMSelection: boolean
   /** Number of recent story entries to check for keyword matching */
   recentEntriesCount: number
+  /**
+   * Whether the world state's Tier 1 + Tier 2 seed the second Tier 2 pass here.
+   *
+   * On, lore about something the world state says is in the scene comes in even when
+   * nobody named it. Off, Tier 2 sees only what the player wrote and the recent story.
+   *
+   * Worth a switch because the seed set is not small: the world state's Tier 1 is every
+   * active character, every inventory item, every active quest and the current location,
+   * and on a mature story that is most of the lorebook's subject matter — so a dense
+   * lorebook can spend its whole Tier 2 cap on entries nobody mentioned.
+   */
+  useSceneEntities: boolean
+}
+
+/** Tier 2 priority floors. The author's own `injection.priority` is added on top. */
+const TIER2_PRIORITY_BASE = 70
+const SECOND_PASS_PRIORITY_BASE = 60
+
+/** One entity already in the scene, as the world state names it. */
+export interface SceneEntity {
+  type: string
+  name: string
+}
+
+export interface EntryRetrievalOptions {
+  activationTracker?: ActivationTracker
+  signal?: AbortSignal
+  /** The entry `userInput` came from, so Tier 3 does not see the action twice. */
+  userActionEntryId?: string
+  /**
+   * What the world state put in the scene this turn (its Tier 1 and Tier 2). Widens the
+   * Tier 2 haystack, so lore about something present is found even when the player did not
+   * name it. Never travels the other way: see the haystack comment in `getRelevantEntries`.
+   */
+  sceneEntities?: SceneEntity[]
 }
 
 export const DEFAULT_ENTRY_RETRIEVAL_CONFIG: EntryRetrievalConfig = {
@@ -104,9 +143,11 @@ export const DEFAULT_ENTRY_RETRIEVAL_CONFIG: EntryRetrievalConfig = {
   // Matching counts would put roughly ten times as much text in the prompt on this side.
   maxTier2Entries: ENTRY_RETRIEVAL_DEFAULTS.maxTier2Entries,
   maxTier3Entries: ENTRY_RETRIEVAL_DEFAULTS.maxTier3Entries,
+  tier3WholesaleWordBudget: ENTRY_RETRIEVAL_DEFAULTS.tier3WholesaleWordBudget,
   maxWordsPerEntry: 0,
   enableLLMSelection: true,
   recentEntriesCount: 5,
+  useSceneEntities: true,
 }
 
 /**
@@ -121,9 +162,12 @@ export function getEntryRetrievalConfigFromSettings(): EntryRetrievalConfig {
     // Not clamped here: the constructor clamps whatever it is handed, so doing it twice
     // meant two copies of the same bounds that had to agree. Passed through as stored --
     // including a non-number from an old settings blob, which `clampMaxWords` handles.
+    tier3WholesaleWordBudget:
+      entrySettings.tier3WholesaleWordBudget ?? ENTRY_RETRIEVAL_DEFAULTS.tier3WholesaleWordBudget,
     maxWordsPerEntry: entrySettings.maxWordsPerEntry,
     enableLLMSelection: entrySettings.enableLLMSelection ?? true,
     recentEntriesCount: entrySettings.recentEntriesCount ?? 5,
+    useSceneEntities: entrySettings.useSceneEntities ?? true,
   }
 }
 
@@ -143,6 +187,14 @@ export interface RetrievedEntry {
   tier: 1 | 2 | 3
   priority: number
   matchReason?: string
+  /** Story positions of carry-over left, when Tier 1 carried this over. Two per turn. */
+  stickyPositionsLeft?: number
+  /** The full window for this entry's type, so the panel can show progress, not just a count. */
+  stickyPositionsTotal?: number
+  /** Tier 3 only: the model picked this, rather than it fitting under the budget. */
+  llmSelected?: boolean
+  /** Tier 2 only: matched on the second pass, through something the first pass found. */
+  viaScene?: boolean
 }
 
 export interface EntryRetrievalResult {
@@ -183,9 +235,9 @@ export class EntryRetrievalService extends BaseAIService {
     entries: Entry[],
     userInput: string,
     recentStoryEntries: StoryEntry[],
-    activationTracker?: ActivationTracker,
-    signal?: AbortSignal,
+    options: EntryRetrievalOptions = {},
   ): Promise<EntryRetrievalResult> {
+    const { activationTracker, signal, userActionEntryId, sceneEntities } = options
     const currentPosition = activationTracker?.currentPosition ?? recentStoryEntries.length
 
     log('getRelevantEntries called', {
@@ -195,9 +247,20 @@ export class EntryRetrievalService extends BaseAIService {
       currentPosition,
     })
 
-    // Build search content from user input and recent story
-    const searchContent =
-      `${userInput} ${recentContent(recentStoryEntries, this.config.recentEntriesCount, AS_HAYSTACK)}`.toLowerCase()
+    // The haystack the *first* Tier 2 pass matches against: what the scene actually says.
+    //
+    // The world state's scene entities are deliberately not in here. They are a second-pass
+    // seed instead (see `getTier2Entries`): a lore entry that matched only because a
+    // character happens to be standing in the room was not named by anyone, and folding it
+    // into this haystack made it indistinguishable from one the player just typed — same
+    // priority, same `matched: <name>` reason, and `viaScene` false, so the debug panel's
+    // whole point of separating relevance-at-one-remove missed the largest source of it.
+    const searchContent = [
+      userInput,
+      recentContent(recentStoryEntries, this.config.recentEntriesCount, AS_HAYSTACK),
+    ]
+      .join(' ')
+      .toLowerCase()
 
     // Tier 1: Always-inject + sticky entries
     const tier1 = this.getTier1Entries(entries, activationTracker, currentPosition)
@@ -215,8 +278,8 @@ export class EntryRetrievalService extends BaseAIService {
       (e) => !tier1Ids.has(e.id) && e.injection.mode !== 'never',
     )
 
-    // Tier 2: Keyword matching - check name, aliases, keywords against search content
-    const tier2 = this.getTier2Entries(candidateEntries, searchContent)
+    // Tier 2: keyword matching, in two passes. See `getTier2Entries`.
+    const tier2 = this.getTier2Entries(candidateEntries, searchContent, sceneEntities)
     log(
       'Tier 2 entries (keyword matched):',
       tier2.length,
@@ -230,51 +293,71 @@ export class EntryRetrievalService extends BaseAIService {
     const remainingEntries = candidateEntries.filter((e) => !tier1And2Ids.has(e.id))
     log('Remaining entries for Tier 3 LLM:', remainingEntries.length)
 
-    // Tier 3: LLM selection, whenever anything at all is left uncovered.
-    //
-    // No threshold, unlike WorldStateInjector, and the asymmetry is about what the
-    // candidates *are*: these are lorebook entries, paragraphs of authored prose, so
-    // "include the leftovers wholesale" -- the injector's cheap path below its threshold --
-    // would put the entire unmatched lorebook in the prompt. Selection is the only way to
-    // use them, so it runs whenever there is anything to select from. On any story with
-    // more lorebook entries than tiers 1-2 matched, that is one LLM call per turn.
+    // Tier 3, volume question first: a leftover cheap enough to send whole is sent whole,
+    // and only what is too expensive is worth an LLM call. The boundary is a word budget
+    // because a lorebook entry is a paragraph — see `tier3WholesaleWordBudget`.
     let tier3: RetrievedEntry[] = []
 
-    if (this.config.enableLLMSelection && remainingEntries.length > 0) {
+    /** Whether Tier 3 got there by being cheap rather than by being chosen. */
+    let tier3IsWholesale = false
+
+    const wholesaleWords = countWholesaleWords(remainingEntries, this.config.maxWordsPerEntry)
+    const fitsWholesale = wholesaleWords <= this.config.tier3WholesaleWordBudget
+
+    if (remainingEntries.length === 0) {
+      // Nothing uncovered.
+    } else if (fitsWholesale) {
+      tier3IsWholesale = true
+      tier3 = remainingEntries.map((entry) => ({
+        entry,
+        tier: 3,
+        priority: 50 + entry.injection.priority,
+        matchReason: 'Included wholesale (under word budget)',
+        llmSelected: false,
+      }))
+      log('Tier 3 included wholesale', {
+        entries: tier3.length,
+        words: wholesaleWords,
+        budget: this.config.tier3WholesaleWordBudget,
+      })
+    } else if (this.config.enableLLMSelection) {
       log('Tier 3 LLM selection triggered', {
         remainingEntries: remainingEntries.length,
+        words: wholesaleWords,
       })
       tier3 = await this.getLLMSelectedEntries(
         remainingEntries,
         userInput,
         recentStoryEntries,
+        currentPosition,
         signal,
+        userActionEntryId,
       )
       log(
         'Tier 3 entries:',
         tier3.length,
         tier3.map((e) => e.entry.name),
       )
+    } else {
+      // Too much to include, and selection is switched off: there is no third option.
+      log('Tier 3 dropped -- over word budget with LLM selection off', {
+        remaining: remainingEntries.length,
+        words: wholesaleWords,
+      })
     }
 
     // Record activations for stickiness tracking.
     //
-    // Tier 3 counts as much as Tier 2: both mean "this entry is relevant right now", and
-    // the whole point of stickiness is that relevance does not end with the turn that
-    // noticed it. Recording only Tier 2 made an entry the LLM picked *less* durable than
-    // one matched by name -- it dropped out of the prompt the next turn, while the cheaper
-    // signal survived several. Sticky entries are excluded from the candidate pool, so
-    // this also stops the same entry being re-selected (and re-paid for) every turn.
+    // A *selected* Tier 3 counts as much as Tier 2: both mean "relevant right now", and
+    // stickiness exists so that relevance outlives the turn that noticed it. A *wholesale*
+    // Tier 3 does not — it means the leftover was small, which says nothing about
+    // relevance, and recording it would make the whole uncovered lorebook sticky.
+    const activated = tier3IsWholesale ? tier2 : [...tier2, ...tier3]
     if (activationTracker) {
-      for (const retrieved of [...tier2, ...tier3]) {
+      for (const retrieved of activated) {
         activationTracker.recordActivation(retrieved.entry.id, currentPosition)
       }
-      log(
-        'Recorded activations for',
-        tier2.length + tier3.length,
-        'entries at position',
-        currentPosition,
-      )
+      log('Recorded activations for', activated.length, 'entries at position', currentPosition)
     }
 
     // Combine and sort by priority. The context block is built from this same ordered
@@ -293,7 +376,62 @@ export class EntryRetrievalService extends BaseAIService {
    * Tier 2: Keyword matching.
    * Match entry name, aliases, and keywords against user input and recent story content.
    */
-  private getTier2Entries(entries: Entry[], searchContent: string): RetrievedEntry[] {
+  /**
+   * Tier 2, in two passes.
+   *
+   * The first matches against what the scene *says* — the player's action and the recent
+   * story. The second matches whatever is left against *names*: those the first pass found,
+   * plus what the world state put in the scene when `useSceneEntities` is on. Both are the
+   * same kind of signal — an entry nobody named directly, arriving because something that
+   * names it did: the clan entry behind a character who just walked in.
+   *
+   * Second-pass hits rank below first-pass ones (`SECOND_PASS_PRIORITY_BASE`): they are
+   * relevance at one remove, so they are what a cap should drop first.
+   */
+  private getTier2Entries(
+    entries: Entry[],
+    searchContent: string,
+    sceneEntities?: SceneEntity[],
+  ): RetrievedEntry[] {
+    const firstPass = this.matchEntries(entries, searchContent, TIER2_PRIORITY_BASE)
+
+    const matchedIds = new Set(firstPass.map((r) => r.entry.id))
+    const seeds = secondPassHaystack([
+      ...firstPass.flatMap((r) => [r.entry.name, ...(r.entry.aliases ?? [])]),
+      // One-way on purpose: lore names never travel back into "who is present", where
+      // they would read as entities the narrator can act on.
+      ...(this.config.useSceneEntities ? (sceneEntities?.map((e) => e.name) ?? []) : []),
+    ])
+    const secondPass = seeds
+      ? this.matchEntries(
+          entries.filter((e) => !matchedIds.has(e.id)),
+          seeds,
+          SECOND_PASS_PRIORITY_BASE,
+        )
+      : []
+
+    if (secondPass.length > 0) {
+      log(
+        'Tier 2 second pass matched',
+        secondPass.length,
+        secondPass.map((r) => r.entry.name),
+      )
+    }
+
+    // Ranked before capping, by the priority the *author* gave the entry. Unlike the
+    // Tier 3 pool there is a real signal here, so the cap drops what was marked least
+    // important rather than whatever the lorebook happened to list last.
+    return [...firstPass, ...secondPass]
+      .sort((a, b) => b.priority - a.priority)
+      .slice(0, this.config.maxTier2Entries)
+  }
+
+  /** One matching pass. `priorityBase` is what separates a first-pass hit from a second. */
+  private matchEntries(
+    entries: Entry[],
+    searchContent: string,
+    priorityBase: number,
+  ): RetrievedEntry[] {
     const result: RetrievedEntry[] = []
 
     for (const entry of entries) {
@@ -323,19 +461,18 @@ export class EntryRetrievalService extends BaseAIService {
       }
 
       if (matchedKeywords.length > 0) {
+        const viaScene = priorityBase === SECOND_PASS_PRIORITY_BASE
         result.push({
           entry,
           tier: 2,
-          priority: 70 + entry.injection.priority,
+          priority: priorityBase + entry.injection.priority,
           matchReason: `matched: ${[...new Set(matchedKeywords)].join(', ')}`,
+          viaScene,
         })
       }
     }
 
-    // Ranked before capping, by the priority the *author* gave the entry. Unlike the
-    // Tier 3 pool there is a real signal here, so the cap drops what was marked least
-    // important rather than whatever the lorebook happened to list last.
-    return result.sort((a, b) => b.priority - a.priority).slice(0, this.config.maxTier2Entries)
+    return result
   }
 
   /**
@@ -358,6 +495,8 @@ export class EntryRetrievalService extends BaseAIService {
       let shouldInclude = false
       let priority = 0
       let reason = ''
+      let stickyPositionsLeft: number | undefined
+      let stickyPositionsTotal: number | undefined
 
       // Check injection mode
       if (entry.injection.mode === 'always') {
@@ -414,7 +553,9 @@ export class EntryRetrievalService extends BaseAIService {
         if (sticky) {
           shouldInclude = true
           priority = Math.max(priority, sticky.priority)
-          reason = `sticky (${entry.type}, ${sticky.turnsLeft} turns left)`
+          reason = `sticky (${entry.type}, ${sticky.positionsLeft} positions left)`
+          stickyPositionsLeft = sticky.positionsLeft
+          stickyPositionsTotal = STICKINESS_BY_TYPE[entry.type]
         }
       }
 
@@ -424,6 +565,8 @@ export class EntryRetrievalService extends BaseAIService {
           tier: 1,
           priority,
           matchReason: reason,
+          stickyPositionsLeft,
+          stickyPositionsTotal,
         })
       }
     }
@@ -439,7 +582,9 @@ export class EntryRetrievalService extends BaseAIService {
     availableEntries: Entry[],
     userInput: string,
     recentStoryEntries: StoryEntry[],
+    currentPosition: number,
     signal?: AbortSignal,
+    userActionEntryId?: string,
   ): Promise<RetrievedEntry[]> {
     if (availableEntries.length === 0) {
       return []
@@ -459,6 +604,8 @@ export class EntryRetrievalService extends BaseAIService {
       recentEntriesCount: this.config.recentEntriesCount,
       presetId: this.presetId,
       serviceLabel: 'tier3-lorebook-selection',
+      userActionEntryId,
+      currentPosition,
       signal,
     })
     if (!result) {
@@ -471,6 +618,7 @@ export class EntryRetrievalService extends BaseAIService {
         tier: 3,
         priority: 50 + entry.injection.priority,
         matchReason: 'LLM selected',
+        llmSelected: true,
       }),
     )
 
@@ -582,7 +730,7 @@ export class SimpleActivationTracker implements ActivationTracker {
   }
 
   /** Clear old activations that are beyond any stickiness window */
-  pruneOldActivations(maxStickiness: number = 10): void {
+  pruneOldActivations(maxStickiness: number = MAX_STICKINESS_POSITIONS): void {
     for (const [entryId, position] of this.activations) {
       if (this.currentPosition - position > maxStickiness) {
         this.activations.delete(entryId)

--- a/src/lib/services/ai/retrieval/index.ts
+++ b/src/lib/services/ai/retrieval/index.ts
@@ -18,7 +18,25 @@ export {
   type ActivationTracker,
   type RetrievedEntry,
   type EntryRetrievalConfig,
+  type EntryRetrievalOptions,
+  type SceneEntity,
 } from './EntryRetrievalService'
+
+// What retrieval put in the prompt for a turn, for the debug panel.
+export {
+  toRetrievalSnapshot,
+  snapshotSize,
+  positionsToTurns,
+  splitTier1,
+  splitTier2,
+  splitTier3,
+  type RetrievalSnapshot,
+  type RetrievalSnapshotEntry,
+  type RetrievalSnapshotTokens,
+} from './retrievalSnapshot'
+
+// Tier 3 selection cache, cleared when the story it was about is no longer loaded.
+export { clearTier3SelectionCache } from './tier3Selection'
 
 // Agentic Retrieval
 export {

--- a/src/lib/services/ai/retrieval/retrievalSnapshot.test.ts
+++ b/src/lib/services/ai/retrieval/retrievalSnapshot.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest'
+import {
+  toRetrievalSnapshot,
+  snapshotSize,
+  positionsToTurns,
+  splitTier1,
+  splitTier2,
+  splitTier3,
+} from './retrievalSnapshot'
+
+const lorebook = {
+  all: [
+    {
+      tier: 1,
+      matchReason: 'always inject',
+      entry: { id: 'l1', type: 'concept', name: 'Thal’kinesh', injection: { mode: 'always' } },
+    },
+    {
+      tier: 1,
+      matchReason: 'sticky (character, 2 turns left)',
+      stickyPositionsLeft: 2,
+      stickyPositionsTotal: 6,
+      entry: { id: 'l2', type: 'character', name: 'Rhiza', injection: { mode: 'keyword' } },
+    },
+    {
+      tier: 2,
+      matchReason: 'matched: Borin',
+      entry: { id: 'l3', type: 'character', name: 'Borin', injection: { mode: 'keyword' } },
+    },
+    {
+      tier: 2,
+      matchReason: 'matched: Borin',
+      viaScene: true,
+      entry: {
+        id: 'l4',
+        type: 'faction',
+        name: 'House of Stone',
+        injection: { mode: 'keyword' },
+      },
+    },
+  ],
+  contextBlock: 'lorebook block',
+}
+
+const worldState = {
+  all: [
+    { id: 'w1', tier: 1, type: 'character', name: 'Morvana' },
+    { id: 'w2', tier: 3, type: 'item', name: 'Silent Bell' },
+  ],
+  contextBlock: 'world state block',
+}
+
+describe('toRetrievalSnapshot', () => {
+  it('keeps tier, type, name and the match reason', () => {
+    const snapshot = toRetrievalSnapshot(lorebook, worldState)!
+
+    expect(snapshot.lorebook[0]).toEqual({
+      id: 'l1',
+      tier: 1,
+      type: 'concept',
+      name: 'Thal’kinesh',
+      reason: 'always inject',
+      alwaysInject: true,
+      stickyPositionsLeft: undefined,
+    })
+    expect(snapshot.worldState[1]).toEqual({
+      id: 'w2',
+      tier: 3,
+      type: 'item',
+      name: 'Silent Bell',
+      stickyPositionsLeft: undefined,
+    })
+  })
+
+  it('takes either half on its own', () => {
+    expect(toRetrievalSnapshot(lorebook, null)?.worldState).toEqual([])
+    expect(toRetrievalSnapshot(null, worldState)?.lorebook).toEqual([])
+  })
+
+  it('returns null when nothing was retrieved, rather than an empty snapshot', () => {
+    // An empty one would overwrite the previous turn's on the way to disk.
+    expect(toRetrievalSnapshot(null, null)).toBeNull()
+    expect(toRetrievalSnapshot({ all: [] }, { all: [] })).toBeNull()
+  })
+})
+
+describe('snapshotSize', () => {
+  it('counts both sections', () => {
+    expect(snapshotSize(toRetrievalSnapshot(lorebook, worldState))).toBe(6)
+    expect(snapshotSize(null)).toBe(0)
+  })
+})
+
+describe('splitTier1', () => {
+  it('separates what the author pinned from what a turn carried over', () => {
+    const snapshot = toRetrievalSnapshot(lorebook, null)!
+    const { always, carried, pinnedByState } = splitTier1(snapshot.lorebook)
+
+    expect(always.map((e) => e.name)).toEqual(['Thal’kinesh'])
+    expect(carried.map((e) => e.name)).toEqual(['Rhiza'])
+    expect(carried[0].stickyPositionsLeft).toBe(2)
+    expect(carried[0].stickyPositionsTotal).toBe(6)
+    expect(pinnedByState).toEqual([])
+  })
+
+  it('puts state-pinned world state in its own group: it is neither', () => {
+    // "You are here", "she is present", "you are carrying it" — no author, no countdown.
+    const snapshot = toRetrievalSnapshot(null, worldState)!
+    const { always, carried, pinnedByState } = splitTier1(snapshot.worldState)
+
+    expect(always).toEqual([])
+    expect(carried).toEqual([])
+    expect(pinnedByState.map((e) => e.name)).toEqual(['Morvana'])
+  })
+
+  it('ignores everything outside Tier 1', () => {
+    const snapshot = toRetrievalSnapshot(lorebook, null)!
+    const groups = splitTier1(snapshot.lorebook)
+
+    expect([...groups.always, ...groups.carried, ...groups.pinnedByState]).toHaveLength(2)
+  })
+})
+
+describe('splitTier3', () => {
+  it('separates what fitted the budget from what the model picked', () => {
+    const { selected, wholesale } = splitTier3([
+      { id: 'a', tier: 3, type: 'concept', name: 'Sent whole', llmSelected: false },
+      { id: 'b', tier: 3, type: 'concept', name: 'Chosen', llmSelected: true },
+    ])
+
+    expect(wholesale.map((e) => e.name)).toEqual(['Sent whole'])
+    expect(selected.map((e) => e.name)).toEqual(['Chosen'])
+  })
+
+  it('reads a row with no flag as wholesale, not as a call nobody made', () => {
+    // Unreachable from the four producers, which all set the flag. It decides how a row
+    // from some later source reads, and the errors are not symmetric: "LLM Selected"
+    // asserts a call was paid for, "Included Whole" only that the leftover fitted.
+    const { selected, wholesale } = splitTier3([
+      { id: 'a', tier: 3, type: 'concept', name: 'Unflagged' },
+    ])
+
+    expect(wholesale.map((e) => e.name)).toEqual(['Unflagged'])
+    expect(selected).toEqual([])
+  })
+})
+
+describe('splitTier2', () => {
+  it('separates a direct match from one found through the scene', () => {
+    const { direct, viaScene } = splitTier2(toRetrievalSnapshot(lorebook, null)!.lorebook)
+
+    expect(direct.map((e) => e.name)).toEqual(['Borin'])
+    expect(viaScene.map((e) => e.name)).toEqual(['House of Stone'])
+  })
+})
+
+describe('token counts', () => {
+  it('prices each block with the counter it is given', () => {
+    const snapshot = toRetrievalSnapshot(lorebook, worldState, (t) => t.length)!
+
+    expect(snapshot.tokens).toEqual({
+      lorebook: 'lorebook block'.length,
+      worldState: 'world state block'.length,
+    })
+  })
+
+  it('is zero when a side produced no block', () => {
+    expect(toRetrievalSnapshot(lorebook, null, (t) => t.length)!.tokens?.worldState).toBe(0)
+  })
+
+  it('counts nothing when no counter is given, so callers can opt out', () => {
+    expect(toRetrievalSnapshot(lorebook, worldState)!.tokens).toEqual({
+      lorebook: 0,
+      worldState: 0,
+    })
+  })
+})
+
+describe('positionsToTurns', () => {
+  it('halves and rounds up: a turn is a user action plus a narration', () => {
+    expect(positionsToTurns(6)).toBe(3)
+    expect(positionsToTurns(3)).toBe(2)
+    expect(positionsToTurns(1)).toBe(1)
+    expect(positionsToTurns(0)).toBe(0)
+  })
+})

--- a/src/lib/services/ai/retrieval/retrievalSnapshot.ts
+++ b/src/lib/services/ai/retrieval/retrievalSnapshot.ts
@@ -1,0 +1,198 @@
+/**
+ * What retrieval put in the prompt for one turn, in the shape the debug panel reads.
+ *
+ * Stored on the narration entry's metadata rather than kept in memory: the in-memory copy
+ * belongs to the run that produced it, so the panel was empty on every fresh start and
+ * after every story switch — exactly when you most want to know what the narrator is
+ * being told.
+ *
+ * Names and tiers only. This is a diagnostic, not a cache: nothing reads it back into a
+ * prompt, and it has to stay small enough to sit on every narration row.
+ */
+
+export interface RetrievalSnapshotEntry {
+  /** The record's own id, so the panel can act on it — change a mode, open an editor. */
+  id: string
+  tier: number
+  type: string
+  name: string
+  /** Why it came in — the match reason, where the source has one. */
+  reason?: string
+  /** Tier 1 only: pinned by the author rather than carried over from a recent turn. */
+  alwaysInject?: boolean
+  /** Tier 1 only: story positions of carry-over left. Two per turn. */
+  stickyPositionsLeft?: number
+  /** Tier 1 only: the full window for this type, so the panel can show progress. */
+  stickyPositionsTotal?: number
+  /** Tier 3 only: the model picked this, rather than it fitting under the budget. */
+  llmSelected?: boolean
+  /** Tier 2 only: matched on the second pass, through something the first pass found. */
+  viaScene?: boolean
+}
+
+/** Tokens the two blocks cost in the prompt, counted once when they were built. */
+export interface RetrievalSnapshotTokens {
+  lorebook: number
+  worldState: number
+}
+
+export interface RetrievalSnapshot {
+  lorebook: RetrievalSnapshotEntry[]
+  worldState: RetrievalSnapshotEntry[]
+  tokens?: RetrievalSnapshotTokens
+}
+
+/** The two source shapes, reduced to what they have in common. */
+interface TieredLorebook {
+  all: {
+    tier: number
+    matchReason?: string
+    stickyPositionsLeft?: number
+    stickyPositionsTotal?: number
+    llmSelected?: boolean
+    viaScene?: boolean
+    entry: { id: string; type: string; name: string; injection: { mode: string } }
+  }[]
+  contextBlock?: string
+}
+interface TieredWorldState {
+  all: {
+    id: string
+    tier: number
+    type: string
+    name: string
+    stickyPositionsLeft?: number
+    stickyPositionsTotal?: number
+    llmSelected?: boolean
+    viaScene?: boolean
+  }[]
+  contextBlock?: string
+}
+
+/**
+ * Build the snapshot, and price the two blocks while their text is still in hand.
+ *
+ * Counted here rather than when the panel opens because the blocks themselves are not
+ * stored — they are several KB each and would sit on every narration row — so on a fresh
+ * start there would be nothing left to count. Two `countTokens` calls per turn, on strings
+ * already about to be sent to a model, after the generation they belong to.
+ */
+export function toRetrievalSnapshot(
+  lorebook: TieredLorebook | null | undefined,
+  worldState: TieredWorldState | null | undefined,
+  countTokens: (text: string) => number = () => 0,
+): RetrievalSnapshot | null {
+  const snapshot: RetrievalSnapshot = {
+    lorebook: (lorebook?.all ?? []).map((r) => ({
+      id: r.entry.id,
+      tier: r.tier,
+      type: r.entry.type,
+      name: r.entry.name,
+      reason: r.matchReason,
+      alwaysInject: r.entry.injection.mode === 'always',
+      stickyPositionsLeft: r.stickyPositionsLeft,
+      stickyPositionsTotal: r.stickyPositionsTotal,
+      llmSelected: r.llmSelected,
+      viaScene: r.viaScene,
+    })),
+    worldState: (worldState?.all ?? []).map((e) => ({
+      id: e.id,
+      tier: e.tier,
+      type: e.type,
+      name: e.name,
+      // World state Tier 1 is pinned by live state (present, carried, active), not authored.
+      stickyPositionsLeft: e.stickyPositionsLeft,
+      stickyPositionsTotal: e.stickyPositionsTotal,
+      llmSelected: e.llmSelected,
+      viaScene: e.viaScene,
+    })),
+    tokens: {
+      lorebook: lorebook?.contextBlock ? countTokens(lorebook.contextBlock) : 0,
+      worldState: worldState?.contextBlock ? countTokens(worldState.contextBlock) : 0,
+    },
+  }
+
+  // Nothing retrieved is not worth a row on disk, and an empty snapshot would overwrite a
+  // useful one from the previous turn.
+  if (snapshot.lorebook.length === 0 && snapshot.worldState.length === 0) return null
+  return snapshot
+}
+
+/**
+ * Story positions as turns, rounded up.
+ *
+ * A turn appends a user action and a narration, so every duration in this system is two
+ * positions long. The panel says "turns" because that is what the player counts; the
+ * services stay in positions because that is what they measure.
+ */
+export function positionsToTurns(positions: number): number {
+  return Math.ceil(positions / 2)
+}
+
+/** Total entries in a snapshot, for the header badge. */
+export function snapshotSize(snapshot: RetrievalSnapshot | null | undefined): number {
+  if (!snapshot) return 0
+  return snapshot.lorebook.length + snapshot.worldState.length
+}
+
+/**
+ * Split Tier 2 by which pass found it.
+ *
+ * A second-pass hit is relevance at one remove — it came in because something *else* the
+ * scene named refers to it. Worth seeing apart, since it is the one that can widen the
+ * prompt without anyone having mentioned the entry.
+ */
+export function splitTier2(entries: RetrievalSnapshotEntry[]): {
+  direct: RetrievalSnapshotEntry[]
+  viaScene: RetrievalSnapshotEntry[]
+} {
+  const tier2 = entries.filter((e) => e.tier === 2)
+  return {
+    direct: tier2.filter((e) => !e.viaScene),
+    viaScene: tier2.filter((e) => e.viaScene),
+  }
+}
+
+/**
+ * Split Tier 3 by how it got there.
+ *
+ * Both branches land in the same tier and behave nothing alike: one is "the leftover was
+ * small enough to send", which costs prompt and no call; the other is "the model was paid
+ * to choose", which is a relevance judgement. Labelling both "LLM Selected" says a call was
+ * made on turns where none was.
+ *
+ * A missing flag therefore reads as *wholesale*, not as selected. All four producers set it
+ * explicitly (the two budget branches in `EntryRetrievalService` and `WorldStateInjector`),
+ * so this only decides how a row from some later source reads — and the two errors are not
+ * symmetric. "LLM Selected" asserts a call was paid for; "Included Whole" asserts only that
+ * the leftover fitted the budget. An ambiguous row belongs in the weaker claim.
+ */
+export function splitTier3(entries: RetrievalSnapshotEntry[]): {
+  selected: RetrievalSnapshotEntry[]
+  wholesale: RetrievalSnapshotEntry[]
+} {
+  const tier3 = entries.filter((e) => e.tier === 3)
+  return {
+    selected: tier3.filter((e) => e.llmSelected === true),
+    wholesale: tier3.filter((e) => e.llmSelected !== true),
+  }
+}
+
+/**
+ * Split Tier 1 into what the author pinned and what a recent turn carried over.
+ *
+ * They read as one list and behave nothing alike: an always-inject entry is in every prompt
+ * until someone changes it, a carry-over leaves on its own within a few turns.
+ */
+export function splitTier1(entries: RetrievalSnapshotEntry[]): {
+  always: RetrievalSnapshotEntry[]
+  carried: RetrievalSnapshotEntry[]
+  pinnedByState: RetrievalSnapshotEntry[]
+} {
+  const tier1 = entries.filter((e) => e.tier === 1)
+  return {
+    always: tier1.filter((e) => e.alwaysInject),
+    carried: tier1.filter((e) => !e.alwaysInject && e.stickyPositionsLeft !== undefined),
+    pinnedByState: tier1.filter((e) => !e.alwaysInject && e.stickyPositionsLeft === undefined),
+  }
+}

--- a/src/lib/services/ai/retrieval/stickiness.test.ts
+++ b/src/lib/services/ai/retrieval/stickiness.test.ts
@@ -35,8 +35,8 @@ describe('resolveStickiness', () => {
   })
 
   it('reports how much of the window is left', () => {
-    expect(resolveStickiness(trackerAt(5), 'x', 5, 3)?.turnsLeft).toBe(3)
-    expect(resolveStickiness(trackerAt(5), 'x', 8, 3)?.turnsLeft).toBe(0)
+    expect(resolveStickiness(trackerAt(5), 'x', 5, 3)?.positionsLeft).toBe(3)
+    expect(resolveStickiness(trackerAt(5), 'x', 8, 3)?.positionsLeft).toBe(0)
   })
 
   it('keeps a longer duration alive longer, at the same freshness', () => {

--- a/src/lib/services/ai/retrieval/stickiness.ts
+++ b/src/lib/services/ai/retrieval/stickiness.ts
@@ -30,8 +30,8 @@ const MAX_PRIORITY = 80
 export interface Stickiness {
   /** Fading priority inside the shared band. */
   priority: number
-  /** Positions left before it drops out, for the human-readable reason string. */
-  turnsLeft: number
+  /** Story positions left before it drops out. Two per turn — see the module note. */
+  positionsLeft: number
 }
 
 /**
@@ -59,6 +59,6 @@ export function resolveStickiness(
 
   return {
     priority: Math.round(MIN_PRIORITY + fade * (MAX_PRIORITY - MIN_PRIORITY)),
-    turnsLeft: duration - elapsed,
+    positionsLeft: duration - elapsed,
   }
 }

--- a/src/lib/services/ai/retrieval/tier2SecondPass.test.ts
+++ b/src/lib/services/ai/retrieval/tier2SecondPass.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { secondPassHaystack } from './tier2SecondPass'
+
+describe('secondPassHaystack', () => {
+  it('joins the names the first pass matched', () => {
+    expect(secondPassHaystack(['Borin', 'Iron Mountain'])).toBe('iron mountain borin')
+  })
+
+  it('drops a name shorter than four characters', () => {
+    // Word-boundary matching makes "Zyl" hit every sentence that happens to contain it.
+    expect(secondPassHaystack(['Zyl', 'Morvana'])).toBe('morvana')
+  })
+
+  it('drops a seed another seed already contains', () => {
+    // "Iron" would match everything "Iron Mountain" matches, plus everything else with
+    // "iron" in it.
+    expect(secondPassHaystack(['Iron', 'Iron Mountain'])).toBe('iron mountain')
+  })
+
+  // Containment has to be word-bounded, because the matching it stands in for is. A
+  // word-boundary search for "ariadne" never finds "Aria", so dropping "Aria" as
+  // "already covered" loses it outright — plain substring containment did exactly that.
+  it('keeps a seed that is only a substring of another, not a word of it', () => {
+    expect(secondPassHaystack(['Aria', 'Ariadne'])).toBe('ariadne aria')
+  })
+
+  it('still drops a seed contained as a whole word', () => {
+    expect(secondPassHaystack(['Mountain', 'Iron Mountain'])).toBe('iron mountain')
+  })
+
+  it('survives a name with regex metacharacters', () => {
+    // Names are user text: an unescaped "(" would throw out of the filter.
+    expect(() => secondPassHaystack(['R.J. (the Fox)', 'R.J.'])).not.toThrow()
+  })
+
+  it('keeps names that merely share a word', () => {
+    const result = secondPassHaystack(['Iron Mountain', 'Iron Bell'])
+    expect(result).toContain('iron mountain')
+    expect(result).toContain('iron bell')
+  })
+
+  it('deduplicates, ignoring case and surrounding space', () => {
+    expect(secondPassHaystack(['Borin', ' borin ', 'BORIN'])).toBe('borin')
+  })
+
+  it('ignores empty and missing names', () => {
+    expect(secondPassHaystack([null, undefined, '', '   '])).toBe('')
+  })
+
+  it('returns an empty string when nothing survives, so the caller can skip the pass', () => {
+    expect(secondPassHaystack(['Zyl', 'Ren'])).toBe('')
+  })
+})

--- a/src/lib/services/ai/retrieval/tier2SecondPass.ts
+++ b/src/lib/services/ai/retrieval/tier2SecondPass.ts
@@ -1,0 +1,57 @@
+/**
+ * Seeds for the second Tier 2 pass.
+ *
+ * The first pass matches candidates against the player's action and the recent story. The
+ * second one matches what is left against the *names* of what the first pass found, so an
+ * entry nobody named directly still comes in when something that names it did.
+ *
+ * Names and aliases only, never descriptions: descriptions cross-reference each other by
+ * construction, so seeding with them pulls in half a dense lorebook in one step.
+ *
+ * Shared by `EntryRetrievalService` and `WorldStateInjector`, which run the same two passes
+ * over different candidate shapes.
+ */
+
+/** Below this a name is too generic to be a seed — it matches by accident, not by meaning. */
+const MIN_SEED_LENGTH = 4
+
+/** Escape a seed for use inside a RegExp — names can hold `.`, `(`, `-` and the rest. */
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * Whether `seed` appears in `longer` as a whole word or run of words.
+ *
+ * Word-bounded, not `includes`: matching downstream is word-bounded too, so `"Iron"` is
+ * genuinely covered by `"Iron Mountain"` and dropping it loses nothing, while `"Aria"` is
+ * *not* covered by `"Ariadne"` — a word-boundary search for the longer name will never find
+ * the shorter one. Plain containment dropped both alike and silently lost the second.
+ */
+function containsAsWords(longer: string, seed: string): boolean {
+  return new RegExp(`(?:^|\\s)${escapeRegExp(seed)}(?:\\s|$)`).test(longer)
+}
+
+/**
+ * The haystack for the second pass, or `''` when nothing survives the filters.
+ *
+ * Two filters, both against false positives. Matching is word-boundary based, so a short
+ * generic name matches wherever it appears as a word inside a longer one — "Iron" hits
+ * "Iron Mountain" every time. So a seed is dropped when it is shorter than
+ * `MIN_SEED_LENGTH`, and when another seed contains it *as a word*: there the longer name
+ * is the specific one and the shorter only widens the match to what the longer already
+ * covers. See `containsAsWords` for why plain containment is the wrong test.
+ */
+export function secondPassHaystack(names: (string | null | undefined)[]): string {
+  const seeds = [...new Set(names.map((n) => n?.trim().toLowerCase()).filter(Boolean) as string[])]
+    .filter((n) => n.length >= MIN_SEED_LENGTH)
+    .sort((a, b) => b.length - a.length)
+
+  const kept: string[] = []
+  for (const seed of seeds) {
+    if (kept.some((longer) => containsAsWords(longer, seed))) continue
+    kept.push(seed)
+  }
+
+  return kept.join(' ')
+}

--- a/src/lib/services/ai/retrieval/tier3Selection.test.ts
+++ b/src/lib/services/ai/retrieval/tier3Selection.test.ts
@@ -29,8 +29,11 @@ vi.mock('$lib/services/context', () => ({
 import {
   resolveTier3Selection,
   runTier3Selection,
+  countWholesaleWords,
+  clearTier3SelectionCache,
   type Tier3SelectionResult,
 } from './tier3Selection'
+import { TIER3_SELECTION_CACHE_POSITIONS } from '../core/defaults'
 
 /** A candidate list in the order the prompt was built from. */
 const candidates = [
@@ -40,49 +43,46 @@ const candidates = [
   { id: 'd-uuid', name: 'Dain' },
 ]
 
-const selection = (...ids: string[]): Tier3SelectionResult => ({ selectedIds: new Set(ids) })
+const selection = (...ids: string[]): Tier3SelectionResult => ({ selectedIndices: new Set(ids) })
 
 beforeEach(() => {
   generateStructured.mockReset()
   rendered.length = 0
+  clearTier3SelectionCache()
 })
 
 describe('resolveTier3Selection', () => {
-  it('matches by id', () => {
-    const selected = resolveTier3Selection(candidates, selection('b-uuid', 'd-uuid'))
-    expect(selected.map((c) => c.name)).toEqual(['Bramble', 'Dain'])
-  })
-
-  it('matches by numeric index, which some models return instead of ids', () => {
+  it('matches by index', () => {
     const selected = resolveTier3Selection(candidates, selection('0', '2'))
     expect(selected.map((c) => c.name)).toEqual(['Aria', 'Corin'])
   })
 
-  it('accepts a mix of ids and indices in one result', () => {
-    const selected = resolveTier3Selection(candidates, selection('a-uuid', '3'))
-    expect(selected.map((c) => c.name)).toEqual(['Aria', 'Dain'])
+  it('does not match by id, which never appears in the prompt', () => {
+    expect(resolveTier3Selection(candidates, selection('b-uuid'))).toEqual([])
   })
 
   it("returns them in the model's order, not in candidate order", () => {
-    // The contract both callers depend on: they cap the result, and candidate order is an
-    // artifact of prompt assembly -- for WorldStateInjector it is grouped by type, so a cap
-    // applied to it drops whole categories regardless of what the model thought mattered.
-    const selected = resolveTier3Selection(candidates, selection('d-uuid', 'a-uuid', 'c-uuid'))
+    // Both callers cap the result, so the order decides what survives the cap.
+    const selected = resolveTier3Selection(candidates, selection('3', '0', '2'))
     expect(selected.map((c) => c.name)).toEqual(['Dain', 'Aria', 'Corin'])
   })
 
-  it('ignores ids that match no candidate', () => {
-    const selected = resolveTier3Selection(candidates, selection('ghost', 'b-uuid'))
+  it('extracts the index out of whatever decoration the model wrapped it in', () => {
+    const selected = resolveTier3Selection(candidates, selection('#0', '[2]', ' 1 ', '3.'))
+    expect(selected.map((c) => c.name)).toEqual(['Aria', 'Corin', 'Bramble', 'Dain'])
+  })
+
+  it('drops an entry with no digits at all rather than guessing', () => {
+    const selected = resolveTier3Selection(candidates, selection('Aria', '1'))
     expect(selected.map((c) => c.name)).toEqual(['Bramble'])
   })
 
   it('ignores an index past the end of the list', () => {
-    // A model that counted wrong must not take a neighbour down with it.
     expect(resolveTier3Selection(candidates, selection('99'))).toEqual([])
   })
 
-  it('does not return a candidate twice when the model names it both ways', () => {
-    const selected = resolveTier3Selection(candidates, selection('a-uuid', '0'))
+  it('does not return a candidate twice when the model names it twice', () => {
+    const selected = resolveTier3Selection(candidates, selection('0', '#0'))
     expect(selected).toHaveLength(1)
     expect(selected[0].name).toBe('Aria')
   })
@@ -92,7 +92,30 @@ describe('resolveTier3Selection', () => {
   })
 
   it('returns nothing when there are no candidates', () => {
-    expect(resolveTier3Selection([], selection('0', 'a-uuid'))).toEqual([])
+    expect(resolveTier3Selection([], selection('0'))).toEqual([])
+  })
+})
+
+describe('countWholesaleWords', () => {
+  it('counts the words the context block would actually inject', () => {
+    expect(
+      countWholesaleWords([
+        { name: 'Aria', description: 'one two three' },
+        { name: 'The Iron Tower', description: 'four' },
+      ]),
+    ).toBe(1 + 3 + 3 + 1)
+  })
+
+  it('stops the description at maxWordsPerEntry, where the block truncates', () => {
+    expect(countWholesaleWords([{ name: 'X', description: 'a b c d e' }], 2)).toBe(3)
+  })
+
+  it('still charges for an entry that has a name and no description', () => {
+    expect(countWholesaleWords([{ name: 'Aria' }, { name: 'Borin', description: null }])).toBe(2)
+  })
+
+  it('treats a blank string as nothing to pay for', () => {
+    expect(countWholesaleWords([{ name: '   ', description: '   ' }, {}])).toBe(0)
   })
 })
 
@@ -112,22 +135,20 @@ describe('runTier3Selection', () => {
   it('returns an empty selection without calling the model when there are no candidates', async () => {
     const result = await runTier3Selection({ ...request, candidates: [] })
 
-    expect(result).toEqual({ selectedIds: new Set() })
+    expect(result).toEqual({ selectedIndices: new Set() })
     expect(generateStructured).not.toHaveBeenCalled()
   })
 
-  it('returns the ids the model selected, plus its reasoning', async () => {
-    generateStructured.mockResolvedValue({ selectedIds: ['b-uuid'], reasoning: 'She is there.' })
+  it('returns the indices the model selected, plus its reasoning', async () => {
+    generateStructured.mockResolvedValue({ selectedIndices: ['1'], reasoning: 'She is there.' })
 
     const result = await runTier3Selection(request)
 
-    expect(result).toEqual({ selectedIds: new Set(['b-uuid']), reasoning: 'She is there.' })
+    expect(result).toEqual({ selectedIndices: new Set(['1']), reasoning: 'She is there.' })
   })
 
-  it('numbers the candidates from zero, which is what the index fallback resolves against', () => {
-    // `resolveTier3Selection` reads a bare number as a position in this list, so the prompt
-    // has to be the thing that taught the model those positions.
-    generateStructured.mockResolvedValue({ selectedIds: [] })
+  it('numbers the candidates from zero, which is what the result resolves against', () => {
+    generateStructured.mockResolvedValue({ selectedIndices: [] })
 
     return runTier3Selection(request).then(() => {
       const summaries = rendered.find((v) => 'entrySummaries' in v)?.entrySummaries ?? ''
@@ -136,8 +157,39 @@ describe('runTier3Selection', () => {
     })
   })
 
+  it('drops the user action entry from the recent context, by id', async () => {
+    // Not by text: with translation on, the stored entry holds the translated wording
+    // while `userInput` holds it too — but the two are only guaranteed equal by identity.
+    generateStructured.mockResolvedValue({ selectedIndices: [] })
+
+    await runTier3Selection({
+      ...request,
+      recentEntries: [
+        { id: 'n1', type: 'narration', content: 'The tower loomed.' } as StoryEntry,
+        { id: 'a1', type: 'user_action', content: 'Sale la torre.' } as StoryEntry,
+      ],
+      userActionEntryId: 'a1',
+    })
+
+    const recent = rendered.find((v) => 'recentContent' in v)?.recentContent ?? ''
+    expect(recent).toContain('The tower loomed.')
+    expect(recent).not.toContain('Sale la torre.')
+  })
+
+  it('keeps every recent entry when no user action id is given', async () => {
+    generateStructured.mockResolvedValue({ selectedIndices: [] })
+
+    await runTier3Selection({
+      ...request,
+      recentEntries: [{ id: 'a1', type: 'user_action', content: 'Sale la torre.' } as StoryEntry],
+    })
+
+    const recent = rendered.find((v) => 'recentContent' in v)?.recentContent ?? ''
+    expect(recent).toContain('Sale la torre.')
+  })
+
   it('omits the colon for a candidate with no description', async () => {
-    generateStructured.mockResolvedValue({ selectedIds: [] })
+    generateStructured.mockResolvedValue({ selectedIndices: [] })
 
     await runTier3Selection(request)
 
@@ -152,5 +204,212 @@ describe('runTier3Selection', () => {
     generateStructured.mockRejectedValue(new Error('provider is down'))
 
     expect(await runTier3Selection(request)).toBeNull()
+  })
+})
+
+describe('runTier3Selection caching', () => {
+  const cachedRequest = {
+    candidates: [
+      { id: 'a-uuid', type: 'character', name: 'Aria', description: 'A swordswoman.' },
+      { id: 'b-uuid', type: 'location', name: 'The Tower', description: null },
+    ],
+    userInput: 'She climbs the tower.',
+    recentEntries: [{ type: 'narration', content: 'The tower loomed.' } as StoryEntry],
+    recentEntriesCount: 5,
+    presetId: 'entryRetrieval',
+    serviceLabel: 'tier3-lorebook-selection',
+  }
+
+  it('reuses the answer when the same question is asked again', async () => {
+    generateStructured.mockResolvedValue({ selectedIndices: ['1'] })
+
+    const first = await runTier3Selection({ ...cachedRequest, currentPosition: 100 })
+    const second = await runTier3Selection({ ...cachedRequest, currentPosition: 100 })
+
+    expect(generateStructured).toHaveBeenCalledTimes(1)
+    expect(second).toEqual(first)
+  })
+
+  it('reuses across a retry, which moves the position backwards', async () => {
+    generateStructured.mockResolvedValue({ selectedIndices: [] })
+
+    await runTier3Selection({ ...cachedRequest, currentPosition: 100 })
+    await runTier3Selection({ ...cachedRequest, currentPosition: 99 })
+
+    expect(generateStructured).toHaveBeenCalledTimes(1)
+  })
+
+  it('asks again for a new player action, even on an unchanged pool', async () => {
+    // The answer is a judgement about a scene. Reusing it across actions would answer the
+    // new one with the previous one's verdict.
+    generateStructured.mockResolvedValue({ selectedIndices: [] })
+
+    await runTier3Selection({ ...cachedRequest, currentPosition: 100 })
+    await runTier3Selection({
+      ...cachedRequest,
+      userInput: 'She draws her sword.',
+      currentPosition: 101,
+    })
+
+    expect(generateStructured).toHaveBeenCalledTimes(2)
+  })
+
+  // The prompt is built from the recent story as much as from the action, so the key has
+  // to be. Without this, two branches sitting at the same position with the same lorebook
+  // and a repeated action ("continue") answered each other's scene.
+  it('asks again when the story behind an identical action differs', async () => {
+    generateStructured.mockResolvedValue({ selectedIndices: [] })
+
+    await runTier3Selection({
+      ...cachedRequest,
+      recentEntries: [{ id: 'n1', type: 'narration', content: 'The tower loomed.' } as StoryEntry],
+      currentPosition: 100,
+    })
+    await runTier3Selection({
+      ...cachedRequest,
+      recentEntries: [{ id: 'n2', type: 'narration', content: 'The tower fell.' } as StoryEntry],
+      currentPosition: 100,
+    })
+
+    expect(generateStructured).toHaveBeenCalledTimes(2)
+  })
+
+  it('reuses when the history is the same entries, whatever their text now says', async () => {
+    // Translation rewrites stored content in place; the entries are still these entries.
+    generateStructured.mockResolvedValue({ selectedIndices: [] })
+    const history = [{ id: 'n1', type: 'narration', content: 'The tower loomed.' } as StoryEntry]
+
+    await runTier3Selection({ ...cachedRequest, recentEntries: history, currentPosition: 100 })
+    await runTier3Selection({
+      ...cachedRequest,
+      recentEntries: [{ ...history[0], content: 'La torre incombeva.' }],
+      currentPosition: 100,
+    })
+
+    expect(generateStructured).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores history the recent-entries window would not have shown the model', async () => {
+    // Only the slice that reaches the prompt is part of the question.
+    generateStructured.mockResolvedValue({ selectedIndices: [] })
+    const shown = { id: 'n9', type: 'narration', content: 'Here.' } as StoryEntry
+
+    await runTier3Selection({
+      ...cachedRequest,
+      recentEntriesCount: 1,
+      recentEntries: [{ id: 'old', type: 'narration', content: 'Long ago.' } as StoryEntry, shown],
+      currentPosition: 100,
+    })
+    await runTier3Selection({
+      ...cachedRequest,
+      recentEntriesCount: 1,
+      recentEntries: [
+        { id: 'different', type: 'narration', content: 'Elsewhere.' } as StoryEntry,
+        shown,
+      ],
+      currentPosition: 100,
+    })
+
+    expect(generateStructured).toHaveBeenCalledTimes(1)
+  })
+
+  it('asks again once the candidate set changes', async () => {
+    generateStructured.mockResolvedValue({ selectedIndices: [] })
+
+    await runTier3Selection({ ...cachedRequest, currentPosition: 100 })
+    await runTier3Selection({
+      ...cachedRequest,
+      candidates: [
+        ...cachedRequest.candidates,
+        { id: 'c-uuid', type: 'item', name: 'Key', description: null },
+      ],
+      currentPosition: 100,
+    })
+
+    expect(generateStructured).toHaveBeenCalledTimes(2)
+  })
+
+  it('asks again on a reordered pool, because the answer is in index space', async () => {
+    // A hit here would resolve "1" against a list where position 1 is a different entity.
+    generateStructured.mockResolvedValue({ selectedIndices: [] })
+
+    await runTier3Selection({ ...cachedRequest, currentPosition: 100 })
+    await runTier3Selection({
+      ...cachedRequest,
+      candidates: [...cachedRequest.candidates].reverse(),
+      currentPosition: 100,
+    })
+
+    expect(generateStructured).toHaveBeenCalledTimes(2)
+  })
+
+  it('reuses inside the window', async () => {
+    generateStructured.mockResolvedValue({ selectedIndices: [] })
+
+    await runTier3Selection({ ...cachedRequest, currentPosition: 100 })
+    await runTier3Selection({
+      ...cachedRequest,
+      currentPosition: 100 + TIER3_SELECTION_CACHE_POSITIONS - 1,
+    })
+
+    expect(generateStructured).toHaveBeenCalledTimes(1)
+  })
+
+  // The window edge is exclusive, and this is why. A turn is exactly two positions, and
+  // `TIER3_SELECTION_CACHE_POSITIONS` is 2 — so an inclusive edge let the *next* turn hit
+  // the cache whenever the action text repeated ("continue", "wait") and the pool had not
+  // moved, answering a new scene with the previous turn's verdict.
+  it('asks again a whole turn later, even on an identical question', async () => {
+    generateStructured.mockResolvedValue({ selectedIndices: [] })
+
+    await runTier3Selection({ ...cachedRequest, currentPosition: 100 })
+    await runTier3Selection({
+      ...cachedRequest,
+      currentPosition: 100 + TIER3_SELECTION_CACHE_POSITIONS,
+    })
+
+    expect(generateStructured).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps the two callers apart', async () => {
+    generateStructured.mockResolvedValue({ selectedIndices: [] })
+
+    await runTier3Selection({ ...cachedRequest, currentPosition: 100 })
+    await runTier3Selection({
+      ...cachedRequest,
+      serviceLabel: 'tier3-world-state-selection',
+      currentPosition: 100,
+    })
+
+    expect(generateStructured).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not cache a failed call', async () => {
+    generateStructured.mockRejectedValueOnce(new Error('provider is down'))
+    generateStructured.mockResolvedValue({ selectedIndices: [] })
+
+    expect(await runTier3Selection({ ...cachedRequest, currentPosition: 100 })).toBeNull()
+    await runTier3Selection({ ...cachedRequest, currentPosition: 100 })
+
+    expect(generateStructured).toHaveBeenCalledTimes(2)
+  })
+
+  it('bypasses the cache entirely when the caller gives no position', async () => {
+    generateStructured.mockResolvedValue({ selectedIndices: [] })
+
+    await runTier3Selection(cachedRequest)
+    await runTier3Selection(cachedRequest)
+
+    expect(generateStructured).toHaveBeenCalledTimes(2)
+  })
+
+  it('is emptied by clearTier3SelectionCache', async () => {
+    generateStructured.mockResolvedValue({ selectedIndices: [] })
+
+    await runTier3Selection({ ...cachedRequest, currentPosition: 100 })
+    clearTier3SelectionCache()
+    await runTier3Selection({ ...cachedRequest, currentPosition: 100 })
+
+    expect(generateStructured).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/lib/services/ai/retrieval/tier3Selection.ts
+++ b/src/lib/services/ai/retrieval/tier3Selection.ts
@@ -1,19 +1,14 @@
 /**
  * Tier 3 Selection
  *
- * Shared LLM-based candidate selection step used by both `EntryRetrievalService`
- * (lorebook `Entry[]` candidates) and `WorldStateInjector` (live `Character`/
- * `Location`/`Item`/`StoryBeat` candidates). Only the LLM call itself -- prompt
- * rendering, the `generateStructured` call, and mapping the result back onto the
- * candidate list -- is identical between the two callers. How candidates are
- * built, and what priority/cap is applied to the result, differs per caller and
- * intentionally stays there.
+ * The LLM selection step shared by `EntryRetrievalService` (lorebook entries) and
+ * `WorldStateInjector` (live world state). Only the call itself is shared: how candidates
+ * are built, and what cap and priority the result gets, stays with each caller.
  *
- * *Whether it runs at all* also differs, though the two now agree on the principle: nothing
- * uncovered is ever silently dropped. `EntryRetrievalService` asks the model about any
- * leftover at all; `WorldStateInjector` includes a small leftover wholesale and only asks
- * once there is more of it than `llmThreshold` (default 30) -- for it the call is an
- * alternative to including everything, not a precondition for including anything.
+ * Both agree that nothing uncovered is silently dropped — each has a "small leftover"
+ * branch that includes it without asking, and calls the model only for what is too big to
+ * include. Both measure "too big" in words of candidate text, against their own
+ * `tier3WholesaleWordBudget`; the budgets differ because their candidates do.
  */
 
 import type { StoryEntry } from '$lib/types'
@@ -22,6 +17,7 @@ import { createLogger } from '$lib/log'
 import { entitySelectionSchema } from '../sdk/schemas/context'
 import { generateStructured } from '../sdk/generate'
 import { recentContent, AS_PROSE } from '$lib/utils/recentContent'
+import { TIER3_SELECTION_CACHE_POSITIONS } from '../core/defaults'
 
 const log = createLogger('Tier3Selection')
 
@@ -38,7 +34,7 @@ export interface Tier3Candidate<TType extends string = string> {
 }
 
 export interface Tier3SelectionResult {
-  selectedIds: Set<string>
+  selectedIndices: Set<string>
   reasoning?: string
 }
 
@@ -57,15 +53,95 @@ export interface Tier3SelectionRequest {
    * profile is used; that is `presetId`.
    */
   serviceLabel: string
+  /**
+   * The entry `userInput` was read from, so the prompt does not render the same action
+   * twice. Matched by id rather than by text: translation rewrites the stored content, so
+   * a text comparison stops recognising it exactly when the two diverge.
+   */
+  userActionEntryId?: string
+  /**
+   * Current story position, used to age the selection cache. Omit to bypass the cache — a
+   * caller that cannot say "when" cannot say whether a hit is still fresh.
+   */
+  currentPosition?: number
   signal?: AbortSignal
+}
+
+interface CachedSelection {
+  /** What this answer is an answer to. Compared, not looked up — see below. */
+  key: string
+  position: number
+  result: Tier3SelectionResult
+}
+
+/**
+ * The last selection per caller. Module-level because the services are constructed once by
+ * `ServiceFactory`, and the cache has to outlive a turn to be worth anything.
+ *
+ * Keyed by caller and holding one entry each, rather than keyed by the question: only the
+ * most recent answer is ever reusable — the window is `TIER3_SELECTION_CACHE_POSITIONS`
+ * positions wide — so keeping the others is growth with no hit rate behind it. Each key is
+ * every candidate id concatenated, several KB on a large lorebook, retained for the whole
+ * session on a WebView heap that is a hard cap on Android.
+ *
+ * Reset on story switch: entry ids are UUIDs and cannot collide, but a stale entry left
+ * behind would still be answering about the wrong story if the same pool came back.
+ */
+const selectionCache = new Map<string, CachedSelection>()
+
+/**
+ * What a cached answer is an answer *to*: this caller, this pool, in this order, for this
+ * player action.
+ *
+ * Order matters because the answer is in index space — `"3"` means "the fourth candidate
+ * in the list the prompt numbered". An order-independent key would resolve those indices
+ * against a different ordering and name entirely different entries, which is reachable:
+ * `WorldStateInjector` builds candidates from world state the classifier rewrites.
+ *
+ * The input matters because the answer is a judgement about a scene, not about the pool.
+ * Keying on it means a reused answer is only ever reused for the same question — which is
+ * what a retry or a second pass in the same turn asks — instead of answering a new action
+ * with the previous one's verdict.
+ *
+ * The recent entries matter for exactly the same reason, and were missing. The prompt is
+ * built from both, so keyed on the action alone two situations sharing a repeated action
+ * ("continue", "wait") and an unmoved pool asked the same question as far as the cache
+ * could see. Reachable across consecutive turns, and more easily still across a branch
+ * switch, where two branches sit at the same position with the same lorebook and only
+ * their history differs. Ids, not text: a slice of UUIDs is what distinguishes one history
+ * from another, and translation rewrites the stored content without changing which entries
+ * these are.
+ *
+ * With those in, the key is complete by content — the position window and the `clear` calls
+ * are belt-and-braces rather than the thing standing between the cache and a wrong answer.
+ */
+function cacheKeyFor(
+  serviceLabel: string,
+  candidates: Tier3Candidate[],
+  userInput: string,
+  recentEntries: StoryEntry[],
+  recentEntriesCount: number,
+): string {
+  return [
+    serviceLabel,
+    userInput,
+    // The same slice the prompt is built from, so the key moves exactly when the prompt does.
+    ...recentEntries.slice(-recentEntriesCount).map((e) => e.id),
+    // Separator: without it a trailing history id and a leading candidate id could
+    // rearrange into the same string across two different splits.
+    '',
+    ...candidates.map((c) => c.id),
+  ].join('\u0000')
+}
+
+/** Exported for tests, and called when the story or the branch changes. */
+export function clearTier3SelectionCache(): void {
+  selectionCache.clear()
 }
 
 /**
  * Ask the LLM to select the most relevant candidates for this turn.
- * Returns `null` on failure -- both current callers treat that as "no Tier 3 entries".
- *
- * Takes an object: it had six positional parameters before this one, and a seventh would
- * have made the call sites unreadable.
+ * Returns `null` on failure — both callers treat that as "no Tier 3 entries".
  */
 export async function runTier3Selection({
   candidates,
@@ -74,11 +150,45 @@ export async function runTier3Selection({
   recentEntriesCount,
   presetId,
   serviceLabel,
+  userActionEntryId,
+  currentPosition,
   signal,
 }: Tier3SelectionRequest): Promise<Tier3SelectionResult | null> {
   if (candidates.length === 0) {
-    return { selectedIds: new Set() }
+    return { selectedIndices: new Set() }
   }
+
+  const cacheKey = cacheKeyFor(
+    serviceLabel,
+    candidates,
+    userInput,
+    recentEntries,
+    recentEntriesCount,
+  )
+  const cached = currentPosition === undefined ? undefined : selectionCache.get(serviceLabel)
+  if (
+    cached &&
+    currentPosition !== undefined &&
+    cached.key === cacheKey &&
+    // Strictly inside the window, not on its edge. A turn is exactly two positions, so
+    // `<=` let a hit land on the *next* turn: same action text ("continue", "wait"), an
+    // unchanged candidate pool, and last turn's verdict answering this turn's scene.
+    // Either direction, because a retry moves the position back and is the same question.
+    Math.abs(currentPosition - cached.position) < TIER3_SELECTION_CACHE_POSITIONS
+  ) {
+    log('Tier 3 selection reused from cache', {
+      serviceLabel,
+      candidates: candidates.length,
+      selected: cached.result.selectedIndices.size,
+    })
+    return cached.result
+  }
+
+  // `recentEntries` ends with the action in `userInput`, and the prompt renders both.
+  // Sending it twice reads as emphasis the player never gave.
+  const filteredRecent = userActionEntryId
+    ? recentEntries.filter((e) => e.id !== userActionEntryId)
+    : recentEntries
 
   const entrySummaries = candidates
     .map(
@@ -89,7 +199,7 @@ export async function runTier3Selection({
 
   const ctx = new ContextBuilder()
   ctx.add({
-    recentContent: recentContent(recentEntries, recentEntriesCount, AS_PROSE),
+    recentContent: recentContent(filteredRecent, recentEntriesCount, AS_PROSE, true),
     userInput,
     entrySummaries,
   })
@@ -100,37 +210,87 @@ export async function runTier3Selection({
       { presetId, schema: entitySelectionSchema, system, prompt, signal },
       serviceLabel,
     )
-    return { selectedIds: new Set(result.selectedIds), reasoning: result.reasoning }
+    const selection = {
+      selectedIndices: new Set(result.selectedIndices),
+      reasoning: result.reasoning,
+    }
+    if (currentPosition !== undefined) {
+      selectionCache.set(serviceLabel, {
+        key: cacheKey,
+        position: currentPosition,
+        result: selection,
+      })
+    }
+    return selection
   } catch (error) {
+    // Not cached: a failure says nothing about which candidates matter, and storing it
+    // would suppress the retry that might succeed.
     log('Tier 3 LLM selection failed', error)
     return null
   }
 }
 
 /**
- * Map an LLM selection result back onto the original candidate list, matching by
- * id (preferred) or by numeric index (some models return indices instead of ids).
- * `candidates` must be in the same order used to build the prompt in `runTier3Selection`.
+ * Words the wholesale branch would put in the prompt for `entries`.
  *
- * Returned in the order the model listed them, not in candidate order. Both callers cap
- * the result, and candidate order is an artifact of how the prompt was assembled -- for
- * `WorldStateInjector` it is grouped by type, so a cap applied to it drops whole
- * categories (every story beat, always) regardless of what the model thought mattered.
- * A model's own ordering is at least a claim about relevance. `Set` preserves insertion
- * order, so this is information already in hand rather than a new contract.
+ * Prices what the context block emits — `- <name>: <description>` per entry, with the
+ * description truncated to `maxWordsPerEntry` — so the name counts too and nothing past
+ * the truncation point does.
+ */
+export function countWholesaleWords(
+  entries: { name?: string | null; description?: string | null }[],
+  maxWordsPerEntry = 0,
+): number {
+  const wordsIn = (text: string | null | undefined) =>
+    text?.trim() ? text.trim().split(/\s+/).length : 0
+
+  let total = 0
+  for (const entry of entries) {
+    const description = wordsIn(entry.description)
+    total +=
+      wordsIn(entry.name) +
+      (maxWordsPerEntry > 0 ? Math.min(description, maxWordsPerEntry) : description)
+  }
+  return total
+}
+
+/**
+ * The prompt numbers the candidates and never renders an id, so the answer is an index.
+ * The listing format (`0. [type] Name`) invites `"1."`, `"#1"` and `"[1]"` back, and each
+ * is unambiguous once the only question is which digits.
+ */
+function extractIndex(raw: string): number | null {
+  const match = /\d+/.exec(String(raw))
+  if (!match) return null
+  const index = Number.parseInt(match[0], 10)
+  return Number.isSafeInteger(index) ? index : null
+}
+
+/**
+ * Map a selection result back onto the candidate list by index. `candidates` must be in the
+ * order `runTier3Selection` built the prompt from.
+ *
+ * Returned in the model's order, not candidate order: both callers cap the result, and
+ * candidate order is an artifact of assembly — `WorldStateInjector` groups by type, so a
+ * cap applied to it drops whole categories regardless of relevance.
  */
 export function resolveTier3Selection<T extends { id: string }>(
   candidates: T[],
   result: Tier3SelectionResult,
 ): T[] {
-  const rank = new Map([...result.selectedIds].map((id, order) => [id, order]))
+  const selected: T[] = []
+  const seen = new Set<number>()
 
-  const selected: { candidate: T; rank: number }[] = []
-  for (let i = 0; i < candidates.length; i++) {
-    const candidate = candidates[i]
-    const matched = rank.get(candidate.id) ?? rank.get(i.toString())
-    if (matched !== undefined) selected.push({ candidate, rank: matched })
+  for (const raw of result.selectedIndices) {
+    const index = extractIndex(raw)
+    if (index === null) {
+      log('Tier 3 selection dropped an unparseable entry', { raw })
+      continue
+    }
+    if (index < 0 || index >= candidates.length || seen.has(index)) continue
+    seen.add(index)
+    selected.push(candidates[index])
   }
 
-  return selected.sort((a, b) => a.rank - b.rank).map((s) => s.candidate)
+  return selected
 }

--- a/src/lib/services/ai/sdk/schemas/context.ts
+++ b/src/lib/services/ai/sdk/schemas/context.ts
@@ -7,11 +7,13 @@
 import * as z from 'zod'
 
 /**
- * Result of LLM entity selection.
- * The LLM returns IDs of relevant entities from a candidate list.
+ * Result of LLM entity selection: positions in the numbered candidate list, never ids —
+ * ids are not rendered into the prompt, so the model has never seen one.
  */
 export const entitySelectionSchema = z.object({
-  selectedIds: z.array(z.string()).describe('IDs of the most relevant entities'),
+  selectedIndices: z
+    .array(z.string())
+    .describe('Index numbers of the most relevant entries, e.g. ["0", "3"]'),
   reasoning: z.string().optional().describe('Brief explanation of selection logic'),
 })
 

--- a/src/lib/services/ai/sdk/tools/lorebook.test.ts
+++ b/src/lib/services/ai/sdk/tools/lorebook.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import {
+  createLoreManagementTools,
+  createInteractiveVaultLorebookTools,
+  type LoreManagementToolContext,
+} from './lorebook'
+
+const context: LoreManagementToolContext = {
+  entries: [],
+  activeLorebookId: 'lb1',
+  onPendingChange: () => {},
+  generateId: () => 'change-1',
+}
+
+/** The parameter names the model is shown for a tool. */
+function inputKeys(tool: { inputSchema: unknown }): string[] {
+  return Object.keys((tool.inputSchema as z.ZodObject<z.ZodRawShape>).shape)
+}
+
+describe('createLoreManagementTools', () => {
+  it('does not offer injectionMode, which would let it pin an entry into every prompt', () => {
+    const tools = createLoreManagementTools(context)
+
+    expect(inputKeys(tools.create_entry)).not.toContain('injectionMode')
+    expect(inputKeys(tools.update_entry)).not.toContain('injectionMode')
+  })
+
+  it('leaves the rest of the entry alone', () => {
+    expect(inputKeys(createLoreManagementTools(context).create_entry)).toEqual(
+      expect.arrayContaining(['name', 'type', 'description', 'keywords', 'aliases', 'priority']),
+    )
+  })
+
+  it('creates entries as keyword-injected', async () => {
+    let created: { entry?: { injectionMode?: string } } | undefined
+    const tools = createLoreManagementTools({
+      ...context,
+      onPendingChange: (change) => {
+        created = change as typeof created
+      },
+    })
+
+    await tools.create_entry.execute?.(
+      {
+        name: 'House of Stone',
+        type: 'faction',
+        description: 'A dwarven house.',
+        keywords: ['Morvana'],
+      } as never,
+      {} as never,
+    )
+
+    expect(created?.entry?.injectionMode).toBe('keyword')
+  })
+})
+
+describe('createInteractiveVaultLorebookTools', () => {
+  it('keeps injectionMode: the user reads the change before it lands', () => {
+    const tools = createInteractiveVaultLorebookTools(
+      { lorebooks: () => [], generateId: () => 'c1' },
+      context,
+    ) as unknown as Record<string, { inputSchema: unknown }>
+
+    expect(inputKeys(tools.create_entry)).toContain('injectionMode')
+  })
+})

--- a/src/lib/services/ai/sdk/tools/lorebook.ts
+++ b/src/lib/services/ai/sdk/tools/lorebook.ts
@@ -573,9 +573,32 @@ export type LoreManagementToolContext = LorebookEntryToolContext & StoryToolCont
  * Includes all entry management and chapter querying tools.
  * Excludes browsing tools (managing the entire vault).
  */
+/**
+ * Drop `injectionMode` from a tool's input schema.
+ *
+ * The field survives in `execute`, which simply never receives it and falls back to
+ * `'keyword'`. Removing it from the schema rather than ignoring it afterwards is the point:
+ * the schema is what the model is shown, so a parameter left in and discarded is a
+ * parameter the model spends tokens choosing.
+ */
+function withoutInjectionMode<T extends { inputSchema: unknown }>(tool: T): T {
+  // `tool()` widens `inputSchema` to the SDK's `FlexibleSchema`, which loses the Zod
+  // methods; these two are built here from `z.object`, so the narrowing is safe.
+  const schema = tool.inputSchema as z.ZodObject<z.ZodRawShape>
+  return { ...tool, inputSchema: schema.omit({ injectionMode: true }) } as T
+}
+
 export function createLoreManagementTools(context: LoreManagementToolContext) {
+  const { create_entry, update_entry, ...entryTools } = createLorebookEntryTools(context)
+
   return {
-    ...createLorebookEntryTools(context),
+    ...entryTools,
+    // Lore management runs unattended, so it does not get to decide that an entry belongs
+    // in every prompt forever: `always` is a budget decision, past every retrieval
+    // threshold, made by an agent that cannot see the budget. The vault assistant keeps it
+    // — there the user reads the change before it lands.
+    create_entry: withoutInjectionMode(create_entry),
+    update_entry: withoutInjectionMode(update_entry),
     ...createStoryTools(context),
   }
 }

--- a/src/lib/services/generation/phases/NarrativePhase.test.ts
+++ b/src/lib/services/generation/phases/NarrativePhase.test.ts
@@ -33,6 +33,7 @@ const retrievalResult: RetrievalResult = {
   chapterContext: '## Chapters',
   lorebookContext: '## Lorebook',
   lorebookRetrievalResult: null,
+  worldStateRetrievalResult: null,
   timelineFillResult: null,
   combinedContext: '## Chapters\n## Lorebook',
 }

--- a/src/lib/services/generation/phases/RetrievalPhase.test.ts
+++ b/src/lib/services/generation/phases/RetrievalPhase.test.ts
@@ -43,8 +43,20 @@ function makeMockDependencies(
       }) as any,
     answerChapterQuestion: async () => 'Answer',
     buildWorldStateContext: async () => ({
+      tier1: [],
+      tier2: [],
+      tier3: [],
       contextBlock: '## World State',
-      all: [{ type: 'character', name: 'Aria' }],
+      all: [
+        {
+          type: 'character' as const,
+          id: 'c1',
+          name: 'Aria',
+          description: null,
+          tier: 1,
+          priority: 90,
+        },
+      ],
     }),
     getRelevantLorebookEntries: async () => ({
       tier1: [],
@@ -229,6 +241,69 @@ describe('RetrievalPhase', () => {
     expect(lorebookSpy.mock.calls[0][2]).toBe(context.visibleEntries)
   })
 
+  it('hands the world state scene to the lorebook pass, before Tier 3 runs', async () => {
+    // The whole point of the handover: the lorebook waits for names, not for an LLM call.
+    let tier3Ran = false
+    const lorebookSpy: RetrievalDependencies['getRelevantLorebookEntries'] = vi.fn(async () => ({
+      tier1: [],
+      tier2: [],
+      tier3: [],
+      all: [],
+      contextBlock: '## Lorebook',
+    }))
+
+    const deps = makeMockDependencies({
+      buildWorldStateContext: async (_ws, _input, _recent, options) => {
+        options?.onSceneEntities?.([{ type: 'character', name: 'Aria' }])
+        await Promise.resolve()
+        tier3Ran = true
+        return { tier1: [], tier2: [], tier3: [], contextBlock: '## World State', all: [] }
+      },
+      getRelevantLorebookEntries: lorebookSpy,
+    })
+
+    for await (const _ of phase().execute({
+      context: makeMockContext(),
+      dependencies: deps,
+      memoryRetrievalEnabled: false,
+    })) {
+      // drain
+    }
+
+    expect(vi.mocked(lorebookSpy).mock.calls[0][3]?.sceneEntities).toEqual([
+      { type: 'character', name: 'Aria' },
+    ])
+    expect(tier3Ran).toBe(true)
+  })
+
+  it('still runs the lorebook pass when the world state fails before handing over', async () => {
+    const lorebookSpy: RetrievalDependencies['getRelevantLorebookEntries'] = vi.fn(async () => ({
+      tier1: [],
+      tier2: [],
+      tier3: [],
+      all: [],
+      contextBlock: '## Lorebook',
+    }))
+
+    const deps = makeMockDependencies({
+      buildWorldStateContext: async () => {
+        throw new Error('world state exploded')
+      },
+      getRelevantLorebookEntries: lorebookSpy,
+    })
+
+    for await (const _ of phase().execute({
+      context: makeMockContext(),
+      dependencies: deps,
+      memoryRetrievalEnabled: false,
+    })) {
+      // drain
+    }
+
+    expect(lorebookSpy).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(lorebookSpy).mock.calls[0][3]?.sceneEntities).toEqual([])
+  })
+
   it('runs memory retrieval only after stage A, so the summary is complete', async () => {
     // A partial summary is worse than none: it is read as a statement about the prompt, so
     // naming half of it invites work on the other half under the impression it is missing.
@@ -238,7 +313,7 @@ describe('RetrievalPhase', () => {
       shouldUseAgenticRetrieval: () => true,
       buildWorldStateContext: async () => {
         order.push('worldState')
-        return { contextBlock: '## World State', all: [] }
+        return { tier1: [], tier2: [], tier3: [], contextBlock: '## World State', all: [] }
       },
       getRelevantLorebookEntries: async () => {
         order.push('lorebook')

--- a/src/lib/services/generation/phases/RetrievalPhase.ts
+++ b/src/lib/services/generation/phases/RetrievalPhase.ts
@@ -15,8 +15,14 @@ import type { TimelineFillResult } from '$lib/services/ai/retrieval/TimelineFill
 import type { RetrievalResult as AgenticRetrievalResult } from '$lib/services/ai/retrieval/AgenticRetrievalService'
 import type {
   EntryRetrievalResult,
+  EntryRetrievalOptions,
   ActivationTracker,
+  SceneEntity,
 } from '$lib/services/ai/retrieval/EntryRetrievalService'
+import type {
+  WorldStateInjectorOptions,
+  WorldStateInjectionResult,
+} from '$lib/services/ai/generation/WorldStateInjector'
 import {
   formatAlreadyInContext,
   type ContextEntity,
@@ -51,15 +57,13 @@ export interface RetrievalDependencies {
     worldState: GenerationContext['worldState'],
     userInput: string,
     recentEntries: GenerationContext['visibleEntries'],
-    signal?: AbortSignal,
-    activationTracker?: ActivationTracker,
-  ) => Promise<{ contextBlock: string; all: { type: string; name: string }[] }>
+    options?: WorldStateInjectorOptions,
+  ) => Promise<WorldStateInjectionResult>
   getRelevantLorebookEntries: (
     entries: GenerationContext['worldState']['lorebookEntries'],
     userInput: string,
     recentStoryEntries: GenerationContext['visibleEntries'],
-    activationTracker?: ActivationTracker,
-    signal?: AbortSignal,
+    options?: EntryRetrievalOptions,
   ) => Promise<EntryRetrievalResult>
 }
 
@@ -83,6 +87,7 @@ export class RetrievalPhase {
     let lorebookRetrievalResult: EntryRetrievalResult | null = null
     let timelineFillResult: TimelineFillResult | null = null
     let worldStateBlock: string | null = null
+    let worldStateResult: WorldStateInjectionResult | null = null
 
     let worldStateEntities: ContextEntity[] = []
     let lorebookEntities: ContextEntity[] = []
@@ -95,23 +100,34 @@ export class RetrievalPhase {
 
     // Stage A: what the narrator gets regardless of memory retrieval.
     //
-    // Both are unconditional and both are mostly free -- tiers 1 and 2 are string matching,
-    // and only tier 3 costs an LLM call, gated on the candidate pool. They run together
-    // because neither reads the other's output, and the activation tracker they share is
-    // safe to touch concurrently: `currentPosition` is fixed for the whole turn at
-    // construction, and they write disjoint id spaces (entity uuids vs lorebook Entry uuids).
+    // The two run together, but not blindly in parallel: the lorebook waits for the world
+    // state's Tier 1 + Tier 2 so it can match lore against what is actually in the scene.
+    // That handover happens before the world state's Tier 3, which may be an LLM call, so
+    // the two Tier 3 passes still overlap rather than queueing.
+    //
+    // One-way on purpose. Lore names must not widen the world state's idea of who is
+    // present: a lorebook entry is reference material, and reading it as scene state is
+    // how a narrator starts acting on characters that are not there.
+    //
+    // The activation tracker they share is safe to touch concurrently: `currentPosition`
+    // is fixed for the whole turn, and they write disjoint id spaces.
+    let releaseSceneEntities: (entities: SceneEntity[]) => void = () => {}
+    const sceneEntities = new Promise<SceneEntity[]>((resolve) => {
+      releaseSceneEntities = resolve
+    })
+
     const stageA: Promise<void>[] = []
 
     stageA.push(
       dependencies
-        .buildWorldStateContext(
-          worldState,
-          userAction.content,
-          visibleEntries,
-          abortSignal,
+        .buildWorldStateContext(worldState, userAction.content, visibleEntries, {
+          signal: abortSignal,
           activationTracker,
-        )
+          userActionEntryId: userAction.entryId,
+          onSceneEntities: releaseSceneEntities,
+        })
         .then((result) => {
+          worldStateResult = result
           worldStateBlock = result.contextBlock
           worldStateEntities = result.all.map((e) => ({ type: e.type, name: e.name }))
         })
@@ -119,7 +135,9 @@ export class RetrievalPhase {
           contextInventoryComplete = false
           if (err instanceof Error && err.name === 'AbortError') return
           console.warn('[RetrievalPhase] World state injection failed (non-fatal):', err)
-        }),
+        })
+        // Unblocks the lorebook pass when the world state never got as far as handing over.
+        .finally(() => releaseSceneEntities([])),
     )
 
     // Lorebook retrieval used to be skipped in agentic mode, on the basis that the agent
@@ -130,16 +148,22 @@ export class RetrievalPhase {
     const hasLoreContent = lorebookEntries.length > 0
     if (hasLoreContent) {
       stageA.push(
-        dependencies
-          .getRelevantLorebookEntries(
-            lorebookEntries,
-            userAction.content,
-            // Not pre-sliced: the service applies its own configured Recent Entries
-            // Window. A fixed slice here silently capped that setting -- the slider goes
-            // to 15, and anything above 10 did nothing.
-            visibleEntries,
-            activationTracker,
-            abortSignal,
+        sceneEntities
+          .then((scene) =>
+            dependencies.getRelevantLorebookEntries(
+              lorebookEntries,
+              userAction.content,
+              // Not pre-sliced: the service applies its own configured Recent Entries
+              // Window. A fixed slice here silently capped that setting -- the slider goes
+              // to 15, and anything above 10 did nothing.
+              visibleEntries,
+              {
+                activationTracker,
+                signal: abortSignal,
+                userActionEntryId: userAction.entryId,
+                sceneEntities: scene,
+              },
+            ),
           )
           .then((result) => {
             lorebookRetrievalResult = result
@@ -166,6 +190,7 @@ export class RetrievalPhase {
         chapterContext: null,
         lorebookContext: null,
         lorebookRetrievalResult: null,
+        worldStateRetrievalResult: null,
         timelineFillResult: null,
         combinedContext: null,
       }
@@ -211,6 +236,7 @@ export class RetrievalPhase {
         chapterContext: null,
         lorebookContext: null,
         lorebookRetrievalResult: null,
+        worldStateRetrievalResult: null,
         timelineFillResult: null,
         combinedContext: null,
       }
@@ -224,6 +250,7 @@ export class RetrievalPhase {
       chapterContext,
       lorebookContext,
       lorebookRetrievalResult,
+      worldStateRetrievalResult: worldStateResult,
       timelineFillResult,
       combinedContext,
     }

--- a/src/lib/services/generation/types.ts
+++ b/src/lib/services/generation/types.ts
@@ -17,6 +17,7 @@ import type {
 import type { ClassificationResult } from '$lib/services/ai/sdk/schemas/classifier'
 import type { TimelineFillResult } from '$lib/services/ai/retrieval'
 import type { EntryRetrievalResult } from '$lib/services/ai/retrieval/EntryRetrievalService'
+import type { WorldStateInjectionResult } from '$lib/services/ai/generation/WorldStateInjector'
 
 // Generation Phases
 export type GenerationPhase =
@@ -62,6 +63,8 @@ export interface RetrievalResult {
   chapterContext: string | null
   lorebookContext: string | null
   lorebookRetrievalResult: EntryRetrievalResult | null
+  /** The tiered world state, for the debug panel. The prompt reads `worldStateBlock`. */
+  worldStateRetrievalResult: WorldStateInjectionResult | null
   timelineFillResult: TimelineFillResult | null
   combinedContext: string | null
 }

--- a/src/lib/services/prompts/templates/analysis.ts
+++ b/src/lib/services/prompts/templates/analysis.ts
@@ -268,15 +268,22 @@ Only include entries that have a clear connection to the current scene or user's
   // nothing to take, though, and the question stays where a question belongs -- at the end,
   // after what it is about.
   userContent: `# Available Entries
+The following candidate entries are available for selection. Each entry is formatted as:
+<index>. [<type>] <name>: <description preview>
+
 {{ entrySummaries }}
 
-# Current Scene
+---
+
+# Current Scene (Preceding Context)
 {{ recentContent }}
 
-# User's Input
+---
+
+# User's Action
 "{{ userInput }}"
 
-Which entries (by number) are relevant to the current scene and user input?`,
+Which entries (by index number 0, 1, 2...) are relevant to the current scene and user's action?`,
 }
 
 export const analysisTemplates: PromptTemplate[] = [

--- a/src/lib/services/prompts/templates/memory.ts
+++ b/src/lib/services/prompts/templates/memory.ts
@@ -122,7 +122,7 @@ const loreManagementPromptTemplate: PromptTemplate = {
 Your tasks:
 1. Identify important characters, locations, items, factions, and concepts that appear in the story but have no entry
 2. Find entries that are outdated or incomplete based on story events
-3. Identify redundant entries that should be merged
+3. **Scan for and clean up duplicate or redundant entries**: Look for entries with overlapping scope, variations of names, or titles referring to the same subject
 4. Update relationship statuses and character states
 
 Guidelines:
@@ -130,7 +130,7 @@ Guidelines:
 - Ask specific questions when querying chapters (e.g., "What did [character] reveal?" not "Give me the full content")
 - Be conservative - only create entries for elements that are genuinely important to the story
 - Use exact names from the story text
-- When merging, combine all relevant information
+- **Deduplication & Merging Rule**: When two entries refer to the same subject (e.g. name variations, titles, or duplicate concepts), consolidate all descriptions, aliases, and keywords into the primary entry using \`update_entry\`, then call \`delete_entry\` on the duplicate entry.
 - Focus on facts that would help maintain story consistency
 - Prefer targeted updates (e.g., search/replace) instead of rewriting long descriptions
 
@@ -143,7 +143,7 @@ Use your tools to review the story and make necessary changes. When finished, ca
 Please review the story content and identify:
 1. Important elements that should have entries but don't
 2. Entries that need updating based on story events
-3. Redundant or duplicate entries that should be merged
+3. **Duplicate or redundant entries that should be merged/deleted**: Consolidate information into the main entry with \`update_entry\` and remove the duplicate with \`delete_entry\`.
 
 Use the available tools to make necessary changes, then call finish_lore_management when done.`,
 }

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -27,6 +27,7 @@ import {
 import {
   migrateEntryRetrieval,
   migrateImageGeneration,
+  migrateWorldStateBudget,
   migrateWorldStateInjection,
 } from './settingsMigrations'
 import { ui } from '$lib/stores/ui.svelte'
@@ -566,8 +567,12 @@ export interface EntryRetrievalSettings {
   maxTier2Entries: number
   /** Cap on Tier 3 (LLM selected) */
   maxTier3Entries: number
+  /** Words of leftover that still go in whole, above which the LLM is asked instead */
+  tier3WholesaleWordBudget: number
   maxWordsPerEntry: number // 0 = unlimited
   enableLLMSelection: boolean
+  /** Whether the world state's Tier 1 + Tier 2 seed the second Tier 2 pass here */
+  useSceneEntities: boolean
   /** Recent story entries scanned for Tier 2 name/keyword matching and included in the Tier 3 prompt */
   recentEntriesCount: number
   reasoningEffort: ReasoningEffort
@@ -589,8 +594,10 @@ export function getDefaultEntryRetrievalSettingsForProvider(
     temperature: 0.2,
     maxTier2Entries: ENTRY_RETRIEVAL_DEFAULTS.maxTier2Entries,
     maxTier3Entries: ENTRY_RETRIEVAL_DEFAULTS.maxTier3Entries,
+    tier3WholesaleWordBudget: ENTRY_RETRIEVAL_DEFAULTS.tier3WholesaleWordBudget,
     maxWordsPerEntry: 0,
     enableLLMSelection: true,
+    useSceneEntities: true,
     recentEntriesCount: 5,
     reasoningEffort: preset.reasoningEffort,
     manualBody: '',
@@ -603,8 +610,8 @@ export function getDefaultEntryRetrievalSettingsForProvider(
 // distinction). Model/temperature/profile are NOT stored here -- they come from
 // the 'worldStateInjection' Agent Profile assignment, same as every other AI task.
 export interface WorldStateInjectionSettings {
-  /** Number of not-yet-selected live entities that triggers Tier 3 LLM selection */
-  llmThreshold: number
+  /** Words of leftover that still go in whole, above which the LLM is asked instead */
+  tier3WholesaleWordBudget: number
   /**
    * Cap on Tier 2 (name matched).
    *
@@ -622,7 +629,7 @@ export interface WorldStateInjectionSettings {
 
 export function getDefaultWorldStateInjectionSettings(): WorldStateInjectionSettings {
   return {
-    llmThreshold: WORLD_STATE_INJECTION_DEFAULTS.llmThreshold,
+    tier3WholesaleWordBudget: WORLD_STATE_INJECTION_DEFAULTS.tier3WholesaleWordBudget,
     maxTier2Entries: WORLD_STATE_INJECTION_DEFAULTS.maxTier2Entries,
     maxTier3Entries: WORLD_STATE_INJECTION_DEFAULTS.maxTier3Entries,
     enableLLMSelection: true,
@@ -1698,10 +1705,12 @@ class SettingsStore {
               ...defaults.entryRetrieval,
               ...loaded.entryRetrieval,
             }),
-            worldStateInjection: migrateWorldStateInjection(loaded.worldStateInjection, {
-              ...defaults.worldStateInjection,
-              ...loaded.worldStateInjection,
-            }),
+            worldStateInjection: migrateWorldStateBudget(
+              migrateWorldStateInjection(loaded.worldStateInjection, {
+                ...defaults.worldStateInjection,
+                ...loaded.worldStateInjection,
+              }),
+            ),
             imageGeneration: migrateImageGeneration({
               ...defaults.imageGeneration,
               ...loaded.imageGeneration,

--- a/src/lib/stores/settingsMigrations.test.ts
+++ b/src/lib/stores/settingsMigrations.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   migrateEntryRetrieval,
   migrateImageGeneration,
+  migrateWorldStateBudget,
   migrateWorldStateInjection,
 } from './settingsMigrations'
 import {
@@ -10,7 +11,7 @@ import {
 } from '$lib/services/ai/core/defaults'
 
 interface MergedWorldState {
-  llmThreshold: number
+  tier3WholesaleWordBudget: number
   maxTier2Entries: number
   maxTier3Entries: number
   enableLLMSelection: boolean
@@ -25,7 +26,7 @@ interface MergedWorldState {
 const merged = (
   over: Partial<{ maxTier2Entries: number; maxTier3Entries: number }> = {},
 ): MergedWorldState => ({
-  llmThreshold: WORLD_STATE_INJECTION_DEFAULTS.llmThreshold,
+  tier3WholesaleWordBudget: WORLD_STATE_INJECTION_DEFAULTS.tier3WholesaleWordBudget,
   maxTier2Entries: WORLD_STATE_INJECTION_DEFAULTS.maxTier2Entries,
   maxTier3Entries: WORLD_STATE_INJECTION_DEFAULTS.maxTier3Entries,
   enableLLMSelection: true,
@@ -57,12 +58,12 @@ describe('migrateWorldStateInjection', () => {
 
   it('preserves every other setting it does not migrate', () => {
     const source = merged()
-    source.llmThreshold = 90
+    source.tier3WholesaleWordBudget = 900
     source.recentEntriesCount = 12
 
     const result = migrateWorldStateInjection({ maxEntriesPerTier: 7 }, source)
 
-    expect(result.llmThreshold).toBe(90)
+    expect(result.tier3WholesaleWordBudget).toBe(900)
     expect(result.recentEntriesCount).toBe(12)
     expect(result.enableLLMSelection).toBe(true)
   })
@@ -178,5 +179,33 @@ describe('migrateImageGeneration', () => {
 
   it('preserves the other settings', () => {
     expect(migrateImageGeneration({ ...legacy, backgroundBlur: 2 }).backgroundBlur).toBe(2)
+  })
+})
+
+describe('migrateWorldStateBudget', () => {
+  it('drops the record-count threshold the word budget replaced', () => {
+    // Not converted: 30 records and 500 words coincide only because a record averages ~16
+    // words, so a raised count would translate into a number nobody asked for.
+    const result = migrateWorldStateBudget({
+      tier3WholesaleWordBudget: WORLD_STATE_INJECTION_DEFAULTS.tier3WholesaleWordBudget,
+      llmThreshold: 100,
+    })
+
+    expect(result).not.toHaveProperty('llmThreshold')
+    expect(result.tier3WholesaleWordBudget).toBe(
+      WORLD_STATE_INJECTION_DEFAULTS.tier3WholesaleWordBudget,
+    )
+  })
+
+  it('leaves a settings object that never had one alone', () => {
+    const clean = { tier3WholesaleWordBudget: 700, maxTier2Entries: 40 }
+
+    expect(migrateWorldStateBudget(clean)).toBe(clean)
+  })
+
+  it('is idempotent', () => {
+    const once = migrateWorldStateBudget({ tier3WholesaleWordBudget: 500, llmThreshold: 30 })
+
+    expect(migrateWorldStateBudget(once)).toEqual(once)
   })
 })

--- a/src/lib/stores/settingsMigrations.ts
+++ b/src/lib/stores/settingsMigrations.ts
@@ -95,3 +95,23 @@ export function migrateImageGeneration<
     backgroundSize: parseImageSpec(merged.backgroundSize),
   }
 }
+
+/**
+ * `llmThreshold` counted world-state *records*; the control that replaced it counts
+ * *words*, the same unit Entry Retrieval already used.
+ *
+ * The stored number is dropped rather than converted: 30 records and 500 words describe the
+ * same boundary only because a record happens to average ~16 words, and someone who raised
+ * the count to 100 was not asking for 1600 words of anything. The new default is calibrated
+ * to do what the old default did, which is a better answer than a guessed conversion.
+ *
+ * Dropping the key matters beyond tidiness: the store merges what is on disk over the
+ * defaults, so an unread key would be written back into every future save.
+ */
+export function migrateWorldStateBudget<T extends { tier3WholesaleWordBudget: number }>(
+  merged: T & { llmThreshold?: number },
+): T {
+  if (!('llmThreshold' in merged)) return merged
+  const { llmThreshold: _dropped, ...rest } = merged
+  return rest as T
+}

--- a/src/lib/stores/story.svelte.ts
+++ b/src/lib/stores/story.svelte.ts
@@ -47,6 +47,7 @@ import { aiService } from '$lib/services/ai'
 import { ChapterBatchService, type WorldState } from '$lib/services/generation'
 import { createLogger } from '$lib/log'
 import { grammarService } from '$lib/services/grammar'
+import { clearTier3SelectionCache } from '$lib/services/ai'
 
 const log = createLogger('StoryStore')
 
@@ -509,6 +510,7 @@ class StoryStore {
     this.invalidateWordCountCache()
     this.invalidateChapterCache()
     grammarService.clearEntityWords()
+    clearTier3SelectionCache()
   }
 
   // Close the current story and reset state
@@ -534,6 +536,9 @@ class StoryStore {
     // Clean up any orphaned embedded_images before loading
     // (fixes FK constraint issues from older data)
     await database.cleanupOrphanedEmbeddedImages()
+
+    // Whatever the previous story left cached is about a pool this one does not have.
+    clearTier3SelectionCache()
 
     this.currentStory = story
     this.currentBgImage = await database.getBackgroundForBranch(storyId, story.currentBranchId)
@@ -3834,6 +3839,11 @@ class StoryStore {
     // Invalidate caches
     this.invalidateWordCountCache()
     this.invalidateChapterCache()
+    // Two branches commonly sit at the same position with the same lorebook and differ
+    // only in history, which is the easiest way to hand one branch the other's Tier 3
+    // verdict. The key covers this on its own now; clearing keeps the cache from
+    // depending on that alone, as it already does on story switch.
+    clearTier3SelectionCache()
 
     // Reload background from database for the branch
     this.currentBgImage = await database.getBackgroundForBranch(this.currentStory.id, branchId)

--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -22,6 +22,16 @@ import type {
   ActivationTracker,
 } from '$lib/services/ai/retrieval/EntryRetrievalService'
 import type { RetrievalResult } from '$lib/services/generation/types'
+import type { WorldStateInjectionResult } from '$lib/services/ai/generation/WorldStateInjector'
+
+/** What a cached retrieval result was computed for. All four must match to reuse it. */
+export interface RetrievalCacheKey {
+  storyId: string
+  branchId: string | null
+  /** `story.entries.length` when retrieval ran, the user action included. */
+  position: number
+  actionContent: string
+}
 import type { SyncMode } from '$lib/types/sync'
 import { SimpleActivationTracker } from '$lib/services/ai/retrieval/EntryRetrievalService'
 import { database } from '$lib/services/database'
@@ -193,11 +203,13 @@ class UIStore {
   private currentStyleReviewStoryId = $state<string | null>(null)
   styleReviewStateWrite = Promise.resolve()
 
-  // Cached retrieval result (for regenerate skip)
+  // Cached retrieval result, reused by retry and regenerate to skip the whole phase.
   lastRetrievalResult = $state<RetrievalResult | null>(null)
+  private lastRetrievalKey: RetrievalCacheKey | null = null
 
   // Lorebook debug state
   lastLorebookRetrieval = $state<EntryRetrievalResult | null>(null)
+  lastWorldStateRetrieval = $state<WorldStateInjectionResult | null>(null)
   lorebookDebugOpen = $state(false)
 
   // Lorebook manager state
@@ -1146,8 +1158,8 @@ class UIStore {
    */
   clearGenerationCaches() {
     this.clearStyleReviewState()
-    this.lastRetrievalResult = null
-    this.lastLorebookRetrieval = null
+    this.setLastRetrievalResult(null)
+    this.setLastLorebookRetrieval(null, null)
   }
 
   /**
@@ -1213,13 +1225,37 @@ class UIStore {
   }
 
   // Retrieval cache methods
-  setLastRetrievalResult(result: RetrievalResult | null) {
+  setLastRetrievalResult(result: RetrievalResult | null, key: RetrievalCacheKey | null = null) {
     this.lastRetrievalResult = result
+    this.lastRetrievalKey = result ? key : null
+  }
+
+  /**
+   * The cached retrieval, but only if it was built for exactly this situation.
+   *
+   * Branch is part of the key because `switchBranch` does not clear this cache and must
+   * not reuse across branches: the same position on another branch is a different story.
+   * Position and action text cover the rest — a retry or a regenerate rewinds to the state
+   * the retrieval was computed in, so an unchanged key means unchanged inputs.
+   */
+  retrievalResultFor(key: RetrievalCacheKey): RetrievalResult | null {
+    const cached = this.lastRetrievalKey
+    if (!cached || !this.lastRetrievalResult) return null
+    const matches =
+      cached.storyId === key.storyId &&
+      cached.branchId === key.branchId &&
+      cached.position === key.position &&
+      cached.actionContent === key.actionContent
+    return matches ? this.lastRetrievalResult : null
   }
 
   // Lorebook debug methods
-  setLastLorebookRetrieval(result: EntryRetrievalResult | null) {
+  setLastLorebookRetrieval(
+    result: EntryRetrievalResult | null,
+    worldState: WorldStateInjectionResult | null = null,
+  ) {
     this.lastLorebookRetrieval = result
+    this.lastWorldStateRetrieval = worldState
   }
 
   openLorebookDebug() {
@@ -1446,6 +1482,18 @@ class UIStore {
     this.activationData = {}
     this.currentStoryPosition = 0
     this.currentActivationStoryId = null
+  }
+
+  /**
+   * Forget one entry's activation, so its carry-over ends now instead of at its countdown.
+   *
+   * Only the in-memory copy: the next retrieval writes the whole map back to the database
+   * through `updateActivationData`, so persisting here would be overwritten a turn later.
+   */
+  clearActivationFor(entryId: string) {
+    if (!(entryId in this.activationData)) return
+    const { [entryId]: _dropped, ...rest } = this.activationData
+    this.activationData = rest
   }
 
   /**

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,3 +1,4 @@
+import type { RetrievalSnapshot } from '$lib/services/ai/retrieval/retrievalSnapshot'
 // Core entity types for Aventura
 export type StoryMode = 'adventure' | 'creative-writing'
 export type POV = 'first' | 'second' | 'third'
@@ -163,6 +164,8 @@ export interface EntryMetadata {
   timeEnd?: TimeTracker // Story time after classification applied time progression
   // Translation fields (for backwards compatibility, also stored in columns)
   originalInput?: string // For translateInput: original user text before translation to English
+  /** What retrieval put in the prompt for this turn. Diagnostic only — nothing reads it back. */
+  retrievalSnapshot?: RetrievalSnapshot
 }
 
 export interface Character {

--- a/src/lib/utils/recentContent.test.ts
+++ b/src/lib/utils/recentContent.test.ts
@@ -56,4 +56,32 @@ describe('recentContent', () => {
     // Callers that need only narration filter before calling; this does not.
     expect(recentContent(entries, 3, AS_HAYSTACK)).toBe('two three four')
   })
+
+  describe('withRoles', () => {
+    const typed = (type: StoryEntry['type']): StoryEntry => ({ ...entry('said', 0), type })
+
+    it('labels who produced each entry', () => {
+      // The fixture alternates by index: 'three' is index 2, so it is the player's.
+      expect(recentContent(entries, 2, AS_PROSE, true)).toBe(
+        '[Player Action]: three\n\n[Narrator]: four',
+      )
+    })
+
+    it('never puts an internal type identifier in the prompt', () => {
+      // Nothing creates these today; they survive in stories saved by older versions.
+      const labelled = recentContent([typed('system'), typed('retry')], 2, AS_PROSE, true)
+
+      expect(labelled).not.toContain('[system]')
+      expect(labelled).not.toContain('[retry]')
+      expect(labelled).toBe('[System Note]: said\n\n[Narrator]: said')
+    })
+
+    it('calls a retry a narration, because that is what the model is being shown', () => {
+      expect(recentContent([typed('retry')], 1, AS_PROSE, true)).toBe('[Narrator]: said')
+    })
+
+    it('leaves the content untouched in the unlabelled form', () => {
+      expect(recentContent(entries, 2, AS_PROSE, false)).toBe('three\n\nfour')
+    })
+  })
 })

--- a/src/lib/utils/recentContent.ts
+++ b/src/lib/utils/recentContent.ts
@@ -20,6 +20,7 @@ export function recentContent(
   entries: StoryEntry[],
   count: number,
   separator: ' ' | '\n\n',
+  withRoles = false,
 ): string {
   // `slice(-0)` is `slice(0)` -- the whole array, not none of it. Every caller today is
   // bounded by a slider with a minimum of 2, or passes `entries.length`, so this never
@@ -27,10 +28,35 @@ export function recentContent(
   // which is the worst possible direction for an off-by-nothing to go.
   if (count <= 0) return ''
 
-  return entries
-    .slice(-count)
-    .map((e) => e.content)
-    .join(separator)
+  const sliced = entries.slice(-count)
+  if (!withRoles) {
+    return sliced.map((e) => e.content).join(separator)
+  }
+
+  return sliced.map((e) => `${roleLabel(e.type)}: ${e.content}`).join(separator)
+}
+
+/**
+ * What each entry type is called when the text is labelled for a model to read.
+ *
+ * A `Record` over the union, so a new entry type is a compile error here rather than an
+ * internal identifier appearing in a prompt. `retry` is an alternative narration and is
+ * labelled as one: a model told it was a retry treats the re-roll as an event.
+ */
+const ROLE_LABELS: Record<StoryEntry['type'], string> = {
+  user_action: '[Player Action]',
+  narration: '[Narrator]',
+  retry: '[Narrator]',
+  system: '[System Note]',
+}
+
+/**
+ * The fallback is not dead code: these rows come out of SQLite, where the column is a bare
+ * `TEXT` and an older save can hold a type the union says is impossible. `[Narrator]` is
+ * the safe guess — `[Player Action]` would assert the player said something.
+ */
+function roleLabel(type: StoryEntry['type']): string {
+  return ROLE_LABELS[type] ?? ROLE_LABELS.narration
 }
 
 /** Separator for text that will be pattern-matched, not read. */


### PR DESCRIPTION
Split out of #415. The largest of the four and the one worth the most review time.

Both selection services — **Entry Retrieval** (authored lorebook `Entry[]`) and **World State
Injection** (live tracked entities) — share the same three-tier shape. This reworks the
boundary between "include the leftover whole" and "ask a model which of it matters", and adds
a diagnostic for what actually reached the prompt.

## Include-All Budget

The boundary is now a **word budget on the candidate text**, in both services, replacing World
State's record count (`llmThreshold`).

30 records and 500 words describe the same line only because a live world-state record averages
~16 words. A lorebook entry averages ~69 — which is exactly why the two budgets differ
(500 / 1000) where one shared record count could not express the difference.

- The stored `llmThreshold` is **dropped, not converted**: someone who raised it to 100 was not
  asking for 1600 words of anything, and the new default is calibrated to do what the old
  default did. Dropping the key matters beyond tidiness — the store merges disk over defaults,
  so an unread key is written back into every future save forever.
- Advanced Settings relabels the whole group in those terms: *Include-All Budget*, *Ask the
  Model Above the Budget*, *Max LLM-Selected …*, and stops claiming Tier 3's cap means "there is
  no Tier 3" when selection is off — a leftover under the budget still goes in whole.

## Tier 3 selection

- **The cache returned a different entry set than the one it cached.** It is now keyed on the
  caller, the candidate pool *in order*, and the player's action, and bounded to
  `TIER3_SELECTION_CACHE_POSITIONS` story positions. Order is part of the key because the answer
  lives in index space, and `WorldStateInjector` builds its candidates from world state the
  classifier rewrites every turn. Cleared when the story it was about is no longer loaded, and
  it holds one entry per caller rather than one per question — see the second commit.
- **The model is asked for indices, not ids.** Ids are never rendered into the prompt, so it had
  never seen one. `selectedIds` → `selectedIndices` across the contract, and the prompt states
  the format. `resolveTier3Selection` tolerates `"1."`, `"#1"` and `"[1]"` coming back.
- **Wholesale-included entries no longer count as relevance activations.** They were not chosen
  for relevance, and treating them as if they were kept them sticky afterwards.
- A Tier 2 **second pass** (`tier2SecondPass.ts`) matches what is left against the *names* of
  what the first pass found, so an entry nobody named directly comes in when something that
  names it did. Names and aliases only — descriptions cross-reference each other by
  construction, so seeding with them pulls in half a dense lorebook in one step. Seeds shorter
  than 4 characters, and seeds contained in a longer seed, are dropped.
- `recentContent(..., withRoles)` labels the scene `[Player Action]` / `[Narrator]` for the
  selection prompt, instead of one undifferentiated block. `retry` is labelled `[Narrator]`: a
  model told it was a retry treats the re-roll as an event.

## Retrieval snapshots

`retrievalSnapshot.ts` records what each tier actually contributed, with token counts, and the
narration entry carries it in `metadata.retrievalSnapshot`. The in-memory copy dies with the
session, so without it the debug panel was empty on every fresh start and after every story
switch — exactly when you most want to know what the narrator is being told. Diagnostic only;
nothing reads it back into a prompt.

- The debug panel shows the injected **World State** block alongside the lorebook one, both
  collapsible.
- The toolbar badge counts the whole active context rather than lorebook entries alone, and the
  button is no longer gated on the lorebook having entries — every story has live world state.
  Reachable from the menu on narrow screens.
- **Stickiness is tracked in story positions, not turns.** A turn appends both an action and a
  narration, so a duration of N covers roughly N/2 turns; the panel converts for display.

## Fixes along the way

- `ActionInput` passed the **raw player text** to `generateResponse` while the entry the narrator
  reads holds `promptContent`. With translation on, retrieval and classification worked from a
  different wording than the narration — and the retry path already passed `promptContent`, so
  the two disagreed with each other.
- **Retry re-ran retrieval from scratch** — an entire agentic loop, now that agentic is the
  default mode — because the cached result was cleared before the call site read it.
- `create_entry` / `update_entry` lose `injectionMode` in the **lore management** toolset only.
  It runs unattended, and `always` is a budget decision past every retrieval threshold, made by
  an agent that cannot see the budget. The vault assistant keeps it, where the user reads the
  change before it lands. Removed from the schema rather than ignored afterwards: the schema is
  what the model is shown, so a parameter left in and discarded is a parameter it spends tokens
  choosing.
- The lore management prompt asks explicitly for duplicate consolidation via `update_entry` +
  `delete_entry`, rather than "merge" with no mechanism named.
- `buildWorldStateContext` / `getRelevantLorebookEntries` take an options object; the positional
  `signal` / `activationTracker` pair had already been passed in the wrong order once.

## Second commit — review fixes

- The selection cache held **one entry per distinct question, retained until the story was
  switched**. Only the most recent answer is ever reusable (the window is two positions wide), so
  every earlier key was growth with no hit rate behind it — and each key is every candidate id
  concatenated, several KB on a large lorebook, held for the whole session on a WebView heap that
  is a hard cap on Android. Now one entry per caller, with the question compared against the
  stored key.
- Comments still describing the World State threshold as a record count named `llmThreshold`.
- `splitTier1` and `splitTier3` had their doc comments stacked above `splitTier2`.

### Third commit

`splitTier3` treated a missing `llmSelected` as *selected*, pinned by a test describing "a
snapshot written before the flag existed" — a state that never existed, since the snapshot and
the flag ship in the same commit. All four producers set the flag, so this only decides how a
row from some later source reads; it now reads as wholesale. The two errors are not symmetric:
"LLM Selected" asserts a call was paid for, "Included Whole" only that the leftover fitted.

---

Base: `upstream/master`. Conflicts with #417 on `settings.svelte.ts` and `settingsMigrations.ts`
(both add a migration next to the other's) — whichever merges second resolves a three-line import
list. `check`, `lint` and the full Vitest suite (747 tests) pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a combined Active Context view for lorebook and world-state retrieval, including counts, token totals, tiers, carry-over status, reasons, and prompt previews.
  - Added Active Context access on mobile and for all current stories.
  - Added navigation, activation clearing, and demotion controls for retrieved entries.
  - Added configurable recent-entry windows and word budgets for retrieval.

- **Improvements**
  - Improved scene-aware matching, retrieval caching, stickiness, and regeneration consistency.
  - Added clearer retrieval settings descriptions and automatic migration to the new budget controls.
  - Improved lore-management guidance for detecting and merging duplicate entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->