### PR TITLE
Slice 3.4b — Retrieval wiring: per-turn phase, memory blocks, reader surfaces

### DIFF
--- a/app/reader-composer/[branchId].tsx
+++ b/app/reader-composer/[branchId].tsx
@@ -779,12 +779,11 @@ export default function ReaderComposerRoute() {
           // absent rather than a no-op handler that would still open the popover.
           {...(isGenerating || refreshingSuggestions
             ? {
+                // The run's own kind, not PER_TURN_KIND: findTurnRun matches on a
+                // denylist, so any foreground pipeline added later raises this
+                // Cancel and a hardcoded kind would abort a run that isn't there.
                 onCancel: () =>
-                  void awaitRunTerminal(
-                    isGenerating ? PER_TURN_KIND : SUGGESTION_REFRESH_KIND,
-                    branchId,
-                    'cancel',
-                  ),
+                  void awaitRunTerminal(turnKind ?? SUGGESTION_REFRESH_KIND, branchId, 'cancel'),
               }
             : {})}
           onErrorTap={(code) => {
@@ -878,7 +877,9 @@ export default function ReaderComposerRoute() {
                   const wrapped = wrapComposerText(rawText, { mode, pov: wrapPov, leadName })
                   void runSubmit(wrapped, mode, { text: rawText, mode })
                 }}
-                onCancel={() => void awaitRunTerminal(PER_TURN_KIND, branchId, 'cancel')}
+                onCancel={() =>
+                  void awaitRunTerminal(turnKind ?? PER_TURN_KIND, branchId, 'cancel')
+                }
               />
             </View>
           </View>

--- a/app/reader-composer/[branchId].tsx
+++ b/app/reader-composer/[branchId].tsx
@@ -6,11 +6,9 @@ import { Platform, View } from 'react-native'
 
 import { type ActionGroup } from '@/components/compounds/actions-menu'
 import { AppActionsMenu } from '@/components/compounds/app-actions-menu'
-import {
-  GenerationStatusPill,
-  type GenerationPhase,
-} from '@/components/compounds/generation-status-pill'
+import { GenerationStatusPill } from '@/components/compounds/generation-status-pill'
 import { Composer, type ComposerHandle } from '@/components/reader/composer'
+import { readerPillPhase } from '@/components/reader/generation-phase'
 import ReaderDocument, { type ReaderDocumentRef } from '@/components/reader/reader-document'
 import {
   type EditResult,
@@ -30,6 +28,7 @@ import { ScreenShell } from '@/components/shells/screen-shell'
 import { EmptyState } from '@/components/ui/empty-state'
 import { Text } from '@/components/ui/text'
 import { useGlobalHotkey } from '@/hooks/use-global-hotkey'
+import { useOpenRegionTokens } from '@/hooks/use-open-region-tokens'
 import { useTier } from '@/hooks/use-tier'
 import {
   clearSystemEntry,
@@ -78,6 +77,7 @@ import {
   isUserEditBlocked,
   rehydrateStories,
   storiesStore,
+  type TxState,
   undoRedoStore,
 } from '@/lib/stores'
 import { useTheme } from '@/lib/themes'
@@ -122,18 +122,26 @@ export default function ReaderComposerRoute() {
   )
 
   const editBlocked = generationStore.useGeneration((s) => isUserEditBlocked(s.txState))
-  // A suggestion refresh is not a turn: counting it here would swap Send for
-  // Cancel and raise the streaming placeholder over a branch that isn't
-  // streaming. Note this is only about the turn-shaped chrome — the refresh
-  // does hold the edit gate, so `editBlocked` above already covers undo/redo.
-  const isGenerating = generationStore.useGeneration((s) =>
-    // Narrative only: a refresh gets its own phase below, and a background kind
-    // (the classifier) must not light the streaming placeholder at all.
-    [...s.txState.runs.values()].some(
-      (r) =>
-        r.branchId === branchId && r.kind !== SUGGESTION_REFRESH_KIND && !isBackgroundKind(r.kind),
-    ),
+  // The phase, not a boolean: one source for whether a turn runs and what it
+  // does. Neither a refresh nor a background classifier pass is a turn — either
+  // counted here would swap Send for Cancel and raise the streaming placeholder
+  // over a branch that isn't streaming. Only the refresh is hard-gate, so
+  // `editBlocked` above still covers undo/redo for it.
+  // Two selectors over one predicate rather than one returning a pair: a fresh
+  // object per read would re-render the reader on every unrelated store write.
+  const findTurnRun = useCallback(
+    (s: { txState: TxState }) =>
+      [...s.txState.runs.values()].find(
+        (r) =>
+          r.branchId === branchId &&
+          r.kind !== SUGGESTION_REFRESH_KIND &&
+          !isBackgroundKind(r.kind),
+      ),
+    [branchId],
   )
+  const turnPhase = generationStore.useGeneration((s) => findTurnRun(s)?.currentPhase ?? null)
+  const turnKind = generationStore.useGeneration((s) => findTurnRun(s)?.kind ?? null)
+  const isGenerating = turnPhase !== null
   const refreshingSuggestions = generationStore.useGeneration((s) =>
     [...s.txState.runs.values()].some(
       (r) => r.branchId === branchId && r.kind === SUGGESTION_REFRESH_KIND,
@@ -208,17 +216,17 @@ export default function ReaderComposerRoute() {
   // A live loop reports through the Memory panel's own progress row instead.
   const swapPaused =
     storyId != null && openForBranch?.settings.embedding_swap_target != null && !swapRunningHere
+  // Composing is fine mid-swap; submitting is not. submitTurn refuses either way
+  // (a swap owns the vec tables), so gate here rather than let the user write a
+  // turn and take a failure entry for it.
+  const swapPending = swapRunningHere || swapPaused
 
-  // A suggestion refresh occupies the pill exactly like a turn does, and the
-  // pill prioritizes activePhase over error — so the two branches must be
-  // derived from one value, or a refresh would leave the warning tone visible.
-  const activePhase: GenerationPhase | undefined = isGenerating
-    ? 'generating-narrative'
-    : refreshingSuggestions
-      ? 'refreshing-suggestions'
-      : classifierRunning
-        ? 'classifying'
-        : undefined
+  const activePhase = readerPillPhase({
+    turnKind,
+    turnPhase,
+    refreshingSuggestions,
+    classifierRunning,
+  })
 
   // Buffer instances live in a ref (mutable, not render state); the safe output
   // they compute on each push drives the re-render via `streaming`.
@@ -448,7 +456,13 @@ export default function ReaderComposerRoute() {
         if (result.outcome === 'failed') await showTurnFailure(result.error, submission)
         else if (result.outcome === 'rejected')
           await showTurnFailure(
-            { kind: 'orchestrator', detail: `blocked by ${result.blockedBy}` },
+            {
+              kind: 'orchestrator',
+              // The detail line persists on the entry and renders to the user,
+              // so the prose is translated; blockedBy itself is a pipeline kind
+              // and stays verbatim as the diagnostic token.
+              detail: t('reader:systemEntry.blockedDetail', { reason: result.blockedBy }),
+            },
             submission,
           )
         else if (result.outcome === 'aborted')
@@ -479,10 +493,14 @@ export default function ReaderComposerRoute() {
     [entries],
   )
 
-  const { onRetry: retrySystemEntry, fixAction } = useSystemEntryActions(systemFailure, () => {
-    const submission = lastSubmission ?? systemFailure?.submission
-    if (submission) void runSubmit(submission.content, submission.composerMode)
-  })
+  const { onRetry: retrySystemEntry, fixAction } = useSystemEntryActions(
+    systemFailure,
+    () => {
+      const submission = lastSubmission ?? systemFailure?.submission
+      if (submission) void runSubmit(submission.content, submission.composerMode)
+    },
+    storyId,
+  )
 
   const dismissSystemEntry = useCallback(async () => {
     await clearSystemEntry(branchId, ctx)
@@ -718,6 +736,7 @@ export default function ReaderComposerRoute() {
   )
 
   const jumpButtonEnabled = appSettingsStore.useAppSettings((s) => s.appearance.showJumpToBottom)
+  const openRegionPct = useOpenRegionTokens(openForBranch?.storyId)
   const { theme } = useTheme()
 
   const surfaceProps = {
@@ -740,7 +759,7 @@ export default function ReaderComposerRoute() {
     <ScreenShell
       variant="in-story"
       title={<Text className="font-semibold">{storyTitle ?? t('reader:placeholderTitle')}</Text>}
-      chapterProgress={0}
+      chapterProgress={openRegionPct}
       onBack={() => router.back()}
       onOpenStorySettings={() => {
         if (storyId != null) router.push(`/story-settings/${storyId}`)
@@ -750,13 +769,11 @@ export default function ReaderComposerRoute() {
         <GenerationStatusPill
           activePhase={activePhase}
           error={
-            activePhase != null
-              ? undefined
-              : swapPaused
-                ? { code: 'swap-paused' }
-                : staleTotal > 0
-                  ? { code: 'memory-incomplete', pendingRows: staleTotal }
-                  : undefined
+            swapPaused
+              ? { code: 'swap-paused' }
+              : staleTotal > 0
+                ? { code: 'memory-incomplete', pendingRows: staleTotal }
+                : undefined
           }
           // A background classifier pass has no cancel affordance, so the prop is
           // absent rather than a no-op handler that would still open the popover.
@@ -844,16 +861,18 @@ export default function ReaderComposerRoute() {
                 ref={composerRef}
                 modesEnabled={modesEnabled}
                 isGenerating={isGenerating}
-                disabled={!hydrationSucceeded}
+                disabled={!hydrationSucceeded || swapPending}
                 sendBlocked={editBlocked}
                 disabledReason={
                   hydrationFailed
                     ? t('reader:hydrationFailedBody')
                     : !hydrationSucceeded
                       ? t('reader:hydrationLoading')
-                      : editBlocked
-                        ? t('reader:actions.blockedWhileGenerating')
-                        : undefined
+                      : swapPending
+                        ? t('reader:actions.blockedWhileSwapping')
+                        : editBlocked
+                          ? t('reader:actions.blockedWhileGenerating')
+                          : undefined
                 }
                 onSend={(rawText, mode) => {
                   const wrapped = wrapComposerText(rawText, { mode, pov: wrapPov, leadName })

--- a/app/story-settings/[storyId].tsx
+++ b/app/story-settings/[storyId].tsx
@@ -30,6 +30,7 @@ import {
 import { EmptyState } from '@/components/ui/empty-state'
 import { Text } from '@/components/ui/text'
 import { useMasterDetailBack } from '@/hooks/use-master-detail-back'
+import { useOpenRegionTokens } from '@/hooks/use-open-region-tokens'
 import { useTier } from '@/hooks/use-tier'
 import { useUnsavedChangesGuard } from '@/hooks/use-unsaved-changes-guard'
 import { StorySettingsStaleStoreError, updateStorySettings } from '@/lib/actions'
@@ -152,6 +153,11 @@ function StorySettingsSurface({ storyId }: { storyId: string | undefined }) {
       )
     : undefined
 
+  // Scoped to THIS route's story: the open story survives navigation, so an
+  // unscoped read would show whichever story the session last opened in the
+  // reader against that story's threshold.
+  const openRegionPct = useOpenRegionTokens(storyId)
+
   const isDirty = session.snapshot.dirtyFields.length > 0
   useUnsavedChangesGuard(isDirty, session.requestLeave)
 
@@ -247,7 +253,7 @@ function StorySettingsSurface({ storyId }: { storyId: string | undefined }) {
             : t('storySettings:title')}
         </Text>
       }
-      chapterProgress={0}
+      chapterProgress={openRegionPct}
       hideSelfReferentialIcon
       onBack={handleBack}
       actions={<AppActionsMenu beforeNavigate={session.requestLeave} />}

--- a/components/compounds/generation-status-pill.stories.tsx
+++ b/components/compounds/generation-status-pill.stories.tsx
@@ -47,6 +47,16 @@ export const ActiveReasoning: Story = {
   ),
 }
 
+export const ActiveRecallingMemory: Story = {
+  render: () => (
+    <GenerationStatusPill
+      activePhase="recalling-memory"
+      onCancel={onCancel}
+      onErrorTap={onErrorTap}
+    />
+  ),
+}
+
 export const ActiveGeneratingNarrative: Story = {
   render: () => (
     <GenerationStatusPill
@@ -60,6 +70,18 @@ export const ActiveGeneratingNarrative: Story = {
 export const ActiveClassifying: Story = {
   render: () => (
     <GenerationStatusPill activePhase="classifying" onCancel={onCancel} onErrorTap={onErrorTap} />
+  ),
+}
+
+// `onCancel` is passed and deliberately has no effect: the background pass is
+// cancel-less, so the tag carries no popover trigger.
+export const ActiveUpdatingMemory: Story = {
+  render: () => (
+    <GenerationStatusPill
+      activePhase="updating-memory"
+      onCancel={onCancel}
+      onErrorTap={onErrorTap}
+    />
   ),
 }
 
@@ -137,8 +159,8 @@ export const ActivePlusError: Story = {
   render: () => (
     <View className="gap-2">
       <Text variant="muted" size="sm">
-        Both inputs set — activePhase wins per principles.md → Affordance loci (active &gt; error
-        &gt; hidden).
+        Both inputs set and the phase is blocking — activePhase wins, since it also carries the only
+        way to cancel the run.
       </Text>
       <GenerationStatusPill
         activePhase="generating-narrative"
@@ -148,6 +170,33 @@ export const ActivePlusError: Story = {
       />
     </View>
   ),
+}
+
+export const BackgroundPhasePlusError: Story = {
+  render: () => {
+    const tap = fn()
+    tapSpy = tap
+    return (
+      <View className="gap-2">
+        <Text variant="muted" size="sm">
+          Both inputs set and the phase is non-blocking — the error wins. `swap-paused` needs a
+          decision, so a cadence-driven pass must not blank it.
+        </Text>
+        <GenerationStatusPill
+          activePhase="updating-memory"
+          error={{ code: 'swap-paused' }}
+          onCancel={onCancel}
+          onErrorTap={tap}
+        />
+      </View>
+    )
+  },
+  play: async () => {
+    const pill = await screen.findByText(t('chrome.generationStatusPill.error.swapPaused'))
+    await userEvent.click(pill)
+    // Still routes: yielding the slot has to yield the affordance with it.
+    expect(tapSpy).toHaveBeenCalledWith('swap-paused')
+  },
 }
 
 export const PhonePopover: Story = {

--- a/components/compounds/generation-status-pill.tsx
+++ b/components/compounds/generation-status-pill.tsx
@@ -3,17 +3,40 @@ import { useRef, type ComponentRef } from 'react'
 import { Button } from '@/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Spinner } from '@/components/ui/spinner'
-import { Tag } from '@/components/ui/tag'
+import { Tag, type TagTone } from '@/components/ui/tag'
 import { Text } from '@/components/ui/text'
 import { useTier } from '@/hooks/use-tier'
 import { t } from '@/lib/i18n'
+import type { ThemeColorSlots } from '@/lib/themes'
 
 type GenerationPhase =
   | 'reasoning'
+  | 'recalling-memory'
   | 'generating-narrative'
   | 'classifying'
+  | 'updating-memory'
   | 'closing-chapter'
   | 'refreshing-suggestions'
+
+// `blocking` is whether the phase holds the turn up, and it drives both columns
+// beside it and the priority rule below. A blocking phase also owns the cancel
+// affordance, so it keeps the slot even against an error; a background one drops
+// the accent fill and yields, since nothing is lost by waiting for it and the
+// error may be waiting on the user. Tracked separately from a null `cancelCopy`,
+// which the two coincide with today only because the one background phase is
+// also the one nothing can cancel.
+const PHASE_APPEARANCE: Record<
+  GenerationPhase,
+  { blocking: boolean; tone: TagTone; spinnerSlot: keyof ThemeColorSlots }
+> = {
+  reasoning: { blocking: true, tone: 'accent', spinnerSlot: '--accent-fg' },
+  'recalling-memory': { blocking: true, tone: 'accent', spinnerSlot: '--accent-fg' },
+  'generating-narrative': { blocking: true, tone: 'accent', spinnerSlot: '--accent-fg' },
+  classifying: { blocking: true, tone: 'accent', spinnerSlot: '--accent-fg' },
+  'updating-memory': { blocking: false, tone: 'default', spinnerSlot: '--fg-muted' },
+  'closing-chapter': { blocking: true, tone: 'accent', spinnerSlot: '--accent-fg' },
+  'refreshing-suggestions': { blocking: true, tone: 'accent', spinnerSlot: '--accent-fg' },
+}
 
 // `memory-incomplete` names the observable state, not a cause: the pill fires
 // off a non-zero stale-row count, which an available embedder can produce too
@@ -31,8 +54,8 @@ type ErrorState =
 type GenerationStatusPillProps = {
   activePhase?: GenerationPhase
   error?: ErrorState
-  // Absent for phases with no cancel affordance (e.g. a background classifier
-  // pass) — the pill then shows the phase with no popover trigger.
+  // Ignored for phases `cancelCopy` marks cancel-less, so a caller that can't
+  // tell which phase is up may pass it unconditionally.
   onCancel?: () => void
   onErrorTap: (code: ErrorState['code']) => void
 }
@@ -41,10 +64,14 @@ function phaseCopy(phase: GenerationPhase): string {
   switch (phase) {
     case 'reasoning':
       return t('chrome.generationStatusPill.phase.reasoning')
+    case 'recalling-memory':
+      return t('chrome.generationStatusPill.phase.recallingMemory')
     case 'generating-narrative':
       return t('chrome.generationStatusPill.phase.generatingNarrative')
     case 'classifying':
       return t('chrome.generationStatusPill.phase.classifying')
+    case 'updating-memory':
+      return t('chrome.generationStatusPill.phase.updatingMemory')
     case 'closing-chapter':
       return t('chrome.generationStatusPill.phase.closingChapter')
     case 'refreshing-suggestions':
@@ -67,12 +94,16 @@ function errorCopy(error: ErrorState): string {
 
 // Exhaustive switch rather than a default-carrying ternary: a new phase must
 // fail the build here instead of silently inheriting "Cancel generation".
-function cancelCopy(phase: GenerationPhase): string {
+// `null` is the cancel-less answer — nothing the user started, nothing to stop.
+function cancelCopy(phase: GenerationPhase): string | null {
   switch (phase) {
     case 'reasoning':
+    case 'recalling-memory':
     case 'generating-narrative':
     case 'classifying':
       return t('chrome.generationStatusPill.cancelGeneration')
+    case 'updating-memory':
+      return null
     case 'closing-chapter':
       return t('chrome.generationStatusPill.cancelChapterClose')
     case 'refreshing-suggestions':
@@ -89,15 +120,20 @@ export function GenerationStatusPill({
   const tier = useTier()
   const triggerRef = useRef<ComponentRef<typeof PopoverTrigger>>(null)
 
-  // Priority: active generation > error state > hidden.
-  if (activePhase != null) {
+  // Priority: blocking phase > error state > background phase > hidden.
+  if (activePhase != null && (PHASE_APPEARANCE[activePhase].blocking || error == null)) {
     const isPhone = tier === 'phone'
+    const appearance = PHASE_APPEARANCE[activePhase]
     const tag = (
-      <Tag tone="accent" leading={<Spinner size="sm" colorSlot="--accent-fg" />}>
+      <Tag
+        tone={appearance.tone}
+        leading={<Spinner size="sm" colorSlot={appearance.spinnerSlot} />}
+      >
         {isPhone ? null : phaseCopy(activePhase)}
       </Tag>
     )
-    if (onCancel == null) return tag
+    const cancelLabel = cancelCopy(activePhase)
+    if (onCancel == null || cancelLabel == null) return tag
     return (
       <Popover>
         <PopoverTrigger ref={triggerRef}>{tag}</PopoverTrigger>
@@ -109,7 +145,7 @@ export function GenerationStatusPill({
               onCancel()
             }}
           >
-            <Text>{cancelCopy(activePhase)}</Text>
+            <Text>{cancelLabel}</Text>
           </Button>
         </PopoverContent>
       </Popover>

--- a/components/reader/generation-phase.test.ts
+++ b/components/reader/generation-phase.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+
+import { readerPillPhase } from './generation-phase'
+
+const IDLE = {
+  turnKind: null,
+  turnPhase: null,
+  refreshingSuggestions: false,
+  classifierRunning: false,
+}
+const TURN = { ...IDLE, turnKind: 'per-turn' }
+
+describe('readerPillPhase', () => {
+  it('gives the blocking retrieval phase its own label instead of the narrative one', () => {
+    expect(readerPillPhase({ ...TURN, turnPhase: 'retrieval' })).toBe('recalling-memory')
+  })
+
+  // The per-turn phase map does not cover other foreground pipelines, so without
+  // a kind check chapter-close borrows its labels and disagrees with the same
+  // run's label in Story Settings.
+  it('labels a chapter-close run by kind rather than borrowing a per-turn label', () => {
+    expect(
+      readerPillPhase({ ...IDLE, turnKind: 'chapter-close', turnPhase: 'chapter-metadata' }),
+    ).toBe('closing-chapter')
+  })
+
+  it('labels the narrative phase as narrative generation', () => {
+    expect(readerPillPhase({ ...TURN, turnPhase: 'narrative' })).toBe('generating-narrative')
+  })
+
+  it('labels the fallback classifier as classifying', () => {
+    expect(readerPillPhase({ ...TURN, turnPhase: 'piggyback-fallback-classifier' })).toBe(
+      'classifying',
+    )
+  })
+
+  it('keeps the pre-retrieval label over the turn opening translation phase', () => {
+    expect(readerPillPhase({ ...TURN, turnPhase: 'user-action-translation' })).toBe(
+      'generating-narrative',
+    )
+  })
+
+  it('labels the window before phase 0 names itself', () => {
+    expect(readerPillPhase({ ...TURN, turnPhase: '' })).toBe('generating-narrative')
+  })
+
+  it('falls back rather than blanking the pill on an unmapped phase name', () => {
+    expect(readerPillPhase({ ...TURN, turnPhase: 'some-future-phase' })).toBe(
+      'generating-narrative',
+    )
+  })
+
+  it('reports a suggestion refresh when no turn is running', () => {
+    expect(readerPillPhase({ ...IDLE, refreshingSuggestions: true })).toBe('refreshing-suggestions')
+  })
+
+  // The periodic classifier is a background run, so it never reaches turnPhase
+  // and would otherwise leave the pill empty for the length of the pass.
+  it('reports the periodic classifier when no turn or refresh is running', () => {
+    expect(readerPillPhase({ ...IDLE, classifierRunning: true })).toBe('updating-memory')
+  })
+
+  // Both run the classifier, but only the in-turn one blocks the composer, and
+  // the pill's tone and cancel affordance key off the distinction.
+  it('separates the background pass from the blocking in-turn fallback', () => {
+    expect(readerPillPhase({ ...IDLE, classifierRunning: true })).not.toBe(
+      readerPillPhase({ ...IDLE, turnPhase: 'piggyback-fallback-classifier' }),
+    )
+  })
+
+  // A turn aborts an in-flight refresh and both runs can sit in txState across
+  // that handoff; the turn owns the pill, and the pill must never go empty
+  // while either runs (the memory error would take the slot).
+  it('lets a running turn win over a refresh', () => {
+    expect(readerPillPhase({ ...IDLE, turnPhase: 'retrieval', refreshingSuggestions: true })).toBe(
+      'recalling-memory',
+    )
+  })
+
+  // The classifier runs concurrently with a turn by design, so both flags are
+  // set for most of a pass; the foreground phase is the one worth naming.
+  it('lets a running turn win over the periodic classifier', () => {
+    expect(readerPillPhase({ ...IDLE, turnPhase: 'retrieval', classifierRunning: true })).toBe(
+      'recalling-memory',
+    )
+  })
+
+  it('lets a refresh win over the periodic classifier', () => {
+    expect(readerPillPhase({ ...IDLE, refreshingSuggestions: true, classifierRunning: true })).toBe(
+      'refreshing-suggestions',
+    )
+  })
+
+  it('hides when nothing is running', () => {
+    expect(readerPillPhase(IDLE)).toBeUndefined()
+  })
+})

--- a/components/reader/generation-phase.ts
+++ b/components/reader/generation-phase.ts
@@ -1,0 +1,52 @@
+import type { GenerationPhase } from '@/components/compounds/generation-status-pill'
+import type { PerTurnPhaseName } from '@/lib/pipeline'
+
+// `satisfies` is the guard: a phase added to the per-turn pipeline widens
+// PerTurnPhaseName and fails the build here until it has a label.
+const PILL_PHASE_BY_TURN_PHASE: Record<string, GenerationPhase | undefined> = {
+  'user-action-translation': 'generating-narrative',
+  retrieval: 'recalling-memory',
+  narrative: 'generating-narrative',
+  'piggyback-fallback-classifier': 'classifying',
+} satisfies Record<PerTurnPhaseName, GenerationPhase>
+
+// Kind wins over phase: the map above only covers per-turn, so a second
+// foreground pipeline would otherwise borrow its labels and read "generating
+// narrative" here while Story Settings reads the real one for the same run.
+// Story Settings carries the matching entry in generation-run.ts.
+const PILL_PHASE_BY_RUN_KIND: Record<string, GenerationPhase | undefined> = {
+  'chapter-close': 'closing-chapter',
+}
+
+// A run holds the pill from the moment it enters txState, which is before phase
+// 0 names itself (RunState.currentPhase starts empty). Blanking there would hand
+// the slot to the sticky memory error mid-turn, so an unnamed phase keeps the
+// generic label.
+const UNMAPPED_TURN_PHASE: GenerationPhase = 'generating-narrative'
+
+/**
+ * Resolves the reader's status-pill phase from live run state. `turnKind` and
+ * `turnPhase` are the `kind` and `currentPhase` of the foreground non-refresh
+ * run on this branch, both null when no turn is running. Background runs are
+ * excluded from them, so the periodic classifier reaches the pill through
+ * `classifierRunning` instead.
+ *
+ * @returns The pill phase, or undefined when the pill should hide.
+ */
+export function readerPillPhase(input: {
+  turnKind: string | null
+  turnPhase: string | null
+  refreshingSuggestions: boolean
+  classifierRunning: boolean
+}): GenerationPhase | undefined {
+  if (input.turnPhase !== null)
+    return (
+      (input.turnKind === null ? undefined : PILL_PHASE_BY_RUN_KIND[input.turnKind]) ??
+      PILL_PHASE_BY_TURN_PHASE[input.turnPhase] ??
+      UNMAPPED_TURN_PHASE
+    )
+  if (input.refreshingSuggestions) return 'refreshing-suggestions'
+  // Not 'classifying': that phase is the per-turn piggyback fallback, which does
+  // hold the turn up. Same work, opposite answer to "can I keep writing?".
+  return input.classifierRunning ? 'updating-memory' : undefined
+}

--- a/components/reader/reader-surface.stories.tsx
+++ b/components/reader/reader-surface.stories.tsx
@@ -1,8 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite'
 
 import type { StoryEntry } from '@/lib/db'
+import { t } from '@/lib/i18n'
 
 import { ReaderSurface } from './reader-surface'
+import { describeTurnFailure } from './system-entry-actions'
 
 const NOW = 1752900000000
 
@@ -106,6 +108,16 @@ export const Streaming: Story = {
   },
 }
 
+// Composed through describeTurnFailure rather than literals so each bubble shows
+// the copy the pipeline would actually persist, magnitude suffix included.
+const PROVIDER_FAILURE = describeTurnFailure({
+  kind: 'provider',
+  reason: 'auth',
+  detail: 'provider returned 401 — invalid API key',
+})
+
+// No fix action: useSystemEntryActions yields one only for config-resolver and
+// embedder failures, so a provider bubble carries Retry and Dismiss alone.
 export const SystemFailure: Story = {
   args: {
     rows: [
@@ -113,14 +125,39 @@ export const SystemFailure: Story = {
       entry({
         id: 'e6',
         kind: 'system',
-        content: 'The turn could not be completed.',
+        content: PROVIDER_FAILURE.content,
         position: 6,
         metadata: {
           ...BASE_META,
-          systemFailure: { kind: 'provider', detail: 'Provider returned 401 — invalid API key.' },
+          systemFailure: { kind: 'provider', detail: PROVIDER_FAILURE.detail },
         },
       }),
     ],
-    systemFixLabel: 'Fix provider',
+  },
+}
+
+const EMBED_FAILURE = describeTurnFailure({
+  kind: 'embedder',
+  reason: 'call',
+  detail: 'embedding request failed: 503',
+  staleCount: 2,
+})
+
+export const EmbedderFailure: Story = {
+  args: {
+    rows: [
+      ...ROWS,
+      entry({
+        id: 'e6',
+        kind: 'system',
+        content: EMBED_FAILURE.content,
+        position: 6,
+        metadata: {
+          ...BASE_META,
+          systemFailure: { kind: 'embedder', detail: EMBED_FAILURE.detail },
+        },
+      }),
+    ],
+    systemFixLabel: t('reader:systemEntry.switchEmbedder'),
   },
 }

--- a/components/reader/system-entry-actions.test.tsx
+++ b/components/reader/system-entry-actions.test.tsx
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { entryMetadataSchema, type SystemFailureMeta } from '@/lib/db'
+import { t } from '@/lib/i18n'
+import type { PipelineError } from '@/lib/pipeline'
+import { embedderSwapStore } from '@/lib/stores'
+
+import {
+  describeTurnFailure,
+  toSystemFailureMeta,
+  useEmbedderFixAction,
+  useSystemEntryActions,
+} from './system-entry-actions'
+
+const router = vi.hoisted(() => ({
+  navigate: vi.fn<(href: string) => void>(),
+  push: vi.fn<(href: string) => void>(),
+}))
+
+vi.mock('expo-router', () => ({ useRouter: () => router }))
+
+beforeEach(() => {
+  embedderSwapStore.__reset()
+  router.navigate.mockReset()
+  router.push.mockReset()
+})
+
+afterEach(cleanup)
+
+const EMBEDDER_INIT: PipelineError = {
+  kind: 'embedder',
+  reason: 'init',
+  detail: 'no model',
+  staleCount: 3,
+}
+
+describe('describeTurnFailure', () => {
+  it('renders embedder-specific copy with the stale row count', () => {
+    const out = describeTurnFailure(EMBEDDER_INIT)
+    expect(out.content).toBe(t('reader:systemEntry.failure.embed'))
+    expect(out.detail).toBe('init: no model (3 rows)')
+  })
+
+  // Only a sync-stage failure past the dirty-set load carries a count; config
+  // unresolved, dim unknown, a failed load and both query-embed branches all
+  // report null. Rendering that absence as a number is the "(null rows)" bug.
+  it('drops the magnitude when staleCount is null', () => {
+    const out = describeTurnFailure({
+      kind: 'embedder',
+      reason: 'call',
+      detail: 'provider 503',
+      staleCount: null,
+    })
+    expect(out.content).toBe(t('reader:systemEntry.failure.embed'))
+    expect(out.detail).toBe('call: provider 503')
+  })
+
+  // No path emits zero today (sync.ts short-circuits an empty dirty set to ok),
+  // but the field is declared `number | null` — this pins the guard to that
+  // contract, so a `staleCount &&` regression can't slip through reading 0 as absent.
+  it('renders a zero count rather than treating it as absent', () => {
+    const out = describeTurnFailure({
+      kind: 'embedder',
+      reason: 'call',
+      detail: 'drained',
+      staleCount: 0,
+    })
+    expect(out.detail).toBe('call: drained (0 rows)')
+  })
+
+  it('still renders provider copy for a provider failure', () => {
+    const out = describeTurnFailure({ kind: 'provider', reason: 'auth', detail: '401' })
+    expect(out.content).toBe(t('reader:systemEntry.failure.llmCall'))
+    expect(out.detail).toBe('auth: 401')
+  })
+
+  it('still renders config-resolver copy for a resolver failure', () => {
+    const out = describeTurnFailure({
+      kind: 'config-resolver',
+      failure: 'no-profile-assigned',
+      target: 'narrative',
+      phaseName: 'narrative',
+      detail: 'narrative',
+    })
+    expect(out.content).toBe(t('reader:systemEntry.failure.noProfileAssigned'))
+  })
+
+  it('falls back to the generic message for an unrecognised kind', () => {
+    const out = describeTurnFailure({ kind: 'orchestrator', detail: 'blocked by per-turn' })
+    expect(out.content).toBe(t('reader:systemEntry.failureMessage'))
+  })
+})
+
+describe('toSystemFailureMeta', () => {
+  it("persists the embedder kind and the branch's detail line", () => {
+    const meta = toSystemFailureMeta(EMBEDDER_INIT, undefined)
+    expect(meta).toEqual({ kind: 'embedder', detail: 'init: no model (3 rows)' })
+  })
+
+  // SystemFailureMeta.kind is an open z.string(); the round trip is what proves
+  // 'embedder' survives a restart without narrowing the schema.
+  it('round-trips through the persisted metadata schema', () => {
+    const meta = toSystemFailureMeta(EMBEDDER_INIT, {
+      content: 'I open the door',
+      composerMode: 'do',
+    })
+    const parsed = entryMetadataSchema.parse({
+      sceneEntities: [],
+      currentLocationId: null,
+      worldTime: 0,
+      systemFailure: meta,
+    })
+    expect(parsed.systemFailure).toEqual(meta)
+  })
+})
+
+describe('useEmbedderFixAction', () => {
+  it('routes to the Memory panel and opens the swap dialog', () => {
+    const { result } = renderHook(() => useEmbedderFixAction('story_1'))
+    expect(result.current?.label).toBe(t('reader:systemEntry.switchEmbedder'))
+
+    act(() => result.current?.onPress())
+
+    expect(router.navigate).toHaveBeenCalledWith('/story-settings/story_1?tab=memory')
+    expect(embedderSwapStore.getState().dialog).toEqual({ storyId: 'story_1' })
+  })
+
+  it('drops the action when no story is resolved', () => {
+    const { result } = renderHook(() => useEmbedderFixAction(null))
+    expect(result.current).toBeUndefined()
+  })
+})
+
+describe('useSystemEntryActions', () => {
+  const onRetry = () => {}
+
+  function actionsFor(failure: SystemFailureMeta | undefined, storyId: string | null = 'story_1') {
+    return renderHook(() => useSystemEntryActions(failure, onRetry, storyId)).result.current
+  }
+
+  it('offers Switch embedder for an embedder failure', () => {
+    expect(actionsFor({ kind: 'embedder' }).fixAction?.label).toBe(
+      t('reader:systemEntry.switchEmbedder'),
+    )
+  })
+
+  it('still offers the config fix for a resolver failure', () => {
+    expect(
+      actionsFor({ kind: 'config-resolver', failure: 'profile-missing' }).fixAction?.label,
+    ).toBe(t('reader:systemEntry.fixProfile'))
+  })
+
+  it('offers no fix action for a provider failure', () => {
+    expect(actionsFor({ kind: 'provider' }).fixAction).toBeUndefined()
+  })
+
+  it('offers no fix action for an embedder failure with no story resolved', () => {
+    expect(actionsFor({ kind: 'embedder' }, null).fixAction).toBeUndefined()
+  })
+})

--- a/components/reader/system-entry-actions.tsx
+++ b/components/reader/system-entry-actions.tsx
@@ -4,6 +4,7 @@ import type { ResolveFailureKind } from '@/lib/ai'
 import type { SystemFailureMeta } from '@/lib/db'
 import { t } from '@/lib/i18n'
 import type { PipelineError } from '@/lib/pipeline'
+import { openEmbedderSwapDialog } from '@/lib/stores'
 
 export type SystemEntryFixAction = { label: string; onPress: () => void } | undefined
 
@@ -27,6 +28,18 @@ export function describeTurnFailure(error: PipelineError | undefined): {
           ? 'reader:systemEntry.failure.profileMissing'
           : 'reader:systemEntry.failure.providerMissing'
     return { content: t(contentKey), detail: error.detail }
+  }
+  if (error?.kind === 'embedder') {
+    // One string for every embedder failure: `reason` is lossy — the shared
+    // classifyEmbedderFailure (lib/retrieval/sync.ts) buckets any untyped throw
+    // (a locked DB, a bug) into 'init' on both the sync-stage and query-embed
+    // paths, so copy keyed off it would name a cause we don't have. The real one
+    // rides in `detail`.
+    const magnitude = error.staleCount != null ? ` (${error.staleCount} rows)` : ''
+    return {
+      content: t('reader:systemEntry.failure.embed'),
+      detail: `${error.reason}: ${error.detail}${magnitude}`,
+    }
   }
   return { content: t('reader:systemEntry.failureMessage'), detail: error?.detail }
 }
@@ -63,12 +76,30 @@ export function useConfigFixAction(
   return { label: t(labelKey), onPress: () => router.push('/settings?tab=providers') }
 }
 
+// components/story-settings/memory-panel.tsx is the swap dialog's only mount
+// host, so the action has to route there — opened from the reader alone, the
+// dialog has nowhere to render.
+export function useEmbedderFixAction(storyId: string | null): SystemEntryFixAction {
+  const router = useRouter()
+  if (storyId === null) return undefined
+  return {
+    label: t('reader:systemEntry.switchEmbedder'),
+    onPress: () => {
+      router.navigate(`/story-settings/${storyId}?tab=memory`)
+      openEmbedderSwapDialog(storyId)
+    },
+  }
+}
+
 export function useSystemEntryActions(
   failure: SystemFailureMeta | undefined,
   onRetry: () => void,
+  storyId: string | null,
 ): { onRetry: () => void; fixAction: SystemEntryFixAction } {
-  const fixAction = useConfigFixAction(
+  const configFix = useConfigFixAction(
     failure?.kind === 'config-resolver' ? failure.failure : undefined,
   )
-  return { onRetry, fixAction }
+  const embedderFix = useEmbedderFixAction(failure?.kind === 'embedder' ? storyId : null)
+  // The two gates are kind-exclusive, so the `??` order carries no meaning.
+  return { onRetry, fixAction: embedderFix ?? configFix }
 }

--- a/components/story-settings/memory-panel.stories.tsx
+++ b/components/story-settings/memory-panel.stories.tsx
@@ -2,7 +2,12 @@ import type { Meta, StoryObj } from '@storybook/react-native-web-vite'
 import { View } from 'react-native'
 import { expect, screen, userEvent, waitFor, within } from 'storybook/test'
 
-import { APP_SETTINGS_DEFAULTS, storySettingsSchema, type StorySettings } from '@/lib/db'
+import {
+  APP_SETTINGS_DEFAULTS,
+  STORY_SETTINGS_DEFAULTS,
+  storySettingsSchema,
+  type StorySettings,
+} from '@/lib/db'
 import { t } from '@/lib/i18n'
 import {
   appSettingsStore,
@@ -26,7 +31,7 @@ function buildSettings(overrides: Partial<StorySettings> = {}): StorySettings {
     piggybackMode: 'on',
     embeddingBackend: 'local',
     embedding_model_id: MINILM,
-    retrievalBudgets: { entities: 8, lore: 6, happenings: 6, threads: 4, chapters: 3 },
+    retrievalBudgets: STORY_SETTINGS_DEFAULTS.retrievalBudgets,
     composerModesEnabled: true,
     composerWrapPov: 'third',
     suggestionsEnabled: true,

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -206,6 +206,60 @@ for the placement rule.
   covers. Surfaced 2026-07-31 reviewing
   [Slice 3.3](./implementation/milestones/03-memory-floor/slices/03-classifier.md).
 
+- **Q3's Medium-weight signals are English-shaped and fail silently.**
+  [`retrieval.md → Q3`](./memory/retrieval.md#q3-heuristic-prose-extract)
+  scores five signals; the two High ones (entity-name, lore-keyword) are
+  language-agnostic by construction — `matchTerms` uses `\p{L}\p{N}`
+  lookarounds specifically so accented and Cyrillic names match. Both
+  Medium ones are not, and neither degrades loudly.
+  - **Action verbs.** `ACTION_VERBS` (`lib/retrieval/prose-extract.ts`)
+    is 13 hardcoded English simple-past verbs matched by exact
+    `Set.has`, no stemming. `stories.settings.definition.narration`
+    offers `first | second | third` with **no tense axis**, so
+    second-person present ("You draw the blade") — a first-class
+    supported register — hits none of them: `drew` scores, `draws` /
+    `draw` / `drawing` do not. There is also no narrative-language
+    setting at all (`translation.targetLanguage` is the translation
+    _target_; entries store the original), so a story written in
+    Spanish or Russian scores zero on this signal permanently. And it
+    false-positives on names: `words` is lowercased before lookup, so
+    "**Drew** nodded." fires the verb weight, and if Drew is an entity
+    the same token also fires the entity weight — one word, two
+    signals, no action. `Said` has the same problem.
+  - **Dialogue spans.** `DIALOGUE_SPAN` covers `"…"`, `“…”` and
+    `‘…’` and misses `«…»` (French, Russian), `„…”` (German, Polish,
+    Czech) and `「…」` (CJK). Same weight, same silent miss, but
+    unlike the verb list this one is a three-alternative regex change
+    with no linguistics in it — worth taking on its own if the wider
+    redesign stalls.
+  - **Brevity** is character-counted (`BREVITY_MAX_CHARS = 90`), so in
+    CJK it fires on nearly every sentence and stops discriminating.
+  - **CJK is never split into sentences at all**, which sits upstream
+    of every signal above. `splitSentences` terminates on `[.!?…]`
+    followed by whitespace; CJK uses ideographic terminators and no
+    inter-sentence space, so a whole entry collapses to one
+    "sentence". Q3 then embeds the full 400-1000 token entry — the
+    cost the extract exists to avoid — and `scores` degenerates to a
+    single meaningless number, emptying the probe's per-sentence
+    capture. Verified against the shipped splitter (2026-08-06):
+    a three-sentence Japanese passage returns one element.
+    [`name-index.ts`](../lib/retrieval/name-index.ts) documents CJK as
+    out of scope for word-boundary matching; nothing documents it for
+    splitting, so this reads as an oversight rather than a deferral.
+    Whatever replaces the scorer has to own this first.
+
+  Failure is silent throughout: when every sentence scores 0,
+  `extractProse` still returns top-K by source-order tie-break, so Q3
+  quietly degrades to "the first 4 sentences" while carrying its full
+  `w_prose = 0.30` share of the blend. One redesign direction worth
+  arguing: drop the hardcoded list for a set derived from the branch's
+  own happening titles, which the classifier writes in the story's
+  language — self-localizing, no linguistics, reuses an index the pass
+  already builds. Mildly circular, hence a discussion rather than a
+  patch. Touches the canon signal table, so it is a spec change, not
+  only a code change. Surfaced 2026-08-06 reviewing
+  [Slice 3.4](./implementation/milestones/03-memory-floor/slices/04-retrieval.md).
+
 ## Tooling
 
 - **`pnpm test:run` over the whole repo cannot be read as a gate.** A

--- a/docs/generation-pipeline.md
+++ b/docs/generation-pipeline.md
@@ -396,8 +396,24 @@ bug, not a runtime case to handle.
   (commit fires a regular `delta_emitted` for the entry's
   `op=create`).
 
-**Never:** SQLite calls, delta-log appends, persisted-store
-mutations, another phase's intermediates.
+**Never:** delta-loggable writes outside `delta_emitted`, delta-log
+appends, persisted-store mutations, another phase's intermediates.
+
+**Reads are fine** — a phase resolves tail positions and working sets
+against `ctx.db`, which is why the handle is on `PhaseContext` at all.
+
+**One carve-out for non-delta-logged writes.** The prohibition
+protects the delta log and the undo contract, so it binds writes that
+belong in that contract. Derived infrastructure state that is
+deterministic from source rows, carries no undo payload and is never
+reverse-replayed sits outside it. The retrieval phase's vec0 sync is
+the only such writer: it embeds `embedding_stale` rows and clears
+their flags in one transaction, per
+[`retrieval.md → Compute lifecycle`](./memory/retrieval.md#compute-lifecycle).
+Routing it through `delta_emitted` would append undo rows for
+embeddings that a CTRL-Z must not remove. Such a phase takes
+`ctx.runInTransaction` rather than the module-global handle, so its
+writes and the run's reads cannot land on different databases.
 
 ### Abort
 
@@ -1328,7 +1344,30 @@ type PipelineError =
       constraintViolated?: string // 'UNIQUE' | 'CHECK' | 'FK' | etc.
     }
   | { kind: 'orchestrator'; detail: string } // abort-path wrap (catches DeltaReplayError, etc.)
+  | {
+      kind: 'config-resolver'
+      failure: ResolveFailureKind // resolver could not produce a usable model config
+      target: ResolveTarget
+      phaseName: string
+      detail?: string
+    }
+  | {
+      kind: 'embedder'
+      reason: EmbedderErrorKind // 'init' | 'call'
+      detail: string
+      staleCount: number | null // rows the blocking sync was embedding; null when unknown
+    }
 ```
+
+**`embedder`** covers the blocking pre-retrieval sync stage and the
+query embed beside it, per
+[`model-management.md → Embed failure is blocking`](./memory/model-management.md).
+Distinct from `provider`, whose retry story is the LLM's: this one
+offers **Switch embedder**, so only a genuine embedder fault may
+carry it. A failure inside the retrieval pass that says nothing about
+the stored vectors — a locked database, a bug — escapes as
+`orchestrator` instead, which surfaces the generic message with no
+misleading fix action.
 
 Categories drive how UI surfaces them — toast for transient,
 banner / dialog for persistent.

--- a/docs/implementation/lessons-learned/README.md
+++ b/docs/implementation/lessons-learned/README.md
@@ -135,6 +135,10 @@ slice plans when relevant.
   — a `typeof window` guard around a Node-only `require()` is safe under
   Metro but can crash every Storybook story importing that module; alias
   the specifier to a stub in `viteFinal`, don't touch the guard.
+- [Token-counting fixtures must be prose, not a repeated character](./token-fixtures-need-real-prose.md)
+  — `'x'.repeat(4000)` reaches tiktoken's byte-pair loop as one word and
+  costs ~620 ms against ~0 ms for prose of the same length; the tell is a
+  timeout that only ever fires on CI.
 - [The `unit` Vitest project cannot render RN-Web component chrome](./unit-project-no-rn-web-chrome.md)
   — `@rn-primitives/*`'s un-transpiled `.mjs` JSX and `react-native-svg` /
   `lucide-react-native` / `nativewind`'s externalized `require('react-native')`

--- a/docs/implementation/lessons-learned/token-fixtures-need-real-prose.md
+++ b/docs/implementation/lessons-learned/token-fixtures-need-real-prose.md
@@ -1,0 +1,51 @@
+# Token-counting fixtures must be prose, not a repeated character
+
+`'x'.repeat(4000)` and 4000 characters of ordinary text are the same
+length and nowhere near the same cost to tokenize:
+
+| fixture             | tokens | encode |
+| ------------------- | ------ | ------ |
+| `'x'.repeat(400)`   | 50     | 26 ms  |
+| `'x'.repeat(4000)`  | 500    | 620 ms |
+| 400 chars of prose  | 89     | ~0 ms  |
+| 4000 chars of prose | 889    | ~0 ms  |
+
+## Why
+
+`js-tiktoken` splits input on a word-boundary regex before it merges
+anything. A run of one repeated character contains no boundary, so it
+reaches the byte-pair loop as a **single word** and each merge pass
+rescans the whole sequence — quadratic in the length of that one word.
+Prose splits into many short words that merge independently, which is
+why its cost stays flat as length grows.
+
+The `o200k` encoder build is a separate one-time ~272 ms, paid by the
+first `countTokens` call in a process.
+
+## How to apply
+
+Any fixture that reaches the real `countTokens` / `countEntryTokens`
+(`lib/retrieval/tokens.ts`) gets prose. Length can be whatever the test
+needs — it is the absence of word boundaries that costs, not the size:
+
+```ts
+// Not this
+const LONG = 'x'.repeat(4000)
+// This
+const LONG = 'the quick brown fox jumps over the lazy dog. '.repeat(90)
+```
+
+A fixture feeding a **stubbed** counter is unaffected, and rewriting it
+buys nothing: `lib/retrieval/ranker.test.ts` injects
+`(t) => Math.ceil(t.length / 4)` and keeps `'x'.repeat(4000)` safely.
+Check whether the real encoder is reachable before changing anything.
+
+## Why it reads as flake
+
+The cost is invisible until the machine is slow enough. Five `LONG`
+encodes in `hooks/use-open-region-tokens.test.tsx` ran in ~1.3 s per
+test locally and passed; the same tests timed out at vitest's 5 s
+default on CI. A CI-only timeout in a token-counting test is a fixture
+smell first and an infrastructure problem second — measure an encode
+before reaching for `testTimeout`. Raising the timeout would have kept
+a 600 ms-per-call fixture in a suite that runs on every push.

--- a/docs/implementation/milestones/03-memory-floor/milestone.md
+++ b/docs/implementation/milestones/03-memory-floor/milestone.md
@@ -348,10 +348,12 @@ cross-slice routing verifies at integration once both are merged
   entire commit and surfaces the retry surface.
 - **Sync-before-read holds.** A turn following classifier writes
   runs the pre-retrieval sync stage and KNN sees the fresh rows;
-  a forced embed failure at the sync stage blocks the turn with
-  `Retry / Switch embedder / Roll back this turn` and the next-turn
-  affordance disabled; rows still stale at retrieval are excluded
-  from candidates (vitest each).
+  a forced embed failure at the sync stage fails the turn (which the
+  orchestrator reverse-replays) and surfaces
+  `Switch embedder / Retry / Dismiss` — no rollback action and no
+  composer gate, since a resubmit re-runs the same blocking sync
+  stage; rows still stale at retrieval are excluded from candidates
+  (vitest each).
 - **Swap crash-safety.** Kill the app mid-re-index; on next story
   open the resume / cancel prompt appears; resume completes the
   stage-then-flip, cancel deletes staged NEW-model vectors and

--- a/docs/implementation/milestones/03-memory-floor/slices/04-retrieval.md
+++ b/docs/implementation/milestones/03-memory-floor/slices/04-retrieval.md
@@ -34,10 +34,18 @@ Scoring blends three query similarities, decays by chapter age
 scaled by the pin signal, adds keyword boosts, and revives
 deeply-decayed rows on very high similarity; MMR de-dupes within
 each type; hard-partitioned per-type token budgets fill greedily
-and stop at the noise floor. Chapter summaries and the
-chapter-match boost are structurally present but inert until M5
-closes chapters. The ranker must be a pure module — the probe's
-simulator re-runs it bit-for-bit.
+and stop at the noise floor. The ranker must be a pure module —
+the probe's simulator re-runs it bit-for-bit.
+
+Everything chapter-shaped is structurally present but inert until
+M5 closes chapters: chapter summaries, the chapter-match boost, and
+recency decay. Decay is inert because `chaptersOld` has no source
+until chapters exist, so it is assembled as `0` for every candidate
+and `recency_factor` collapses to `1`. That also neutralises the pin
+signal, which only ever appears as a scale on the decay exponent —
+so `decay_resistance` is recorded by the classifier and read by the
+ranker without being able to move a score. See
+[Open questions](#open-questions) for the shape M5 should land.
 
 ## Required reading
 
@@ -74,10 +82,11 @@ simulator re-runs it bit-for-bit.
 - **Pre-retrieval sync stage:** batch-embed `embedding_stale` rows
   via C1 at the head of the retrieval phase (inserted before the
   narrative phase through the C6 phase-list seam); blocking failure
-  surface (`Retry / Switch embedder / Roll back this turn`,
-  next-turn affordance disabled — the switch action imports 3.1b's
-  swap-dialog open action per C8); stale-at-KNN rows excluded from
-  pools.
+  surface (`Switch embedder / Retry / Dismiss` — no rollback action,
+  the orchestrator already reverse-replayed the turn, and no composer
+  gate, since a resubmit re-runs the same blocking sync stage; the
+  switch action imports 3.1b's swap-dialog open action per C8);
+  stale-at-KNN rows excluded from pools.
 - **Query stack:** Q1 user action; Q2 structural digest
   (code-template floor + optional piggyback `summary` enrichment,
   handed off by 3.2's parse);
@@ -160,6 +169,10 @@ simulator re-runs it bit-for-bit.
   (~43 ms per KNN query at 10k rows on flagship Android) on desktop
   (logged timing, not a CI gate).
 
+Status at close — criteria 2 through 6 met, criterion 1 met in part,
+criterion 7 met by the timing log — is recorded under
+[Notable deviations from the brief](#notable-deviations-from-the-brief).
+
 ## Tests
 
 - Vitest: pure-ranker matrix (the load-bearing suite), query
@@ -174,30 +187,184 @@ simulator re-runs it bit-for-bit.
 ## Open questions
 
 - **Where does the sync-failure `Switch embedder` action land the
-  user?** The C8 import (`openEmbedderSwapDialog`, carried from
-  [Slice 3.1b](./01b-embedder-lifecycle.md#implementation-notes))
-  opens dialog state whose only mount host is the Story Settings
-  route's Memory panel — calling it from a reader-side failure
-  surface without navigating first is a silent no-op. 3.1b's own
-  pill routes via the story-settings route with the memory tab
-  preselected; decide whether the sync-failure surface navigates
-  the same way before opening the dialog, or grows a reader-side
-  dialog host.
-- **Entity-name / keyword index shape** — in-memory per-branch
-  index rebuilt on hydrate vs SQL-side matching; Q3 and Layer A
-  share it.
-- **Per-type overhead constants** — measured after the memory
-  macros are concrete; record the measured values.
+  user?** — **resolved:** it navigates the story-settings route with
+  the memory tab preselected and then opens the dialog, matching
+  3.1b's pill rather than growing a reader-side host. The dialog
+  state is sticky, so the ordering is a readability choice, not a
+  race: the Memory panel is simply the only mount host, and a route
+  that never gets there renders the open nowhere.
+- **Entity-name / keyword index shape** — **resolved:** neither
+  option as posed. The index is built in memory from the source rows
+  the pass has already loaded, so it costs no query of its own and
+  cannot drift from the rows the floor and the pools are reading.
+  Q3 and Layer A share it.
+- **Per-type overhead constants** — **resolved:** measured against
+  the shipped macro; the values and what shapes them are canon at
+  [`retrieval.md → Token estimation`](../../../../memory/retrieval.md#token-estimation),
+  the measurement narrative is in
+  [Per-type overhead constants](#per-type-overhead-constants) below.
 - **vec0 returns L2 distance, not cosine similarity** — the
   `0005_embedder_vec0.sql` tables declare no `distance_metric`, so
   KNN ranks by raw L2. That matches cosine ranking only because
   every stored and query vector is unit-norm, an invariant 3.1a's
   embedder facade enforces on every embed rather than something the
-  vec0 layer guarantees. The ranker has to convert each `distance`
-  column back to a similarity via `cos = 1 − d²/2` before scoring or
-  tracing, not treat distance as already-cosine. Carried over from
-  3.1a implementation (2026-07-20).
+  vec0 layer guarantees. Carried over from 3.1a implementation
+  (2026-07-20). **Resolved, and not the way this question assumed:**
+  no `cos = 1 − d²/2` conversion exists anywhere. `knnQuery` returns
+  the `embedding` column on the match row — vec0 gives it up for
+  almost nothing, whereas fetching vectors by id afterwards would
+  scan the partition — so the ranker computes cosine over the vectors
+  themselves. `distance` is carried for logging and never scored, and
+  L2 order is only relied on for which rows vec0 hands back.
+- **How should `chaptersOld` be sourced once M5 closes chapters?** —
+  **deferred to M5, with the shape decided:** store the chapter a row
+  belongs to and subtract at rank time, rather than materialising a
+  `chapters_old` column that every chapter close would have to
+  rewrite across every row. Immutable input, no write amplification,
+  and nothing to drift. Happenings need no schema change — they carry
+  `occurred_at_entry_id`, and the pass already loads the entry-to-
+  chapter map through `loadChapterRanges` for the chapter-match
+  boost. Entities, lore and threads need a created-at-chapter column.
+  Until then `chaptersOld` is `0` and both decay and the pin signal
+  are inert; see [Background](#background).
 
 ## Implementation notes
 
-_Populated at finish: notable deviations from the plan and resolved developer decisions._
+### Per-type overhead constants
+
+Method: render exactly one row of a block with an empty
+`renderedText` through the shipped `macro_memory_blocks`
+(`lib/prompts/bundled/memory-blocks.ts`) and count the remainder with
+the same `countTokens` the ranker uses. The measurement is a test
+assertion, not a one-off script —
+`lib/prompts/bundled/memory-blocks.test.ts` fails, naming the file and
+the new value, when the macro moves and
+`RANKER_DEFAULTS.typeOverhead` does not.
+
+The canon estimates were 2-5x high across the board: entities 30 → 11,
+lore 10 → 4, happenings 20 → 5, threads 10 → 4, chapters 20 → 4. The
+values and the rules that shape them are canon at
+[`retrieval.md → Token estimation`](../../../../memory/retrieval.md#token-estimation).
+
+Chapters measured 6 before the title moved off its `##` line and into
+`renderedText`. Measured at the default
+`retrievalBudgets.chapters = 600` with a 14-token title and 36-token
+`summary` + `theme`: budget-fill seated 14 rows charged at 588 that
+rendered **732 — a 132-token, 22% overrun of a hard partition**,
+scaling with title length times row count. The same shape after the
+move seats 10 rows charged at 550 that render 514, i.e. back to
+under-filling. Chapters were the only block putting a variable-length
+string outside `renderedText`.
+
+Three `lib/retrieval/ranker.test.ts` budget cases moved: they encoded
+the old `10 text + 20 overhead = 30` row cost as literal budgets
+(`60`, `35`). They now derive the budget from
+`RANKER_DEFAULTS.typeOverhead.happenings`, so they assert budget-fill
+semantics rather than a constant's current value.
+
+### Resolved developer decisions
+
+- **`retrievalBudgets` needed migration 0007.** Task 3 restated the key
+  as token budgets where it had held row counts, and
+  `stories.settings.retrievalBudgets` carries no schema default — so a
+  pre-slice story kept a count-shaped number that sits below
+  `RANKER_DEFAULTS.typeOverhead` on its own, and budget-fill would have
+  seated zero rows of every type for the life of that story with
+  nothing reporting it. `0007_retrieval_budget_tokens.sql` rewrites the
+  key unconditionally, which is safe only because story creation is the
+  one writer it has ever had: no stored value can be a user-chosen
+  token budget worth preserving.
+- **Canon's `[Roll back this turn]` action was removed, across six
+  sites.** `abortRun` reverse-replays every delta written under the
+  run's `actionId`, and `submitTurn` writes the turn's `user_action`
+  entry under that same id — so the turn is already gone when the
+  failure bubble is written, and the action would have offered to
+  reverse nothing.
+  [`model-management.md → Embed failure is blocking`](../../../../memory/model-management.md#embed-failure-is-blocking)
+  justified it with a per-row half-commit that the no-inline-embed
+  contract at
+  [`retrieval.md → Compute lifecycle`](../../../../memory/retrieval.md#compute-lifecycle)
+  makes unreachable; the two were reconciled in favour of the latter,
+  and the shipped surface is `Switch embedder / Retry / Dismiss`.
+- **Q2's structural inputs are derived from the floor, not accepted
+  from the caller.** `RetrievalParams.query` omits `sceneEntityNames`,
+  `currentLocationName` and `activeThreadTitles` from
+  `QueryStackInput`, and `runRetrieval` fills all three from
+  `buildStructuralFloor`'s output. That closes the two-sources-of-truth
+  seam the plan flagged: a caller was otherwise free to describe a
+  scene the floor had not seated, embedding a digest of a scene the
+  prompt never rendered.
+- **Per-type budgets are not reduced by the floor.**
+  [`retrieval.md → Structural floor takes budget first`](../../../../memory/retrieval.md#structural-floor-takes-budget-first)
+  subtracts the floor from the **window**, not from each type's
+  partition — which is why the recent buffer, a floor member with no
+  retrieval type of its own, appears in that list at all. `runRetrieval`
+  therefore passes `settings.retrievalBudgets` to `rankAll` unmodified.
+  Subtracting per type would have silently redefined the user's own
+  sliders every turn. The window-level accounting canon describes is
+  unbuilt and filed in [triage](../../../triage.md).
+
+### Notable deviations from the brief
+
+- **Both bundled templates dropped the `| recent:` filter, not just
+  `per-turn.ts`.** The window is composed in code now, by
+  `composePromptBuffer` (`lib/retrieval/buffer.ts`) per
+  [`cadence.md → Composition rule`](../../../../memory/cadence.md#composition-rule);
+  a Liquid re-trim on top of it discards entries whenever the composed
+  window is wider than `partialChapterBuffer` — under
+  `fullChapterInBuffer`, or with a `protectedBuffer` above
+  `partialChapterBuffer` — and does it silently. The plan scheduled
+  only `per-turn.ts`; `suggestion-refresh.ts` carried the same filter.
+- **The structural floor renders, beyond the ranked bundles the plan
+  scheduled.** `macro_memory_blocks`
+  (`lib/prompts/bundled/memory-blocks.ts`) renders
+  `structuralActiveThreads` and the three `structuralPinned*` bundles
+  beside each ranked one. `buildStructuralFloor` seats every
+  `injection_mode='always'` row and every active thread, and
+  `filterEntityPool` / `filterLorePool` / `filterThreadPool` then
+  exclude what the floor seated — so a template rendering only the
+  ranked bundles would have dropped both classes outright the moment
+  retrieval shipped, against
+  [`retrieval.md → Structural floor`](../../../../memory/retrieval.md#structural-floor--always-inject).
+- **Chapter titles and thread status live inside `renderedText`, so the
+  ranker charges for them.** A string the macro renders but the
+  candidate's text omits is costed nowhere and overruns its partition
+  by its own length times the row count — measured at 22% for chapter
+  titles under
+  [Per-type overhead constants](#per-type-overhead-constants). Thread
+  status is the same move for a different reason: the pool is pending /
+  resolved / failed, and a bare title hands the model a resolved thread
+  that reads as an open one.
+- **Three tasks the plan did not have.** The **E2E retrofit**: a
+  blocking phase ahead of narrative means a turn without an embedder
+  model on disk fails before any reply renders, which broke eight
+  specs, one of them (`reader-composer-modes`) having passed until then
+  only by winning a race against reverse-replay — 4/4 failures on
+  repeat. The **generation-status pill's phase label**, which until then
+  claimed "generating narrative" while the app was embedding. And
+  **`selectedLocationIds`**, without which the `<current_location>`
+  instruction named only the location already seated; piggyback reads an
+  omitted tag as inherit, so the model had no way to report a location
+  change at all.
+- **Acceptance criterion 1 is met only in part.** Its injection-mode
+  invariants are pinned at both layers — `lib/retrieval/pools.test.ts`
+  runs the full status × mode × in-scene × is-location matrix, and
+  `lib/prompts/bundled/structural-floor.test.ts` covers the rendered
+  side with a permanent negative fixture — but "within each type's
+  budget" is asserted only inside the ranker
+  (`funnel.tokensUsed` against `funnel.typeBudget`, over a stub
+  tokenizer), never against a rendered prompt. It holds by
+  construction, since budget-fill decrements by the same estimate the
+  macro renders and the per-row header slack runs in the safe
+  direction; nothing measures it. Criteria 2 through 6 are met as
+  written.
+- **Criterion 7 is met by `retrieval.timing`, and the number it reports
+  is a concern.** The retrieval phase logs `RetrievalTimings`
+  (`totalMs` plus disjoint `syncMs` / `embedMs` / `knnMs` / `rankMs`
+  spans) on every pass. Measured cost overshoots
+  [`retrieval.md → Per-turn cost budget`](../../../../memory/retrieval.md#per-turn-cost-budget)
+  at the volumes
+  [`Scale assumptions`](../../../../memory/retrieval.md#scale-assumptions)
+  projects for 60 chapters, and the budget table has no line for most
+  of what the shipped pass does. Filed in
+  [triage](../../../triage.md) with the measurements.

--- a/docs/implementation/milestones/03-memory-floor/slices/05-dev-probe.md
+++ b/docs/implementation/milestones/03-memory-floor/slices/05-dev-probe.md
@@ -121,6 +121,47 @@ trustworthy.
   constants (tuning surface parked); the snapshot should read the
   same constants module so the simulator diff is honest. Confirm at
   planning.
+- **The outcome exposes text-presence, not the presence the ranker
+  blended.** `RetrievalOutcome` returns `queries` (whose `presence`
+  means "this query's text was non-empty"), while `runRetrieval`
+  re-derives a second triple from the vectors actually returned and
+  blends on that one — a short embed result nulls a slot the flag
+  still reports present. A replay reconstructing the blend from the
+  captured `queries.presence` therefore reproduces a **different**
+  `simBlend` than the run it is replaying, on exactly the case the
+  derivation exists to handle. Either capture the vector-presence
+  triple, or fold presence into `Candidate.sims` as
+  `readonly [number | null, number | null, number | null]` — `null`
+  meaning "no query vector", which `0` currently cannot be
+  distinguished from — and delete the second type. Surfaced by the
+  M3.4 review (2026-08-06).
+- **`StructuralFloor` declares a narrower shape than it holds.** The
+  floor is built over loaded source rows, so every row still carries
+  `embeddingStale` (and lore's `keywords`) at runtime; only
+  `generation-context.ts`'s projection drops them. A capture that
+  serialises `floor.sceneEntities` whole ships those fields into the
+  payload with no error. Project at construction, or make
+  `buildStructuralFloor` generic over the row types so the wider
+  value is visible rather than silently erased. Surfaced by the M3.4
+  review (2026-08-06).
+- **The barrel exports the ranker functions without their input
+  types.** `rankAll` / `rankPerType` are public; `RankAllInput` and
+  `RankTypeInput` are not, so a replay caller can invoke them but
+  cannot name their argument except as
+  `Parameters<typeof rankAll>[0]`. `QueryWeights` (the type of
+  `RankerParams.weights`) is likewise unexported.
+  [`code-conventions.md → Module structure`](../../../../code-conventions.md#module-structure)
+  makes types part of the public API. Surfaced by the M3.4 review
+  (2026-08-06).
+- **`RankerParams` needs validation at the point a capture feeds
+  it.** The ranker defends `pinSignal` and `chaptersOld` and says why
+  — "pin_signal arrives unvalidated from the probe's per-row
+  override" — while the nine tunables share that source and get
+  nothing. `lambdaDiv` at 0 makes every type select nothing silently;
+  `tauRevive` below 0 bypasses the decay model entirely. The
+  constants are frozen as of M3.4, so code cannot retune them; a
+  stored capture can. Add an `assertRankerParams` at the capture
+  reader. Surfaced by the M3.4 review (2026-08-06).
 
 ## Implementation notes
 

--- a/docs/implementation/triage.md
+++ b/docs/implementation/triage.md
@@ -398,7 +398,26 @@ here`, `Flip era`, the edit textarea's `Edit entry content`, `Save` /
   `recentEntries` would fix it but changes what already-merged piggyback
   behavior sends the model, so it needs an owner and a token-cost
   measurement before anyone touches it. Surfaced by M3.7a Task 1
-  (2026-07-25).
+  (2026-07-25). **M3.4 added two more consumers of the same raw
+  column, both in retrieval.** (1) Q3's prose extract runs over
+  `lastNarrative.content`, and the tail survives sentence splitting as
+  a single pseudo-sentence — `splitSentences` needs terminator plus
+  whitespace, which `</summary>` and `</state>` never provide — that
+  scores above real narrative (measured 5 against 0–3 on the shipped
+  scorer, since the `<summary>` line names entities and the XML
+  attribute quotes register as dialogue). One of Q3's four slots is
+  spent on tags, opaque ids, and suggested actions the story did not
+  take, which is what
+  [`retrieval.md → Q3`](../memory/retrieval.md#q3-heuristic-prose-extract)
+  exists to avoid. (2) Layer-A same-name suppression scans
+  `composePromptBuffer(...).content`, so a reader clicking a
+  suggestion that names a staged entity suppresses that entity from
+  the pool on the very turn it is introduced — the "who is this
+  person" failure the structural floor exists to prevent, arriving
+  through the mechanism meant to prevent collisions. Stripping at the
+  caller fixes all three consumers at once; the retrieval module
+  cannot do it itself, since it has no way to know which tags a pack
+  emits. Surfaced by the M3.4 review (2026-08-06).
 - **`runPreflight` omits `storyModels` from the `ResolveModelConfig` it
   builds, so a story-level model override can't satisfy pre-flight even
   though the runtime call resolves fine.** `lib/pipeline/runtime/preflight.ts`
@@ -870,3 +889,647 @@ here`, `Flip era`, the edit textarea's `Edit entry content`, `Save` /
   changes a shared UI contract, so it wants a design pass rather than a
   drive-by. Cross-cutting: every `disabledReason` consumer, present and
   future. Predates M3.7b; surfaced by the M3.7b review (2026-08-01).
+- **`retrieval.md`'s MMR cost model understates measured cost by ~2.5x,
+  and its complexity claim doesn't match the shipped algorithm.**
+  [`retrieval.md → Per-turn cost budget`](../memory/retrieval.md#per-turn-cost-budget)
+  budgets "<5ms per type" for MMR after the top-200 pre-filter, and
+  [`Diversity — MMR`](../memory/retrieval.md#diversity--mmr) calls it
+  "sub-millisecond" for pools in the hundreds. Measured on the M3.4
+  implementation (Node 24 / V8, desktop, `Candidate`-shaped payloads,
+  N=200): **6.55 ms at dim 384 and 12.32 ms at dim 768**. dim 768 is a
+  shipped config — `onnx-community/embeddinggemma-300m-ONNX` in
+  `catalog-data.json` — so five types cost ~61 ms of the doc's ~100 ms
+  total per-turn target before anything else runs. Restructuring is
+  **not** the lever: a `Uint8Array` bitmap variant measured only 10-18%
+  faster, and the irreducible cosine floor alone is 4.34 ms at N=200.
+  Separately the doc states MMR is `O(N × K)`, but C4's per-candidate
+  trace requires a rank for every candidate that entered MMR
+  (`CandidateTrace.mmrRank` is documented as null only for pre-filtered
+  rows), which forces the full `O(N²)` greedy ranking — roughly 5x the
+  work the cost model assumes. The implementation is correct; the
+  budget line was written against a different algorithm. Wants either a
+  corrected budget or an explicit decision that the trace contract is
+  worth the cost. **Open sub-question, unmeasured:** `retrieval.md`'s
+  PoC puts a 384-dim dot at ~24-30 µs on Hermes; if that holds, 19,900
+  dots is ~500 ms per type on mobile, which would dominate the turn.
+  Nobody has run MMR on-device. Surfaced by M3.4 Task 5 review
+  (2026-08-01).
+- **Lore `priority` is inert in the shipped ranker, and a user-facing
+  control promises otherwise.** Two canon statements conflict.
+  [`retrieval.md → Per-type decay rates`](../memory/retrieval.md#per-type-decay-rates)
+  says lore "ranks purely on `sim_blend × (priority/100) + kw_boost`",
+  and [`world.md → Lore detail`](../ui/screens/world/world.md) exposes a
+  0-100 `priority` input whose tooltip repeats that formula. But the
+  authoritative [Pseudocode](../memory/retrieval.md#pseudocode) puts
+  `pin_signal` **only** inside the recency exponent, and λ_lore is 0 —
+  so the exponent is 1 regardless and `priority` cannot move a lore
+  row's score at all. Verified empirically against the M3.4
+  implementation: `pinSignal: 1` and `pinSignal: 0` produce identical
+  `finalScore` for lore. Note the alternative formula is also wrong as
+  literally written — multiplying by `priority/100` would zero every
+  lore row at the default `priority = 0`. This also makes probe.md's
+  simulatable "`pin_signal` overrides" a dead control for lore. M3.4
+  followed the pseudocode (the designated authority) and is not at
+  fault; canon needs a design decision on what `priority` should
+  actually do. Blocks nothing in M3.4; blocks the World panel's lore
+  editor meaning what it says. Surfaced by M3.4 Task 6 review
+  (2026-08-01).
+- **Token estimation costs ~180x its budgeted line, for the same
+  reason MMR does.** [`retrieval.md → Per-turn cost budget`](../memory/retrieval.md#per-turn-cost-budget)
+  budgets "Token estimation — <1ms total". Measured with the production
+  `countTokens` (js-tiktoken `cl100k_base`) on ~69-token rows:
+  **60.5 µs/row, ~181 ms for 3000 rows**. C4's per-candidate trace
+  makes `CandidateTrace.tokensEstimated` non-nullable, so every pool
+  row must be tokenized, not just the ones budget-fill reaches — the
+  same trace-contract-vs-cost-model tension already recorded for MMR
+  above. One concrete mitigation exists with **zero contract loss**:
+  `preFilterTopN` is absent from
+  [`probe.md → Simulatable parameters`](../memory/probe.md#simulatable-parameters),
+  so a pre-filtered row can never be seated by the simulator at any
+  threshold or budget — meaning the pre-filtered excess need not be
+  tokenized at all. Capping eager tokenization at the kept ≤200/type
+  would cut the worst case from ~3000 rows to ~1000 (~181 ms → ~60 ms).
+  It requires making `tokensEstimated` nullable for pre-filtered rows,
+  which is a C4 trace-shape change and therefore wants a deliberate
+  C4 decision pass. Surfaced by M3.4 Task 6 review (2026-08-01).
+- **The high-similarity bypass is mathematically inert under the
+  default parameter set — it can never change which rows get
+  injected.** [`retrieval.md → High-similarity bypass`](../memory/retrieval.md#high-similarity-bypass--revival-of-decayed-memories)
+  spends 48 lines specifying revival of decayed memories, and
+  [`probe.md`](../memory/probe.md#what-gets-captured--light-mode-default)
+  captures a `bypass_triggered` column for it — but with v1's defaults
+  it cannot seat a single row. The bypass is a `max`, so it only binds
+  when `sim_blend − τ_revive` beats the normal score, and that floor is
+  capped at `1.0 − 0.85 = 0.15`. Budget-fill then compares the **MMR**
+  score against `min_score_threshold`, and a first pick (empty `S`, no
+  diversity penalty) is `λ_div × score = 0.75 × 0.15 = 0.1125` — below
+  the 0.15 floor. Even at a theoretically perfect `sim_blend` of 1.0
+  _and_ the 1.3 chapter boost the ceiling is `0.75 × 0.195 = 0.14625`,
+  still short. By the MMR monotonicity property every later candidate
+  is lower, so a bypass-bound row is always `below_threshold`.
+  Confirmed empirically against the M3.4 ranker: a happening at
+  `sims [1,1,1]`, `chaptersOld 60`, against a 10,000-token budget for
+  one 30-token row yields `finalScore 0.15`, `dropReason
+"below_threshold"`, `selectedCount 0`.
+  Proximate cause is a units mismatch: `min_score_threshold` is
+  described at [`retrieval.md → Budget-fill termination`](../memory/retrieval.md#budget-fill-termination)
+  as a "cosine baseline", but it is compared against a value already
+  scaled by `λ_div` — so the effective raw-score floor for a first pick
+  is `0.15 / 0.75 = 0.2`, while `τ_revive = 0.85` caps bypass output at
+  0.15. Three knobs could resolve it — lower `τ_revive` (measured
+  boundary is `< 0.80`, not `≤`: at exactly 0.80 the comparison value
+  is `0.14999999999999997`, still under the floor in IEEE754), lower
+  `min_score_threshold`, or threshold against the raw score rather than
+  the MMR score — and choosing among them is a canon decision. M3.4's
+  ranker follows the Pseudocode exactly and is not at fault. Same shape
+  as the inert lore `priority` entry above: a documented feature
+  neutralized by the default parameter set.
+  **The mismatch is broader than the bypass.** 0.2 is only the
+  _first-pick_ floor, where `S` is empty and the diversity penalty is
+  zero. The real floor rises with that penalty: a candidate whose
+  `maxSim` to an already-selected row is 0.5 must reach a raw score of
+  `(0.15 + 0.25 × 0.5) / 0.75 ≈ 0.367` — roughly 2.4x the documented
+  0.15 — to survive. Every pick after the first, in every type, is
+  therefore held to a stricter floor than canon states; the bypass is
+  simply the case where it is provably fatal. Surfaced by M3.4 Task 6
+  (2026-08-01).
+- **`chapters_old` has no home in the capture, but the simulator is
+  specified to recompute from it.**
+  [`probe.md → Simulatable parameters`](../memory/probe.md#simulatable-parameters)
+  says the simulator recomputes `recency_factor` from stored
+  `chapters_old` when a user re-tunes per-type `λ`. But neither
+  `CandidateTrace` (`lib/retrieval/types.ts`) nor `CaptureCandidate`
+  (`lib/db/world-json-types.ts`) carries a `chapters_old` field, and
+  [`probe.md → What gets captured`](../memory/probe.md#what-gets-captured--light-mode-default)
+  doesn't list one — it captures the _derived_ `recency_factor` only.
+  From `recency_factor` alone the simulator cannot invert to a new λ
+  without also knowing the age and the pin, so a λ slider is not
+  actually simulatable as specified. Either add `chapters_old` to the
+  capture shape (a C4 trace-contract change, same decision pass as the
+  eager-tokenization item above) or drop λ from the
+  simulatable list. M3.4 is not at fault — it emits exactly the fields
+  C4 pins. Surfaced by M3.4 Task 6 review (2026-08-01).
+- **Q3's dialogue signal mis-pairs across unbalanced quotes.**
+  `lib/retrieval/prose-extract.ts` finds quoted spans over the whole
+  narrative entry (needed, because a quote legitimately opens in one
+  sentence and closes in a later one) and awards
+  [`retrieval.md → Q3`](../memory/retrieval.md#q3-heuristic-prose-extract)'s
+  Medium "dialogue" weight to any sentence overlapping a span. On
+  well-formed prose this is correct. On an **unclosed** opener it
+  mis-pairs: that opener binds to the _opening_ quote of the next
+  speech, so the pure narration between them collects a spurious +2,
+  and every subsequent quote in the entry is off by one. Measured:
+  `'"Run, she said. He left the room. "Wait." Done here.'` yields one
+  span covering the first two sentences, flagging `He left the room.`
+  as dialogue. Two things bound the damage — a lone stray `"` with no
+  later quote produces **no** span at all (it does not swallow the rest
+  of the entry), and the multi-paragraph dialogue convention (each
+  paragraph opening a quote, only the last closing it) happens to flag
+  correctly. LLM narrative does emit unbalanced quotes, so this is
+  reachable. A stateful open-quote tracker was considered and rejected
+  during M3.4 as needing its own pairing and nesting logic per quote
+  style; any regex pairing degrades on unbalanced input, and the
+  shipped version is strictly better than the per-sentence one it
+  replaced, which lost the signal entirely whenever a quote spanned a
+  sentence break. Worth revisiting only if probe captures show the
+  dialogue weight firing on obvious narration. Surfaced by M3.4 Task 8
+  review (2026-08-02).
+- **Canon's Q2 template renders four lines unconditionally; the shipped
+  digest omits the empty ones.**
+  [`retrieval.md → Q2`](../memory/retrieval.md#q2-structural-digest)
+  specifies the structural digest as a fixed four-line template. M3.4
+  Task 9 makes every line conditional: the scene line is dropped when it
+  would carry neither entities nor a location, the threads line when
+  there are no threads, and the era and summary lines when those are
+  absent. `presence[1]` is derived from the rendered result rather than
+  hardcoded true, so a digest carrying no content reports itself absent
+  and the ranker re-normalizes the blend across the remaining queries.
+  The driver was measurable: under the literal template, a story with no
+  cast, no location, no threads and no era renders Q2 as punctuation
+  only, and that vector still took a full `w_digest` share — 35% of
+  every candidate's blended similarity — because nothing marks it
+  absent. (Q3 is present even on turn 1:
+  [`retrieval.md → Cold start`](../memory/retrieval.md#cold-start)
+  sources it from the opening entry, which the wizard always commits.)
+  The plan had already
+  made the era line conditional, so the module was internally
+  inconsistent either way. Code and canon now disagree and the project
+  rule is that the doc wins — either amend the Q2 section to describe
+  the conditional template or revert the module. Recommended: amend the
+  doc, since the literal template embeds noise. Surfaced by M3.4 Task 9
+  (2026-08-02).
+- **Canon promises a wizard-derived structural digest that the wizard
+  does not produce.**
+  [`retrieval.md → Cold start`](../memory/retrieval.md#cold-start)
+  specifies turn 1's Q2 as a wizard-derived structural digest, and
+  [`retrieval.md → Q2`](../memory/retrieval.md#q2-structural-digest)
+  calls the four structural fields deterministic, free and always
+  available. Three of the four have no shipped producer.
+  `components/wizard/finish.ts` hardcodes `currentLocationId: null`, and
+  the only writer that sets it is the piggyback block
+  (`lib/piggyback/apply.ts`), which runs after narrative while retrieval
+  runs before — so turn 1 can never carry a location. Threads have
+  exactly one insert site (`lib/actions/threads/register.ts`), reachable
+  only through a `createThread` delta that nothing outside tests
+  dispatches. The default and only shipped calendar sets `eras: null`
+  (`lib/calendar/builtins/earth-gregorian.ts`). Scene entities are empty
+  whenever the wizard produces no lead, which `needsLead`
+  (`components/wizard/step-frame-logic.ts`) reports for the shipped
+  default mode and narration — a case
+  [`wizard.md`](../ui/screens/wizard/wizard.md) calls out explicitly.
+  Retrieval is not broken, since Task 9 marks an empty Q2 absent and the
+  blend re-normalizes, but canon's cold-start guarantee is aspirational
+  and Q2 contributes nothing on turn 1 of a default-wizard story. The
+  dev seed does create threads, which is why this stays invisible in
+  development. Decide whether the wizard should collect an era and
+  opening threads, or whether canon should drop the cold-start Q2
+  guarantee. Surfaced by M3.4 Task 9 (2026-08-02).
+- **The C4 purity guard's transitive claim has an identifier-heuristic
+  hole.** `PURE_FILES` in `lib/retrieval/ranker.test.ts` is documented
+  as covering the whole transitive surface the simulator loads, not just
+  the entry file. M3.4 Task 9 added `queries.ts`, which value-imports
+  `extractProse`, which in turn value-imports `matchTerms` from
+  `name-index.ts` — so `name-index.ts` is now inside the guarded closure
+  but absent from the list, and it cannot be added: the guard's second
+  assertion rejects any file whose source matches `queryAll`, and
+  `buildNameKeywordIndex` takes an injected parameter of that exact
+  name. No live violation exists, because injecting the query function
+  is what keeps the module pure — the heuristic penalizes the very
+  pattern that satisfies C4. A future `@/lib/db` value-import added to
+  `name-index.ts` would go undetected by a guard that claims to cover
+  it. Fix by scoping the second assertion to import statements rather
+  than scanning bare identifiers, or by exempting injected parameter
+  names. Surfaced by M3.4 Task 9 review (2026-08-02).
+- **The buffer composition rule's spillover source is stated two ways
+  that cannot both hold.**
+  [`cadence.md → Composition rule`](../memory/cadence.md#composition-rule)
+  says to "fill from the **previous chapter** to satisfy the
+  `protectedBuffer` floor" — singular — while the same section states
+  the unconditional arithmetic invariant that total entries before the
+  chapter reaches the floor equal `protectedBuffer`, "with
+  previous-chapter spillover making up the gap". Those disagree
+  whenever the previous chapter holds fewer entries than the shortfall:
+  honouring the singular source leaves the total below the floor, and
+  honouring the invariant means walking backwards across as many closed
+  chapters as it takes. M3.4 Task 10 implements the invariant reading
+  and pins it with a test asserting output that spans two closed
+  chapters plus the open region, on the grounds that a floor which
+  silently stops short is not a floor. The case is uncommon in practice
+  — `chapterTokenThreshold` defaults to 24000 tokens, so a chapter
+  normally holds far more than the default `protectedBuffer` of 10 —
+  which is likely why the wording was never stress-tested. Tighten the
+  sentence to say "walking backwards from the chapter boundary", or
+  state the single-chapter cap explicitly and accept a total below the
+  floor. Surfaced by M3.4 Task 10 (2026-08-02).
+- **Structural-floor seating silently bypasses two pool-level rules
+  canon states elsewhere.**
+  [`retrieval.md → Structural floor`](../memory/retrieval.md#structural-floor--always-inject)
+  seats every `injection_mode='always'` row unconditionally, "across
+  entities / lore / threads". Two later sections assume those same rows
+  still pass through pool machinery, which seated rows never reach.
+  First,
+  [`retrieval.md → Three-sub-pool entity model`](../memory/retrieval.md#three-sub-pool-entity-model)
+  makes `injection_mode='always'` the **only** opt-in for retired
+  entities and then states all three sub-pools "compete for the
+  entity-type token budget" — but a retired row that opted in is
+  already seated, so the retired sub-pool is empty in production and
+  cannot compete. M3.4 Task 11 resolves this in favour of the floor, so
+  that "always" means always; `filterEntityPool` still excludes every
+  retired row by default, but the `always` opt-in that would readmit one
+  is unreachable whenever `floorIds` comes from `buildStructuralFloor`,
+  because that floor has already seated it. Second, same-name
+  suppression is defined
+  as removing staged namesakes "from the current pool", so a staged row
+  carrying `always` is injected even when its name appears in recent
+  buffer prose — which is the collision the rule exists to prevent. The
+  shipped behaviour matches canon's literal wording in both cases; what
+  is unclear is whether canon means it. Decide whether `always` should
+  outrank the retired-exclusion and same-name rules (current behaviour,
+  and the simplest to explain to a user who set the flag) or whether
+  seating should be checked against them first. Surfaced by M3.4 Task 11
+  (2026-08-02).
+- **The blocking sync stage bounds neither request token size nor
+  provider fan-out, and sends the whole dirty set in one call on the
+  local backend.** M3.4 Task 12's `runSyncStage` calls `embedRows` once
+  for every `embedding_stale = 1` row, unlike `lib/embedder/drain.ts`,
+  which batches at 16 and isolates poison rows. The **row count** is not
+  the exposure it first appears: `lib/ai/embedding.ts` embeds through
+  the AI SDK's `embedMany`, which splits at `maxEmbeddingsPerCall`, and
+  `@ai-sdk/openai-compatible` defaults that to 2048 — so a 5000-row
+  dirty set becomes three requests, not one. Three real gaps remain.
+  Per-request **token** size is still unbounded, so 2048 long rows can
+  413 anyway; the SDK fires those chunks **in parallel** when the model
+  reports `supportsParallelCalls`, with no concurrency ceiling; and the
+  **local** backend has no equivalent split, so it really does hand the
+  whole set over in one IPC call. Because this stage is **blocking** by
+  design, any of those fails the turn outright rather than degrading.
+  The drain worker mitigates in practice by pre-warming, but only for
+  the open branch, while the sync stage's `branchIds` may be wider.
+  [`retrieval.md → Compute lifecycle`](../memory/retrieval.md#compute-lifecycle)
+  says the stage "embeds every dirty row … in one batch", but that
+  sentence contrasts deferred sync against embedding-on-write — it is
+  about collapsing repeated writes into a single pass, not about issuing
+  a single HTTP request. **Chunking would not violate canon**, so this
+  is a deferred robustness decision rather than a constraint. A remedy
+  belongs in the embedder layer rather than in `sync.ts` — but note the
+  provider path already chunks by row count, so the work is a token
+  budget per request, a concurrency cap on the fan-out, and a split on
+  the local backend. Surfaced by M3.4 Task 12 review (2026-08-02).
+- **Nothing implements the window-level accounting that
+  [`retrieval.md → Structural floor takes budget first`](../memory/retrieval.md#structural-floor-takes-budget-first)
+  describes.** Canon reads "recent buffer + active+in-scene entities +
+  their location + active threads consume tokens unconditionally. Then
+  prompt-overhead reservation. Then the per-type retrieval budgets
+  allocate the remainder", and the UI is meant to show allocations "of
+  remaining ~X tokens after structural inject". Three pieces are absent:
+  no context-window total is tracked anywhere, no prompt-overhead
+  reservation exists, and the story-settings sliders show absolute
+  numbers with no remaining-window figure beside them. `runRetrieval`
+  passing `settings.retrievalBudgets` through to `rankAll` unmodified is
+  **correct** under this reading — the floor is subtracted from the
+  window, not from each type's partition, which is why the prompt
+  buffer, a floor member with no retrieval type, appears in that list at
+  all. Subtracting per type instead would silently redefine the user's
+  sliders every turn and double-count against the UI figure canon asks
+  for. What is missing is the window arithmetic and the surface that
+  reports it, which spans retrieval, the prompt builder and
+  story-settings and so has no single owning slice. Surfaced by M3.4
+  Task 17 review (2026-08-02).
+- **`lib/piggyback/apply.ts` writes `<current_location>` with no kind
+  check.** `block.currentLocation` lands in `metadata.currentLocationId`
+  verbatim; `buildStructuralFloor` then seats whatever it names as the
+  location if that row is `active`, and `apply.ts` writes
+  `state.current_location_id` for every in-scene character. A model that
+  answers with a character or item id corrupts scene state with no
+  diagnostic. M3.4 Task 17 narrowed the prompt-side exposure (the
+  `<current_location>` instruction now fires only when the floor seats a
+  location), but the parser accepts any id regardless of what the prompt
+  asked for. The fix belongs with piggyback parsing, not the prompt.
+  Surfaced by M3.4 Task 17 review (2026-08-02).
+- **`structuralSceneEntities` has no template consumer.**
+  `buildGenerationContext` emits it and `templateContextMap` documents
+  it, but the bundled per-turn and suggestion-refresh templates both
+  render the scene from `entities` filtered by `sceneEntities` so the
+  active+in-scene invariant survives a render with no retrieval behind
+  it. Either the bundle earns a consumer or it is documented as
+  pack-author-only surface. Surfaced by M3.4 Task 17 review
+  (2026-08-02).
+- **The token-progress strip reads a 50-entry window, so it cannot
+  reach its own threshold.** `useOpenRegionTokens` sums the open region
+  out of `entriesStore`, which holds a trailing `ENTRIES_WINDOW_SIZE`
+  (50) slice rather than the branch. Measured: 50 entries at realistic
+  length is **37.7%** of the default 24 000 `chapterTokenThreshold`, and
+  reaching 100% would need ~132 entries. Once the open region exceeds 50
+  — the normal state, since nothing closes a chapter before M5 — the
+  strip reports a fraction of the truth and reads "plenty of room" while
+  chapter-close is overdue. `generation-pipeline.md → Chapter close`
+  sketches `openRegionTokens(branchId)` reading from the **DB**, so the
+  two will diverge the moment M5 wires the real trigger. The strip is
+  still better than the hardcoded `0` it replaced; the number is not
+  trustworthy. Surfaced by M3.4 Task 19 (2026-08-02).
+- **The same strip is non-monotonic across a reload.** `entriesStore`
+  grows within a session (`patch` never evicts) but `reload()`
+  re-hydrates to the trailing 50, discarding paged-in older rows.
+  `reload()` fires on turn failure, on submit-with-system-tail, and on
+  system-entry dismissal — so **dismissing a system entry visibly
+  shrinks the progress strip**, as does restarting the app. Same story,
+  same open region, different number. Follows from the entry above and
+  is fixed by the same change. Surfaced by M3.4 Task 19 (2026-08-02).
+- **`countEntryTokens` now runs on the reader's first render, adding a
+  synchronous tiktoken encoder build before first paint.** It had zero
+  production callers before M3.4 Task 19 — `countTokens` was reached
+  only through the ranker, inside the async per-turn retrieval phase.
+  The BPE map build measured **116ms** on desktop under Node
+  (`lib/retrieval/tokens.ts` documents ~135ms) and will be worse on
+  Android. If story-open shows a hitch, this is it, and the fix is to
+  warm the encoder during story open rather than to change the hook.
+  **Unmeasured on device.** Surfaced by M3.4 Task 19 (2026-08-02).
+- **A retrieval pass costs more than its whole budget at 60-chapter
+  volumes, and the budget table has no line for most of what the pass
+  does.** Measured against a real migrated SQLite plus sqlite-vec
+  database, median of 7 warm in-process passes on desktop, **excluding**
+  the embedder, the blocking sync stage and all IPC: **60 ms** at 1200
+  happenings / 3000 awareness rows, **137 ms** at 3600 / 9000, **166 ms**
+  at 6000 / 15 000.
+  [`retrieval.md → Per-turn cost budget`](../memory/retrieval.md#per-turn-cost-budget)
+  targets **under 100 ms total including the three query embeds**, so
+  the largest figure already exceeds the entire budget with the
+  embedder subtracted out of it. 6000 / 15 000 is not a worst case:
+  [`Scale assumptions`](../memory/retrieval.md#scale-assumptions) puts
+  60 chapters at 3-6k happenings and 15-60k awareness rows, and its own
+  "5-10× happenings" ratio puts a 6000-happening branch at 30-60k
+  awareness — so the measurement sits at that row's awareness floor,
+  2.5× rather than 5-10×. Supporting numbers, dim 384 and `k = 200`:
+  vec0 KNN costs 0.96 / 4.41 / 22.58 ms at 1k / 10k / 60k rows, and a
+  `WHERE branch_id = ?` source scan costs 0.94 / 9.56 / 33.27 ms at
+  2k / 20k / 60k. The budget table prices only the query embed, a
+  cosine batch, MMR, token estimation and budget fill — it has no line
+  at all for the KNN passes, the five source reads, the awareness read
+  or the chapter-ranges JOIN. It also inherits the "three queries per
+  pass" of
+  [`Performance characteristics`](../memory/retrieval.md#performance-characteristics--poc-findings),
+  which is the PoC baseline M3.4's own AC7 is written against, where
+  the shipped pass issues **fifteen** — three query vectors across five
+  types. Two of the overruns are already filed above (MMR, eager
+  tokenization) and
+  are inside these totals; what is missing is a budget re-derived
+  against the pass that actually ships. Surfaced by the M3.4 whole-slice
+  review (2026-08-03).
+- **A retrieval pass makes 27 sequential DB round-trips and
+  parallelises none of them.** `runRetrieval` (`lib/retrieval/run.ts`)
+  awaits, in order: five `loadStaleRows` reads (one per `VEC_FAMILIES`
+  kind — `lib/actions/embedder-swap/app-deps.ts:532`), five
+  `loadSourceRows` reads (`lib/retrieval/source-rows.ts:51`), one
+  awareness read, fifteen KNN passes (three query vectors across five
+  types), and the chapter-ranges JOIN. There is no `Promise.all`
+  anywhere in `lib/retrieval/`, and on desktop every one of those is an
+  IPC round-trip, so the fixed per-call cost is paid 27 times. The five
+  source reads are mutually independent, and so are the fifteen KNN
+  passes: every query vector is in hand before the loop starts, and the
+  per-kind vector map each pass writes into is order-independent. Only
+  two orderings are load-bearing — sync before any source read, floor
+  before the query stack. Surfaced by the M3.4 whole-slice review
+  (2026-08-03).
+- **`loadSourceRows` reads every happening on the branch each turn,
+  purely to filter down to at most 600 KNN ids.** The happenings arm of
+  `lib/retrieval/source-rows.ts:51` is a full
+  `WHERE branch_id = ?` scan, and its only consumers are the pool
+  intersection in `assembleCandidates` (`lib/retrieval/run.ts:465`) and
+  the `staleCounts` tripwire, which wants a count rather than rows. At
+  60 chapters that is ~33 ms of SQL plus ~21 ms of structured-clone
+  across the IPC boundary to discard over 99% of what it read. Entities,
+  lore and threads genuinely need the full scan — `buildStructuralFloor`
+  looks for `injection_mode='always'` across all three,
+  `nameKeywordIndexFrom` indexes every entity name and lore keyword, and
+  Layer-A suppression needs every staged entity. Happenings needs none
+  of that, and it is the one table
+  [`Scale assumptions`](../memory/retrieval.md#scale-assumptions)
+  projects into the thousands. The KNN top-k is supposed to be the
+  scaling mechanism, and this read defeats it. The fix needs no
+  restructuring: nothing before the KNN pass touches
+  `sourceRows.happenings`, so that one read can move after the pool ids
+  are known and fetch by id, bounding it at the pool size. (Chapters has
+  the same shape and does not matter — ~60 rows at 60 chapters.)
+  Surfaced by the M3.4 whole-slice review (2026-08-03).
+- **`poolIdsFromKnn`'s ordering is computed and then discarded.** Its
+  JSDoc (`lib/retrieval/pools.ts:168`) promises a "de-duplicated,
+  first-seen order" union of the per-query KNN id sets, and it builds
+  exactly that — but `assembleCandidates` consumes the result only as
+  `new Set(ids)` membership (`lib/retrieval/run.ts:371`), so the pool's
+  actual order is SQL row order from `loadSourceRows`, not KNN rank.
+  That order is not inert: it decides ties in the ranker's
+  `scored.sort((a, b) => b.score - a.score)`, which is stable, and in
+  MMR's strict-`>` pick, which keeps the first of an equal pair. Two
+  candidates with identical scores are therefore ranked by whatever
+  order SQLite returned them in. Either thread the KNN order through to
+  pool assembly or return a `Set` and drop the array — the current
+  shape documents a guarantee it does not deliver. Surfaced by the M3.4
+  whole-slice review (2026-08-03).
+- **`countEntryTokens`' memo is never pruned.** `lib/retrieval/tokens.ts`
+  keys an unbounded module-level `Map` on entry id and holds it for the
+  process lifetime, across deletes, rollbacks, branch switches and story
+  switches; `__resetTokenCache` has no production caller. Deleting an
+  entry and later reinstating that id — reverse-replay of a delete
+  re-inserts with the original id — resurrects a memo entry written
+  before the deletion. The content check on read bounds the damage to a
+  stale-content miss rather than a wrong count, so this is a leak rather
+  than a defect today, but it is precisely the shape
+  [lessons-learned → No "harmless" id leaks](./lessons-learned/no-harmless-id-leaks.md)
+  records. Surfaced by the M3.4 whole-slice review (2026-08-03).
+- **`rankPerType` recomputes `tokensEstimated` rather than accepting a
+  captured one, which desynchronises M3.5's simulator from its own
+  capture.** `score` (`lib/retrieval/ranker.ts:101`) always evaluates
+  `input.countTokens(c.renderedText) + params.typeOverhead[type]`; there
+  is no path that takes a stored value. The probe's simulator re-runs
+  budget-fill against `CaptureCandidate.tokens_estimated`
+  ([`probe.md → Simulatable parameters`](../memory/probe.md#simulatable-parameters)),
+  so any drift between the js-tiktoken version that produced the capture
+  and the one loaded at replay makes the two disagree row by row, with
+  nothing reporting it. The ranker's purity is not at issue — the
+  function is deterministic given its inputs; the tokenizer is one of
+  its inputs and is not pinned by the capture. Wants either an optional
+  captured-token input on `RankTypeInput` or a recorded encoding
+  identity the simulator can refuse to replay across. Needs deciding
+  before 3.5 builds the simulator. Surfaced by the M3.4 whole-slice
+  review (2026-08-03).
+- **The C4 purity guard is an identifier scan, not a purity check.**
+  Distinct from the transitive-closure hole filed above: that entry is
+  about a file the guard claims to cover and cannot list, this one is
+  about what the guard checks at all. Its second assertion
+  (`lib/retrieval/ranker.test.ts:402`) is
+  `expect(src).not.toMatch(/queryAll|runInTransaction|drizzle/)` — a
+  scan for three bare identifiers anywhere in the file, including
+  comments and parameter names. It catches an import-shaped violation
+  only because imports happen to mention those words, and it says
+  nothing about the ways replay actually breaks: a clock, an RNG, a
+  locale-sensitive format, or module-level mutable state read across
+  calls. Behavioural purity does currently hold — the whole
+  value-import closure (`ranker`, `mmr`, `vector`, `constants`,
+  `queries`, `prose-extract`, `name-index`; `types` and `@/lib/db` are
+  type-only) was grepped for `Date.`, `Math.random`, `performance.`,
+  `Intl` and `toLocale` with zero hits, and every value import inside it
+  is intra-module. So the guard is not hiding a live violation; it is
+  claiming coverage it does not have. Surfaced by the M3.4 whole-slice
+  review (2026-08-03).
+- **Four hand-built `RetrievalSuccess` fixtures, and a factory home that
+  already exists.** `lib/actions/turns/submit-turn.test.ts:50`,
+  `lib/pipeline/definitions/per-turn-retrieval.test.ts:71`,
+  `lib/pipeline/definitions/generation-context.test.ts:128` and
+  `lib/pipeline/definitions/per-turn.test.ts:774` each construct the
+  full outcome — five `RankedType` bundles, a `StructuralFloor`, a
+  `QueryStack`, `staleCounts`, `timings` — by hand, and every field
+  added to the type has to be added four times.
+  `lib/retrieval/__tests__/` exists (it holds the shared `queryAll`
+  stub) and is the natural home for a factory. Hygiene, not risk:
+  `RetrievalSuccess` is a closed object type, so typecheck fails all
+  four the moment a required field lands. Surfaced by the M3.4
+  whole-slice review (2026-08-03).
+- **`retrieval.md → Token estimation` describes a ranker-side token
+  cache that does not exist.**
+  [The section](../memory/retrieval.md#token-estimation) ends "Ranker
+  passes cache results in memory for reuse within the turn." No such
+  cache exists: `score` calls the injected `countTokens` once per
+  candidate and keeps the result on the `Scored` row, and the only memo
+  in `lib/retrieval/tokens.ts` is `countEntryTokens`, which the ranker
+  never touches. Each candidate is tokenized exactly once per pass, so
+  the intent — do not pay twice for the same row — is satisfied; the
+  sentence describes a mechanism that was never built, and it shares a
+  paragraph with the "per-turn cost is sub-millisecond total" claim the
+  measurements above already contradict. Fix with the same pass that
+  re-derives the cost budget. Surfaced by the M3.4 whole-slice review
+  (2026-08-03).
+- **`KNN_K` borrows canon's post-score pre-filter bound to gate
+  pre-score candidate membership, which puts the chapter-match boost
+  out of reach of the rows it exists to rescue.** _Blocks the M3.4 PR
+  merge — revisit before integration, not on the ordinary triage pass._
+  Two independent 200s are in play and only one is canon.
+  `preFilterTopN: 200` (`lib/retrieval/constants.ts:19`) is specified by
+  [`retrieval.md → Diversity — MMR`](../memory/retrieval.md#diversity--mmr)
+  and applies to the **boosted** score after `score` has run; canon
+  justifies it as "candidates ranking ~200th by raw score are unlikely
+  to make it into the budget anyway." `KNN_K = 200`
+  (`lib/retrieval/constants.ts:24`) appears nowhere in canon — it is an
+  implementation choice whose own comment reads "matches the pre-filter
+  bound." The two cuts act on different signals at different stages, so
+  that justification does not transfer: at KNN time
+  (`lib/retrieval/run.ts:315`) none of recency, `kwBoost`, `pinSignal`
+  or the 1.3× chapter boost exists yet. The consequence is that the
+  boost can reorder the candidate set but cannot change its membership —
+  a happening outside the KNN cut for all three query vectors is never
+  scored, so a row the boost would have carried well into the seated set
+  never gets the chance. Chapter membership never reaches pool
+  construction at all: `chapterRanges` is loaded at
+  `lib/retrieval/run.ts:226` and read only by `boostedEntryIdsFor`
+  (`lib/retrieval/ranker.ts:128`). That inverts the mechanism's purpose —
+  [`retrieval.md → Chapter-match boost on happenings`](../memory/retrieval.md#chapter-match-boost-on-happenings)
+  introduces it because pure-similarity happening retrieval comes out
+  "scattered," yet the set it operates on is gated purely by similarity.
+  Magnitude is unmeasured: the per-type union is at most 3 × 200 ids,
+  but all three query vectors describe the same turn, so heavy overlap
+  is expected and the effective pool is likely nearer 200-350 — against
+  the 3-6k happenings
+  [`retrieval.md → Scale assumptions`](../memory/retrieval.md#scale-assumptions)
+  contemplates at 60 chapters. Two directions worth weighing: size the
+  KNN depth against recall independently of `preFilterTopN`, or let
+  chapter membership feed pool construction via a bounded fetch by
+  range (ids are known, so it is a lookup rather than a second vector
+  search). Surfaced by a post-merge design question from the user
+  (2026-08-05).
+- **`metadata.tokens.completion` is the wrong measure for the chapter
+  threshold, on four independent counts.** M5 needs
+  `openRegionTokens(branchId)` as a DB read
+  ([`generation-pipeline.md → chainsTo on predecessor`](../generation-pipeline.md#chainsto-on-predecessor)),
+  and `story_entries.metadata.tokens` already looks like the answer.
+  It is not. (1) **Stale on edit** — `updateStoryEntryContent`
+  (`lib/actions/story-entries/operational.ts:45`) sets only `{ content }`,
+  so the count survives a rewrite unchanged. (2) **Wrong text even when
+  fresh** — it is provider `usage.outputTokens`
+  (`lib/pipeline/definitions/per-turn.ts:256`), counting everything the
+  model emitted, including the state block stripped before persist; the
+  world-state-block work in [`followups.md`](../followups.md) widens that
+  gap deliberately. (3) **Wrong tokenizer** — provider-side, whichever
+  one that provider uses, while `chapterTokenThreshold` and the
+  token-progress strip measure in o200k via `countTokens`. A story that
+  switches providers mid-run would sum two incompatible token scales.
+  (4) **AI entries only** — `usage` exists only on a generation call, so
+  `user_action` rows carry no count at all, and they are part of the open
+  region (`kind !== 'system'`). A SUM over `completion` undercounts by
+  every user turn. The decision is therefore a **new field, not a
+  rename**: `tokens.{prompt, completion, reasoning}` is a coherent
+  provider-usage triple worth keeping for cost provenance, and
+  repurposing one leg of it to mean "o200k count of the stored content"
+  makes the other two incoherent. Open sub-questions: a real
+  `story_entries` column (SUM-able and indexable, which a JSON field is
+  not — and M5's trigger reads this per turn) versus another metadata
+  key; which write paths must maintain it (generation, edit, prose
+  reversal, system entries, import/seed); backfill for existing rows;
+  whether a translated story counts the original or the translation
+  (the original feeds the prompt buffer, so presumably that); and which
+  number the entry card shows now that "reply tokens" and "content
+  tokens" diverge
+  ([`entry-card.md`](../ui/patterns/entry-card.md#reasoning-expansion)).
+  Sits with the three token-progress-strip entries above, which the same
+  change would resolve. Surfaced by review discussion (2026-08-06).
+- **A local embed cannot be cancelled, so Cancel during
+  `recalling-memory` works on provider backends only.** M3.4 made the
+  blocking embed interruptible by threading a bounded signal from the
+  retrieval phase down to `embedMany`, which closes the case where a
+  provider accepts the connection and stalls. `embedLocal`
+  (`lib/embedder/local/runtime.ts`) is one IPC call into the Electron
+  main process with no cancellation channel, so the signal cannot
+  reach it: a local pass runs to completion and the timeout fires only
+  after it returns. Closing the gap needs a cancellation channel in
+  `electron/` main plus preload plus the bridge, which is why M3.4
+  scoped it out rather than shipping a Cancel that silently no-ops on
+  one backend. Compounding it, the local backend does not chunk, so
+  the whole dirty set is a single call. Surfaced by the M3.4 review
+  (2026-08-06).
+- **Move the `embedding_stale` flip into the action layer.**
+  [`retrieval.md → Storage`](../memory/retrieval.md#storage) resolves
+  the source-hash question by making the flag solely responsible for
+  drift: no retrieval-time hash comparison, because hashing every
+  candidate on every turn re-derives what the flag already carries.
+  That trade only holds if the flag cannot be forgotten, and today it
+  can — `registerEntities`, `registerLore`, `registerThreads` and
+  `registerHappenings` all default `embeddingStale` to `0` and leave
+  the flip to the caller, and only the classifier opts in.
+  `setEntityOperationalFlags` and `setLoreOperationalFlags` have no
+  callers outside their own files. The first M4 or M7 edit surface
+  that writes a description without remembering produces a row that
+  ranks against its old text forever, with nothing to report it. The
+  action layer already knows which fields are embedded (the
+  composite-text builders behind `lib/db/embeddings`), so the flip
+  belongs there. Needs a decision on the seed and import paths, which
+  write rows with precomputed vectors and a deliberately clean flag.
+  Surfaced by the M3.4 review (2026-08-07).
+- **Tighten the unprobed-dim escape hatches once M7 makes probing
+  mandatory.** `validateCustomDim` skips its `above-native` check and
+  `clampEffectiveDim` returns the value untouched whenever the model's
+  native dim is unknown (`components/wizard/memory-cost-logic.ts`),
+  both deliberately — rejecting on a ceiling nobody has measured would
+  block valid picks. The cost is one representable cell: an unprobed
+  provider with `effectiveDim` above native. There the pass reads the
+  dim family named by `effectiveDim` while the embed service clamps
+  the vectors it writes to the native dim, so the sync commits one
+  family and clears the flags before the query embed refuses on the
+  mismatch. The story has no in-app recovery — no post-creation
+  `effectiveDim` editor exists, and a swap reuses the locked dim. M7
+  is slated to force a probe before a model is selectable, which
+  removes the cell; when it lands, both permissive branches should go
+  with it rather than being left as a latent re-opening. Surfaced by
+  the M3.4 review (2026-08-07).
+- **`clearEmbeddingStaleOp` clears unconditionally, so a write racing
+  the sync loses its dirty flag.** `lib/db/embeddings/stale.ts` clears
+  by row and branch with no guard on the row still hashing to what was
+  embedded. A writer that flips `embedding_stale` between
+  `loadStaleRows` reading the dirty set and the sync transaction
+  committing has its flag wiped by that commit, leaving new text, an
+  old vector and a clean flag — permanently, because nothing
+  re-derives the flag outside an embedder swap. This is a lost update
+  rather than writer negligence, so the action-layer rule that every
+  embedded-field writer flips the flag does not reach it. The window
+  is one embed round trip wide, and no M3 writer amends an embedded
+  field (the classifier only creates, piggyback writes non-embedded
+  state, user edits are gated), so it is structural rather than live.
+  The cheap fix is optimistic concurrency on the clear rather than a
+  content hash. Surfaced by the M3.4 review (2026-08-07).

--- a/docs/implementation/triage.md
+++ b/docs/implementation/triage.md
@@ -1533,3 +1533,15 @@ here`, `Flip era`, the edit textarea's `Edit entry content`, `Save` /
   state, user edits are gated), so it is structural rather than live.
   The cheap fix is optimistic concurrency on the clear rather than a
   content hash. Surfaced by the M3.4 review (2026-08-07).
+- **`electron/embedder/downloads.test.ts`'s resume test races the first
+  disk flush.** `leaves a .part on mid-stream abort, then resumes with
+Range and completes` sets `behavior.abortAfter = 15000` and then
+  asserts the `.part` file is non-empty. The byte count bounds what the
+  server sends, not what the client has written, so on a loaded runner
+  the abort lands before the first chunk reaches disk and the assertion
+  fails with `expected 0 to be greater than 0`. Observed once on a
+  branch that changes no `electron/` file, green on re-run and green on
+  the sibling PR's identical job, so it is an existing flake rather than
+  a regression. The fix is making the abort point observable — wait on
+  the first flush rather than on a byte count — not a longer timeout.
+  Surfaced by Slice 3.4 CI (2026-08-07).

--- a/docs/memory/cadence.md
+++ b/docs/memory/cadence.md
@@ -58,21 +58,27 @@ Three knobs per story. Defaults copied from
   the current chapter has fewer entries than `protectedBuffer`,
   fill from the previous chapter to satisfy the `protectedBuffer`
   floor. Total entries =
-  `max(partialChapterBuffer, protectedBuffer)` once the chapter
-  is past `protectedBuffer` entries; before that, total =
-  `protectedBuffer` (with previous-chapter spillover making up
-  the gap).
+  `max(protectedBuffer, min(current_chapter_size, partialChapterBuffer))`.
 - **Full mode** (`fullChapterInBuffer = true`): LLM gets ALL
   entries in the current chapter. If the current chapter has
   fewer entries than `protectedBuffer`, fill from the previous
   chapter to satisfy the `protectedBuffer` floor. Total entries =
   `max(current_chapter_size, protectedBuffer)`.
 
+The current-chapter term is clamped to the chapter's own size in
+both modes: `partialChapterBuffer` is a window over the current
+chapter, never a claim on earlier prose. Only `protectedBuffer`
+pulls entries from before the boundary, so a
+`partialChapterBuffer` wider than the current chapter buys nothing.
+
 **Examples** (both buffers at default 10):
 
 - partial, chapter 3 has 2 entries → 2 current + 8 previous = 10
 - partial, chapter 3 has 10 entries → 10 current
 - partial, chapter 3 has 50 entries → last 10 current (no spillover)
+- partial at `partialChapterBuffer = 20`, chapter 3 has 12 entries →
+  12 current (the window clamps to the chapter; protected floor of
+  10 is already met, so no spillover)
 - full, chapter 3 has 2 entries → 2 current + 8 previous = 10
 - full, chapter 3 has 50 entries → all 50 current (chapter size
   exceeds protected floor; no spillover needed)

--- a/docs/memory/probe.md
+++ b/docs/memory/probe.md
@@ -116,14 +116,14 @@ Per capture:
     `chapter_boost_applied` (bool), `bypass_triggered` (bool).
   - `final_score`, `mmr_rank` (or null if pre-filtered out).
   - `selected` (bool), `drop_reason` (enum):
-    `pre_filtered | mmr_dedupe | below_threshold | over_budget |`
+    `pre_filtered | below_threshold | over_budget |`
     `candidate_too_large | not_dropped`.
   - `tokens_estimated`.
   - `embedding_stale` flag at capture time
     (per [`retrieval.md → Compute lifecycle`](./retrieval.md#compute-lifecycle)).
 - **Pool funnel summary per type.** `pool_size`,
   `pre_filtered_size` (capped at 200 per
-  [pre-filter rule](./retrieval.md#diversity--mmr)), `mmr_size`,
+  [pre-filter rule](./retrieval.md#diversity--mmr)),
   `selected_count`, `tokens_used`, `type_budget`.
 - **Structural floor.** List of must-inject rows (prompt buffer
   per the mode-dependent rule + protected-buffer spillover,

--- a/docs/ui/patterns/generation-status-pill.md
+++ b/docs/ui/patterns/generation-status-pill.md
@@ -25,7 +25,8 @@ The pill renders on every in-story top bar (Reader, World, Plot,
 Story Settings, Chapter Timeline). Three concerns travel together
 and must stay in lockstep across consumers:
 
-- **Priority machine** — `active phase > error > hidden`. The
+- **Priority machine** — `blocking phase > error > background phase >
+hidden` (see [Priority resolution](#priority-resolution)). The
   consumer derives both inputs from different sources (pipeline
   orchestrator + memory health observations); the compound owns the
   resolution.
@@ -43,44 +44,65 @@ and must stay in lockstep across consumers:
 ```ts
 type GenerationPhase =
   | 'reasoning'
+  | 'recalling-memory'
   | 'generating-narrative'
   | 'classifying'
+  | 'updating-memory'
   | 'closing-chapter'
   | 'refreshing-suggestions'
-  | 'translating-display'
-  | 'retrying-translations'
 
+// `memory-incomplete` names the observable state, not a cause: the pill fires
+// off a non-zero stale-row count, which an available embedder can produce too.
+// `swap-paused` is separate because staging CLEARS embedding_stale as it goes,
+// so a half-finished swap drives the count toward zero — the story most in need
+// of a signal is the one least likely to raise one.
 type ErrorState =
-  | { code: 'embedder-offline'; pendingRows: number }
+  | { code: 'memory-incomplete'; pendingRows: number }
+  | { code: 'swap-paused' }
   | { code: 'classifier-offline' }
-  | { code: 'classifier-no-profile' }
-  | { code: 'classifier-profile-provider-missing' }
-  | { code: 'classifier-default-provider-missing' }
-  | { code: 'translation-misses'; missingCount: number }
 
 type GenerationStatusPillProps = {
   activePhase?: GenerationPhase
   error?: ErrorState
-  onCancel: () => void
+  // Optional: ignored for phases `cancelCopy` marks cancel-less, so a caller
+  // that cannot tell which phase is up may pass it unconditionally.
+  onCancel?: () => void
   onErrorTap: (code: ErrorState['code']) => void
 }
 ```
 
 Both `activePhase` and `error` are caller-derived. The consumer
-collapses simultaneous errors to one
-(`embedder-offline > classifier-* > translation-misses` — biggest
-blocker first; translation degradation is display-only and ranks
-below memory errors that degrade retrieval quality) and hands the
-result in. The compound imports no router; tap-handling is a
-consumer concern, surfaced via `onErrorTap`.
+collapses simultaneous errors to one — `swap-paused` outranks
+`memory-incomplete`, because a paused swap drives the stale count
+toward zero and would otherwise be hidden by the very signal it
+suppresses — and hands the result in. The compound imports no router;
+tap-handling is a consumer concern, surfaced via `onErrorTap`.
 
 ## Priority resolution
 
 ```
-if (activePhase != null)  → render active variant
-else if (error != null)   → render error variant
-else                      → return null   (idle-hide)
+if (activePhase is blocking)          → render active variant
+else if (error != null)               → render error variant
+else if (activePhase != null)         → render active variant  (background phase)
+else                                  → return null            (idle-hide)
 ```
+
+A **blocking** phase is one the user is waiting on, and it also owns the
+cancel affordance — replacing it with a warning would take away the only
+way to stop a running generation, so it keeps the slot unconditionally.
+A **non-blocking** phase (see [below](#non-blocking-phases)) yields to
+any error: nothing is lost by waiting for background work, and the error
+may be the thing waiting on the user. `swap-paused` is the case that
+forces this — its remedy is a decision, not waiting, so a periodic
+classifier pass blanking it on a cadence is the failure mode this rule
+exists to prevent.
+
+Deliberately a blocking/non-blocking split rather than a rank on
+`ErrorState`. The two resolve identically in every combination except
+one — a self-clearing error (`memory-incomplete`)
+during a background phase — and that cell is arguably miscast anyway:
+"N rows pending" is a drain reporting progress, not a fault. Revisit as
+an error-severity axis only if that cell reads wrong in practice.
 
 Returning `null` when both inputs are absent matches
 [`principles.md → Universal in-story chrome`](../principles.md#universal-in-story-chrome)'s
@@ -94,29 +116,28 @@ The compound owns phase → copy and error → copy:
 | Phase                    | Label                     |
 | ------------------------ | ------------------------- |
 | `reasoning`              | `reasoning…`              |
+| `recalling-memory`       | `recalling memory…`       |
 | `generating-narrative`   | `generating narrative…`   |
 | `classifying`            | `classifying…`            |
+| `updating-memory`        | `updating memory…`        |
 | `closing-chapter`        | `closing chapter…`        |
 | `refreshing-suggestions` | `refreshing suggestions…` |
-| `translating-display`    | `translating…`            |
-| `retrying-translations`  | `retrying translations…`  |
 
-| Error code                            | Label                                                                          |
-| ------------------------------------- | ------------------------------------------------------------------------------ |
-| `memory-incomplete`                   | `Memory incomplete — {pendingRows} rows pending`                               |
-| `classifier-offline`                  | `Classifier offline — retrieval coverage thinning`                             |
-| `classifier-no-profile`               | `Classifier has no profile — retrieval coverage thinning`                      |
-| `classifier-profile-provider-missing` | `Classifier profile's provider is missing — retrieval coverage thinning`       |
-| `classifier-default-provider-missing` | `Classifier default model's provider is missing — retrieval coverage thinning` |
-| `translation-misses`                  | `Translation: {missingCount} missing`                                          |
+| Error code           | Label                                              |
+| -------------------- | -------------------------------------------------- |
+| `memory-incomplete`  | `Memory incomplete — {{count}} row(s) pending`     |
+| `swap-paused`        | `Embedder switch paused — waiting on you`          |
+| `classifier-offline` | `Classifier offline — retrieval coverage thinning` |
 
-The three `classifier-*-missing` / `classifier-no-profile` variants
-come from periodic-classifier
+`memory-incomplete` is pluralised (`_one` / `_other`), so the count is
+`{{count}}` rather than a named field.
+
+Periodic-classifier
 [config pre-flight failures](../../generation-pipeline.md#config-pre-flight-validation)
-— a broken provider/profile reference that the periodic classifier
-pre-flight catches at its scheduled fire time. Distinct from
-`classifier-offline` (transient runtime failure) — different cause,
-same consequence framing.
+— a broken provider or profile reference caught at the scheduled fire
+time — currently surface through `classifier-offline` alongside
+transient runtime failures: different cause, same consequence framing.
+Splitting them into their own codes is unbuilt.
 
 ## Active variant
 
@@ -128,13 +149,34 @@ same consequence framing.
 
 Tap opens a `Popover` anchored to the tag. Body is a single button:
 
-- `Cancel generation` — for `reasoning` / `generating-narrative` /
-  `classifying`.
+- `Cancel generation` — for `reasoning` / `recalling-memory` /
+  `generating-narrative` / `classifying`.
 - `Cancel chapter close` — for `closing-chapter`.
 - `Cancel suggestion refresh` — for `refreshing-suggestions`.
+- None — for `updating-memory`. The phase is cancel-less, so the tag
+  carries no popover trigger and a passed `onCancel` is ignored.
 
 Clicking the button fires `onCancel()` and closes the popover.
 Esc / outside-tap closes the popover without firing `onCancel`.
+
+### Non-blocking phases
+
+`updating-memory` — the periodic classifier's background pass — is the
+only phase that doesn't hold the turn up. It drops the accent fill for
+`tone="default"` (the header's own `bg-base` plus a border) and a
+`--fg-muted` spinner, and it yields the slot to any error per
+[Priority resolution](#priority-resolution). Copy alone can't carry the
+distinction, because the phone variant is icon-only.
+
+It is deliberately a separate phase from `classifying`, which is the
+per-turn piggyback fallback: same work, opposite answer to "can I keep
+writing?".
+
+Blocking is tracked per phase rather than inferred from a phase having
+no cancel label. The two coincide today only because the one background
+phase is also the one nothing can cancel; a blocking phase that is
+uncancellable for its own reasons (a committing transaction, say) would
+otherwise inherit the wrong priority.
 
 Pill dimensions stay stable — the popover is an overlay, never an
 inline expansion. The active label renders regardless of popover
@@ -148,27 +190,19 @@ open state.
 </Tag>
 ```
 
-No popover. Tap fires `onErrorTap(error.code)` directly; the
-consumer handles each code by either routing (memory errors point
-the user at the configuration that fixes them) or triggering a
-recovery action (`translation-misses` fires the retry pipeline
-directly). Per
+No popover. Tap fires `onErrorTap(error.code)` directly and the
+consumer decides what a code is worth routing to. Per
 [`reader-composer.md → Persistent state — top-bar status pill error variant`](../screens/reader-composer/reader-composer.md#persistent-state--top-bar-status-pill-error-variant):
 
-| Error code                            | Consumer response                                                                            |
-| ------------------------------------- | -------------------------------------------------------------------------------------------- |
-| `embedder-offline`                    | Route to Story Settings · Memory's resolution panel.                                         |
-| `classifier-offline`                  | Route to Story Settings · Memory · Classifier panel.                                         |
-| `classifier-no-profile`               | Route to App Settings · Profiles · Assignments (classifier row).                             |
-| `classifier-profile-provider-missing` | Route to App Settings · Profiles (the broken profile's edit dialog).                         |
-| `classifier-default-provider-missing` | Route to App Settings · Default models (classifier row).                                     |
-| `translation-misses`                  | Fire `runPipeline('translation-retry', { branchId, targetLanguage, intendedTranslations })`. |
+| Error code           | Consumer response                                 |
+| -------------------- | ------------------------------------------------- |
+| `memory-incomplete`  | Route to Story Settings · Memory.                 |
+| `swap-paused`        | Route to Story Settings · Memory.                 |
+| `classifier-offline` | No route — the pass retries on its own next fire. |
 
-The translation-misses tap is an in-place action rather than a
-route — the user already knows what's wrong (the count is in the
-copy), so the affordance offers the fix directly. The retry
-pipeline's standard `active` state then drives the pill through
-`translating…` while it runs.
+`classifier-offline` is deliberately inert: it reports a background
+pass that will retry unprompted, so routing the user somewhere to act
+on it would imply an action that is not theirs to take.
 
 ## Tier-aware render
 
@@ -190,23 +224,28 @@ fits the ≤ 200 px tiny-popover threshold.
 
 ## Local state
 
-```ts
-const [popoverOpen, setPopoverOpen] = React.useState(false)
-```
-
-Only the active variant uses this. Error variant has no popover.
-The compound has no other internal state — `activePhase` / `error`
-come from props on every render.
+None. The active variant's Popover is uncontrolled — the compound
+holds a `triggerRef` and calls `triggerRef.current?.close()` after a
+cancel rather than mirroring open/closed into React state. The error
+variant has no popover at all, and `activePhase` / `error` come from
+props on every render.
 
 ## Open items
 
 - **Pipeline orchestrator wiring.** Real `activePhase` source from
-  the per-turn + chapter-close pipelines per
+  the per-turn / chapter-close pipelines per
   [`generation-pipeline.md → Orchestrator topology`](../../generation-pipeline.md#orchestrator-topology).
   The compound takes `activePhase` as a prop; consumers wire it from
   the orchestrator state via a derived selector on `txState`
-  (foreground-first heuristic).
-- **Memory error observation.** Surface `embedder-offline` from
+  (foreground-first heuristic). **Done for the reader**, whose
+  `components/reader/generation-phase.ts` maps the running phase's
+  node name to a `GenerationPhase` — exhaustively over the per-turn
+  phase-name union, so a phase added to that pipeline fails the
+  build until it is labelled, and with a generic-label fallback so an
+  unmapped name never blanks the pill mid-run. Story Settings still
+  derives its phase from the run's _kind_, and the remaining in-story
+  surfaces are unwired.
+- **Memory error observation.** Surface `memory-incomplete` from
   staleness detection per
   [`memory/model-management.md → Staleness UI`](../../memory/model-management.md#staleness-ui);
   `classifier-offline` from failed-persistent classifier state per

--- a/docs/ui/screens/reader-composer/reader-composer.html
+++ b/docs/ui/screens/reader-composer/reader-composer.html
@@ -113,6 +113,9 @@
   .gen-status.visible { display: flex; }
   .gen-status .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--ok); animation: pulse 1.6s infinite; }
   .gen-status.error { border-color: var(--warn); background: var(--warn-bg); color: #642; }
+  /* Background phase: no accent fill, muted dot — nothing is being waited on. */
+  .gen-status.background { color: var(--ink-muted); }
+  .gen-status.background .dot { background: var(--ink-muted); }
   .gen-status.error .dot { background: var(--warn); animation: none; }
   @keyframes pulse { 0% { box-shadow: 0 0 0 0 rgba(74,168,136,0.5);} 70% { box-shadow: 0 0 0 5px rgba(74,168,136,0);} 100% { box-shadow: 0 0 0 0 rgba(74,168,136,0);} }
 
@@ -566,6 +569,9 @@
     <button class="rb-btn" data-gen="generating">replying</button>
     <button class="rb-btn" data-gen="classifying">classifying</button>
     <button class="rb-btn" data-gen="chapter-close">chapter-close</button>
+    <button class="rb-btn" data-gen="recalling-memory">recalling-memory</button>
+    <button class="rb-btn" data-gen="updating-memory">updating-memory</button>
+    <button class="rb-btn" data-gen="error-swap-paused">error-swap-paused</button>
     <button class="rb-btn" data-gen="error-stale">error-stale</button>
     <button class="rb-btn" data-gen="error-classifier">error-classifier</button>
   </div>
@@ -1366,11 +1372,19 @@
     generating: 'generating narrative…',
     classifying: 'classifying…',
     'chapter-close': 'closing chapter…',
-    'error-stale': 'Embedder offline · 12 rows pending',
-    'error-classifier': 'Classifier offline · retrieval thinning',
+    'recalling-memory': 'recalling memory…',
+    'updating-memory': 'updating memory…',
+    'error-swap-paused': 'Embedder switch paused — waiting on you',
+    'error-stale': 'Memory incomplete — 12 rows pending',
+    'error-classifier': 'Classifier offline — retrieval coverage thinning',
   };
 
-  const errorStates = new Set(['error-stale', 'error-classifier']);
+  const errorStates = new Set(['error-swap-paused', 'error-stale', 'error-classifier']);
+
+  // The one non-blocking phase: it drops the accent fill and YIELDS the slot to
+  // any error, which is why gen-state and error-state are not mutually exclusive
+  // here (patterns/generation-status-pill.md -> Priority resolution).
+  const backgroundPhases = new Set(['updating-memory']);
 
   const streamingBrain = document.getElementById('streaming-brain');
   const streamingToks = document.getElementById('streaming-toks');
@@ -1383,6 +1397,7 @@
     if (label) {
       genStatus.classList.add('visible');
       genStatus.classList.toggle('error', isError);
+      genStatus.classList.toggle('background', backgroundPhases.has(state));
       genLabel.textContent = label;
 
       if (isError) {
@@ -1394,6 +1409,14 @@
         cancelBtn.classList.add('hidden');
         banner.classList.remove('visible');
         cancelAction.textContent = state === 'error-classifier' ? 'Open Memory settings' : 'Open Memory settings';
+      } else if (backgroundPhases.has(state)) {
+        // Background phase: muted pill, no streaming surface, composer stays
+        // usable — nothing is being waited on and there is nothing to cancel.
+        streamingEntry.classList.remove('visible');
+        composer.classList.remove('generating');
+        sendBtn.classList.remove('hidden');
+        cancelBtn.classList.add('hidden');
+        banner.classList.remove('visible');
       } else {
         // Active generation phase — streaming surface + composer-cancel mode.
         streamingEntry.classList.add('visible');
@@ -1582,8 +1605,8 @@
     },
     embed: {
       kind: '⚠ System · embedding error',
-      content: "<b>Embedding failed for 2 rows.</b> The narrative completed and 3 of 5 classifier-emitted rows embedded successfully; 2 rows hit a provider timeout. The next-turn affordance is disabled until you resolve.",
-      actions: '<span class="err-btn primary">Retry</span><span class="err-btn">Switch embedder</span><span class="err-btn">Roll back this turn</span><span class="err-btn" id="err-dismiss">Dismiss</span>',
+      content: "<b>The embedder failed, so memory retrieval couldn't run.</b> call: embedding request failed: 503 (2 rows). The turn was reverse-replayed, so there is nothing to roll back; the composer stays enabled because a resubmit re-runs the same blocking sync stage.",
+      actions: '<span class="err-btn primary">Switch embedder</span><span class="err-btn">Retry</span><span class="err-btn" id="err-dismiss">Dismiss</span>',
     },
   };
   function setErr(state) {

--- a/docs/ui/screens/reader-composer/reader-composer.md
+++ b/docs/ui/screens/reader-composer/reader-composer.md
@@ -421,30 +421,41 @@ and action buttons. Rationale: these errors need to be visible,
 actionable, and part of the narrative log as context, not a silent
 chrome blip.
 
-| Failure                                                                                                                                                                          | Action buttons                                      |
-| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
-| **LLM call failed**                                                                                                                                                              | `Retry` · `View details` · `Dismiss`                |
-| **Embed call failed** mid-turn (the new-turn affordance disables until resolved per [`memory/retrieval.md → Compute lifecycle`](../../../memory/retrieval.md#compute-lifecycle)) | `Retry` · `Switch embedder` · `Roll back this turn` |
-| **Narrative profile's provider missing** (pre-flight or resolver-time)                                                                                                           | `Fix profile` · `View details` · `Dismiss`          |
-| **Assigned agent profile's provider missing** (pre-flight or resolver-time)                                                                                                      | `Fix profile` · `View details` · `Dismiss`          |
-| **Agent has no profile assigned** (`assignments[agentId]` unset)                                                                                                                 | `Assign profile` · `View details` · `Dismiss`       |
-| **Agent default model's provider missing**                                                                                                                                       | `Fix default` · `View details` · `Dismiss`          |
+| Failure                                                                                                                                                                                                                | Action buttons                                |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| **LLM call failed**                                                                                                                                                                                                    | `Retry` · `View details` · `Dismiss`          |
+| **Embed call failed** mid-turn (blocking per [`memory/retrieval.md → Compute lifecycle`](../../../memory/retrieval.md#compute-lifecycle); the composer is not gated — a resubmit re-runs the same blocking sync stage) | `Switch embedder` · `Retry` · `Dismiss`       |
+| **Narrative profile's provider missing** (pre-flight or resolver-time)                                                                                                                                                 | `Fix profile` · `View details` · `Dismiss`    |
+| **Assigned agent profile's provider missing** (pre-flight or resolver-time)                                                                                                                                            | `Fix profile` · `View details` · `Dismiss`    |
+| **Agent has no profile assigned** (`assignments[agentId]` unset)                                                                                                                                                       | `Assign profile` · `View details` · `Dismiss` |
+| **Agent default model's provider missing**                                                                                                                                                                             | `Fix default` · `View details` · `Dismiss`    |
 
 The embed-failure system entry follows the same visual shape as the
 LLM-failure entry — the contract is "transient pipeline failure
 that blocks turn completion until resolved." `Switch embedder`
 routes to Story Settings · Memory · Switch and fires the
-[Model swap UX](../../../memory/retrieval.md#model-swap-ux) dialog.
-`Roll back this turn` reverse-replays the entire turn's deltas
-through the
-[rollback-confirm modal](./rollback-confirm/rollback-confirm.md).
+[Model swap UX](../../../memory/retrieval.md#model-swap-ux) dialog;
+the bubble's failure detail renders as muted text beneath the
+message rather than behind `View details`.
+
+This row carried a `Roll back this turn` action through the
+[rollback-confirm modal](./rollback-confirm/rollback-confirm.md)
+until it was reconciled against
+[`memory/model-management.md → Embed failure is blocking`](../../../memory/model-management.md#embed-failure-is-blocking):
+there is nothing left to roll back. Any phase failure
+[reverse-replays](../../../generation-pipeline.md#reverse-replay) the
+whole run, and the turn's `user_action` entry shares the run's
+action id, so the rollback has already happened when the bubble is
+written. A _failed_ sync stage wrote nothing at all, and vec0 rows a
+_succeeded_ sync wrote sit outside the delta log by design — they
+repaired rows dirtied by earlier turns, so reversing them would
+discard correct work.
 
 The four **broken-reference** variants come from the pipeline's
 [config pre-flight validation](../../../generation-pipeline.md#config-pre-flight-validation)
-(caught before phase 0 fires — no deltas written, so no
-`Roll back this turn` action), or, in the race case, from a
-resolver-time failure mid-turn. The user can't distinguish which
-layer caught it — same vocabulary either way. The
+(caught before phase 0 fires — no deltas written at all), or, in the
+race case, from a resolver-time failure mid-turn. The user can't
+distinguish which layer caught it — same vocabulary either way. The
 [deletion-semantics design](../../../data-model.md#app-settings-storage)
 is what makes these resolver inputs go missing in the first place.
 Action buttons route to the relevant settings surface: profile /
@@ -473,10 +484,13 @@ dismissed by the next turn:
   Pill copy: `Classifier offline — retrieval coverage thinning`.
   Tap → routes to Story Settings · Memory · Classifier panel.
 
-Pill state precedence: active generation (narrative / chapter-
-close / classifier) > error state > hidden. Sticky errors stay
-visible between turns; once resolved, the pill collapses back to
-hidden until the next event.
+Pill state precedence: blocking phase > error state > background
+phase > hidden, per
+[`generation-status-pill.md → Priority resolution`](../../patterns/generation-status-pill.md#priority-resolution).
+The background classifier pass is the one phase that yields, so a
+sticky error survives it rather than being blanked on its cadence.
+Sticky errors stay visible between turns; once resolved, the pill
+collapses back to hidden until the next event.
 
 The error-pill is **not a new vocabulary** — it reuses the existing
 gen-pill chrome with error-tinted styling instead of the active

--- a/e2e/harness/seed.ts
+++ b/e2e/harness/seed.ts
@@ -108,6 +108,23 @@ export function markEntitiesEmbeddingStale(dbPath: string, branchId: string): vo
   }
 }
 
+// Every embeddable table at once. The seed leaves happenings, threads and
+// entities fresh, so their vec0 families stay empty and KNN returns nothing —
+// a retrieval spec that needs a ranked bundle has to give the embed path
+// something to embed. Runs before launch.
+const EMBEDDABLE_TABLES = ['entities', 'lore', 'chapters', 'threads', 'happenings'] as const
+
+export function markBranchEmbeddingStale(dbPath: string, branchId: string): void {
+  const db = new DatabaseSync(dbPath)
+  try {
+    for (const table of EMBEDDABLE_TABLES) {
+      db.prepare(`UPDATE "${table}" SET embedding_stale = 1 WHERE branch_id = ?`).run(branchId)
+    }
+  } finally {
+    db.close()
+  }
+}
+
 // Leave a story mid-swap: the marker is exactly what a crash mid-phase-1 leaves
 // behind, and the state the swap-paused pill exists to surface. Runs before launch.
 export function markSwapPending(dbPath: string, storyId: string, targetModelId: string): void {

--- a/e2e/locators/story-settings.ts
+++ b/e2e/locators/story-settings.ts
@@ -32,6 +32,10 @@ export const storySettings = {
   // The standalone re-index is gated by a confirm dialog; this is its start button.
   reindexConfirmStart: (page: Page): Locator => page.getByTestId('reindex-confirm-start'),
 
+  // The swap dialog's own title — the observable half of an action that both
+  // routes to the memory panel and opens the dialog on top of it.
+  swapDialogTitle: (page: Page): Locator => page.getByText(t('storySettings:swap.title')),
+
   // SwapDialog's CandidateRow testID embeds the whole target, not the model id:
   // a model installed locally AND served by the provider is two rows, and a bare
   // id would match both and trip strict mode. getByTestId matches through

--- a/e2e/tests/classifier.spec.ts
+++ b/e2e/tests/classifier.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test'
 
 import { queryApp } from '../harness/db'
+import { installEmbedderModel } from '../harness/embedder'
 import { t } from '../harness/i18n'
 import { launchApp, type LaunchedApp } from '../harness/launch'
 import { startMockLlm, type MockLlm } from '../harness/mock-llm'
@@ -22,8 +23,13 @@ test.describe('turn fanning out to the fallback classifier', () => {
   let userDataDir: string | undefined
 
   test.beforeAll(async () => {
+    // Retrieval blocks ahead of narrative, so a turn without an installed
+    // embedder never reaches the reply (model-management.md → Embed failure is
+    // blocking). Cold cache downloads ~24 MB from Hugging Face before launch.
+    test.setTimeout(180_000)
     const seeded = createSeededUserDataDir()
     userDataDir = seeded.userDataDir
+    await installEmbedderModel(userDataDir)
     mock = await startMockLlm()
     mock.setNarrative('E2E-CLASSIFIER-TURN the courier moves.')
     setProviderEndpoint(seeded.dbPath, mock.url)

--- a/e2e/tests/periodic-classifier.spec.ts
+++ b/e2e/tests/periodic-classifier.spec.ts
@@ -24,8 +24,12 @@ test.describe('periodic classifier — graph population', () => {
   let userDataDir: string | undefined
 
   test.beforeAll(async () => {
+    // Retrieval blocks ahead of narrative, so a turn without an installed
+    // embedder never reaches the reply. Cold cache downloads ~24 MB.
+    test.setTimeout(180_000)
     const seeded = createSeededUserDataDir()
     userDataDir = seeded.userDataDir
+    await installEmbedderModel(userDataDir)
     mock = await startMockLlm()
     mock.setNarrative('E2E-CLASSIFIER the courier reaches the ford.')
     // A new character with a temp handle keeps the reply independent of the
@@ -96,13 +100,23 @@ test.describe('periodic classifier — graph population', () => {
       )
       .toBe(1)
 
-    // Nothing embeds on the write path.
-    const stale = await queryApp(
-      app.window,
-      `SELECT embedding_stale FROM happenings WHERE branch_id = ? AND title LIKE '%ford%'`,
-      [branchId],
-    )
-    expect(stale[0][0]).toBe(1)
+    // The drain resets embedding_stale moments after the write, so the flag is
+    // not observable from here (lessons-learned/staleness-flags-are-cleared-by-the-drain.md).
+    // plan.test.ts owns the write-path contract; assert the settled state.
+    await expect
+      .poll(
+        async () =>
+          (
+            await queryApp(
+              app.window,
+              `SELECT COUNT(*) FROM happenings
+               WHERE branch_id = ? AND title LIKE '%ford%' AND embedding_stale = 1`,
+              [branchId],
+            )
+          )[0][0],
+        { timeout: 20_000 },
+      )
+      .toBe(0)
 
     // Scoped to the happening this run created — the fixture already seeds
     // unrelated happening_awareness / happening_involvements rows on this branch.
@@ -246,8 +260,12 @@ test.describe('periodic classifier — backlog deeper than the reader window', (
   let userDataDir: string | undefined
 
   test.beforeAll(async () => {
+    // Retrieval blocks ahead of narrative, so a turn without an installed
+    // embedder never reaches the reply. Cold cache downloads ~24 MB.
+    test.setTimeout(180_000)
     const seeded = createSeededUserDataDir()
     userDataDir = seeded.userDataDir
+    await installEmbedderModel(userDataDir)
     mock = await startMockLlm()
     mock.setNarrative('E2E-BACKLOG the road goes on.')
     setProviderEndpoint(seeded.dbPath, mock.url)
@@ -306,8 +324,12 @@ test.describe('periodic classifier — unassigned agent', () => {
   let userDataDir: string | undefined
 
   test.beforeAll(async () => {
+    // Retrieval blocks ahead of narrative, so a turn without an installed
+    // embedder never reaches the reply. Cold cache downloads ~24 MB.
+    test.setTimeout(180_000)
     const seeded = createSeededUserDataDir()
     userDataDir = seeded.userDataDir
+    await installEmbedderModel(userDataDir)
     mock = await startMockLlm()
     mock.setNarrative('E2E-NOAGENT the lantern gutters.')
     setProviderEndpoint(seeded.dbPath, mock.url)

--- a/e2e/tests/reader-cancel.spec.ts
+++ b/e2e/tests/reader-cancel.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test'
 
 import { queryApp } from '../harness/db'
+import { installEmbedderModel } from '../harness/embedder'
 import { launchApp, type LaunchedApp } from '../harness/launch'
 import { startMockLlm, type MockLlm } from '../harness/mock-llm'
 import { createSeededUserDataDir, removeUserDataDir, setProviderEndpoint } from '../harness/seed'
@@ -20,8 +21,13 @@ test.describe('reader — cancel a turn mid-flight', () => {
   let userDataDir: string | undefined
 
   test.beforeAll(async () => {
+    // Retrieval blocks ahead of narrative, so without an installed embedder the
+    // turn dies there and no stream is ever opened to cancel. Cold cache
+    // downloads ~24 MB from Hugging Face before launch.
+    test.setTimeout(180_000)
     const seeded = createSeededUserDataDir()
     userDataDir = seeded.userDataDir
+    await installEmbedderModel(userDataDir)
     mock = await startMockLlm()
     setProviderEndpoint(seeded.dbPath, mock.url)
     app = await launchApp({ userDataDir, cleanupUserData: true })
@@ -43,6 +49,12 @@ test.describe('reader — cancel a turn mid-flight', () => {
 
     // The held stream keeps the turn in-flight, so the composer shows Cancel.
     await expect(reader.cancel(app.window)).toBeVisible({ timeout: 20_000 })
+    // Cancel is live from the first phase, and retrieval runs ahead of
+    // narrative — so waiting on the button alone would let the click land
+    // mid-retrieval, aborting a turn that never opened a stream and quietly
+    // retiring what this spec exists to cover. The mock recording the streaming
+    // request is the proof the held stream is actually open.
+    await expect.poll(() => mock.requests.some((r) => r.streamed), { timeout: 20_000 }).toBe(true)
     await reader.cancel(app.window).click()
 
     // Generation ends: the composer returns to its Send state.

--- a/e2e/tests/reader-composer-modes.spec.ts
+++ b/e2e/tests/reader-composer-modes.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test'
 
 import { queryApp } from '../harness/db'
+import { installEmbedderModel } from '../harness/embedder'
 import { launchApp, type LaunchedApp } from '../harness/launch'
 import { startMockLlm, type MockLlm } from '../harness/mock-llm'
 import { createSeededUserDataDir, removeUserDataDir, setProviderEndpoint } from '../harness/seed'
@@ -20,8 +21,13 @@ test.describe('reader — composer modes', () => {
   let userDataDir: string | undefined
 
   test.beforeAll(async () => {
+    // Retrieval blocks ahead of narrative, so a turn without an installed
+    // embedder never reaches the reply (model-management.md → Embed failure is
+    // blocking). Cold cache downloads ~24 MB from Hugging Face before launch.
+    test.setTimeout(180_000)
     const seeded = createSeededUserDataDir()
     userDataDir = seeded.userDataDir
+    await installEmbedderModel(userDataDir)
     mock = await startMockLlm()
     mock.setNarrative('E2E-MODES-REPLY the courier answers.')
     setProviderEndpoint(seeded.dbPath, mock.url)

--- a/e2e/tests/reader-failure-retry.spec.ts
+++ b/e2e/tests/reader-failure-retry.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test'
 
 import { queryApp } from '../harness/db'
+import { installEmbedderModel } from '../harness/embedder'
 import { launchApp, type LaunchedApp } from '../harness/launch'
 import { startMockLlm, type MockLlm } from '../harness/mock-llm'
 import { createSeededUserDataDir, removeUserDataDir, setProviderEndpoint } from '../harness/seed'
@@ -20,8 +21,14 @@ test.describe('reader — turn failure then retry', () => {
   let userDataDir: string | undefined
 
   test.beforeAll(async () => {
+    // Retrieval blocks ahead of narrative, so without an installed embedder the
+    // turn fails there first — and an `embedder`-kind failure is a DIFFERENT
+    // system entry (Switch embedder, describeTurnFailure) than the provider one
+    // this spec pins. Cold cache downloads ~24 MB from Hugging Face.
+    test.setTimeout(180_000)
     const seeded = createSeededUserDataDir()
     userDataDir = seeded.userDataDir
+    await installEmbedderModel(userDataDir)
     mock = await startMockLlm()
     mock.setNarrative(REPLY)
     setProviderEndpoint(seeded.dbPath, mock.url)

--- a/e2e/tests/reader-undo-redo.spec.ts
+++ b/e2e/tests/reader-undo-redo.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test'
 
 import { queryApp } from '../harness/db'
+import { installEmbedderModel } from '../harness/embedder'
 import { launchApp, type LaunchedApp } from '../harness/launch'
 import { startMockLlm, type MockLlm } from '../harness/mock-llm'
 import { createSeededUserDataDir, removeUserDataDir, setProviderEndpoint } from '../harness/seed'
@@ -19,8 +20,13 @@ test.describe('reader — undo / redo a turn', () => {
   let userDataDir: string | undefined
 
   test.beforeAll(async () => {
+    // Retrieval blocks ahead of narrative, so a turn without an installed
+    // embedder never reaches the reply (model-management.md → Embed failure is
+    // blocking). Cold cache downloads ~24 MB from Hugging Face before launch.
+    test.setTimeout(180_000)
     const seeded = createSeededUserDataDir()
     userDataDir = seeded.userDataDir
+    await installEmbedderModel(userDataDir)
     mock = await startMockLlm()
     mock.setNarrative(REPLY)
     setProviderEndpoint(seeded.dbPath, mock.url)

--- a/e2e/tests/retrieval-embed-failure.spec.ts
+++ b/e2e/tests/retrieval-embed-failure.spec.ts
@@ -1,0 +1,233 @@
+import { expect, test } from '@playwright/test'
+
+import { queryApp } from '../harness/db'
+import { installEmbedderModel } from '../harness/embedder'
+import { t } from '../harness/i18n'
+import { launchApp, type LaunchedApp } from '../harness/launch'
+import { startMockLlm, type MockLlm } from '../harness/mock-llm'
+import { createSeededUserDataDir, removeUserDataDir, setProviderEndpoint } from '../harness/seed'
+import { home } from '../locators/home'
+import { reader } from '../locators/reader'
+import { storySettings } from '../locators/story-settings'
+
+const HERO_TITLE = 'The Veilstone Courier'
+const HERO_BRANCH = 'br_hero_main'
+
+const USER_MARKER = 'E2E-EMBEDFAIL-USER'
+const REPLY_MARKER = 'E2E-EMBEDFAIL-REPLY'
+const REPLY = `${REPLY_MARKER} the amulet answers, memory restored.`
+const ACTION = `${USER_MARKER} I reach for the amulet.`
+
+// The five embeddable source tables (lib/db → SOURCE_TABLES). The seed leaves
+// two rows on this branch dirty, and runSyncStage reports one EmbeddedFieldRow
+// per record — so this sum IS the staleCount the failure detail must carry.
+const STALE_SUM_SQL = `SELECT ${['entities', 'lore', 'happenings', 'threads', 'chapters']
+  .map((table) => `(SELECT count(*) FROM "${table}" WHERE branch_id = ? AND embedding_stale = 1)`)
+  .join(' + ')}`
+
+const MARKER_ENTRY_SQL = `SELECT count(*) FROM story_entries WHERE branch_id = ? AND content LIKE '%${USER_MARKER}%'`
+
+// The blocking half of the retrieval seam: with no embedder on disk the sync
+// stage fails, and model-management.md → Embed failure is blocking says the turn
+// must be refused whole rather than generated against a stale index. The fault
+// injection is the absent model — the same shape wizard-embedder-gate.spec.ts
+// uses, and no product change. See docs/memory/model-management.md.
+//
+// Serial, not a plain describe: the second test retries the first one's failed
+// turn, so a retry has to replay the pair from the start — Playwright's default
+// would re-run beforeAll into a fresh app and then only the second test, which
+// has no system entry to retry.
+test.describe.serial('retrieval — a failed embed blocks the turn', () => {
+  let app: LaunchedApp
+  let mock: MockLlm
+  let userDataDir: string | undefined
+
+  test.beforeAll(async () => {
+    const seeded = createSeededUserDataDir()
+    userDataDir = seeded.userDataDir
+    // Deliberately NOT installEmbedderModel — the inverse of every other spec
+    // that submits a turn. The model arrives mid-describe, in the second test.
+    mock = await startMockLlm()
+    mock.setNarrative(REPLY)
+    setProviderEndpoint(seeded.dbPath, mock.url)
+    app = await launchApp({ userDataDir, cleanupUserData: true })
+  })
+
+  test.afterAll(async () => {
+    await app?.close()
+    await mock?.close()
+    removeUserDataDir(userDataDir)
+  })
+
+  async function scalar(sql: string, params: unknown[] = []): Promise<number> {
+    const [[value]] = await queryApp(app.window, sql, params)
+    return Number(value)
+  }
+
+  async function systemFailureMeta(): Promise<{
+    kind: string
+    detail?: string
+    submission?: { content: string; composerMode: string }
+  }> {
+    const rows = await queryApp(
+      app.window,
+      `SELECT metadata FROM story_entries WHERE branch_id = ? AND kind = 'system'`,
+      [HERO_BRANCH],
+    )
+    expect(rows.length, 'exactly one system entry on the branch').toBe(1)
+    const metadata = JSON.parse(String(rows[0][0])) as {
+      systemFailure?: {
+        kind: string
+        detail?: string
+        submission?: { content: string; composerMode: string }
+      }
+    }
+    expect(metadata.systemFailure, 'the entry carries its failure meta').toBeDefined()
+    return metadata.systemFailure!
+  }
+
+  test('refuses the turn, reverses the action, and offers Switch embedder', async () => {
+    test.setTimeout(120_000)
+
+    await home.openStory(app.window, HERO_TITLE).click()
+    await expect(reader.composer(app.window)).toBeVisible({ timeout: 20_000 })
+
+    const staleBefore = await scalar(STALE_SUM_SQL, [HERO_BRANCH, ...Array(4).fill(HERO_BRANCH)])
+    // Without dirty rows runSyncStage short-circuits before the embedder and the
+    // magnitude below has nothing to report.
+    expect(staleBefore, 'the seed leaves the branch with rows to embed').toBeGreaterThan(0)
+    expect(await scalar(MARKER_ENTRY_SQL, [HERO_BRANCH]), 'the marker is ours alone').toBe(0)
+
+    await reader.composer(app.window).fill(ACTION)
+    await reader.send(app.window).click()
+
+    // The embedder-specific copy, which only describeTurnFailure's `embedder`
+    // arm produces — a failure that reached the generic arm renders the string
+    // asserted absent below instead.
+    await expect(
+      app.window.getByText(t('reader:systemEntry.failure.embed'), { exact: false }),
+      'the embedder-specific system entry',
+    ).toBeVisible({ timeout: 90_000 })
+    await expect(
+      app.window.getByText(t('reader:systemEntry.failureMessage'), { exact: false }),
+      'not the generic failure copy',
+    ).toHaveCount(0)
+
+    // The turn is reversed whole: the user_action shares the run's actionId, so
+    // abortRun's reverse-replay takes it with the rest. Nothing narrative-side
+    // reached the mock either — retrieval blocks ahead of it.
+    expect(
+      await scalar(MARKER_ENTRY_SQL, [HERO_BRANCH]),
+      'the user action left no row on the branch',
+    ).toBe(0)
+    expect(
+      mock.requests.filter((r) => r.streamed).length,
+      'the narrative call was never opened behind the refusal',
+    ).toBe(0)
+
+    // The text survives only on the system entry, which is what makes the retry
+    // in the next test possible at all — reversed from the timeline, retained
+    // for recovery.
+    const failure = await systemFailureMeta()
+    expect(failure.kind, 'the persisted discriminant drives the fix action').toBe('embedder')
+    expect(failure.submission?.content, 'the reversed action is retained for retry').toBe(ACTION)
+
+    // A real staleCount from a real sync failure reaches the rendered detail:
+    // reason prefix, cause, and the magnitude in rows. `(null rows)` — the shape
+    // this template has to avoid — is unit-pinned in system-entry-actions.test.tsx;
+    // what only a run can show is that the number is the branch's actual dirty
+    // set rather than a post-drain zero.
+    expect(failure.detail, 'the detail carries reason and magnitude').toMatch(
+      new RegExp(`^(init|call): .+ \\(${staleBefore} rows\\)$`, 's'),
+    )
+    await expect(
+      app.window.getByText(failure.detail!, { exact: false }),
+      'the detail line renders under the copy',
+    ).toBeVisible()
+
+    // The fix action exists only because the reader hands the open story's id to
+    // useSystemEntryActions; a null there drops the button silently, and no unit
+    // test can reach app/**. The id in the URL pins that it is the RIGHT story.
+    const [[storyId]] = await queryApp(app.window, `SELECT story_id FROM branches WHERE id = ?`, [
+      HERO_BRANCH,
+    ])
+    await app.window
+      .getByRole('button', { name: t('reader:systemEntry.switchEmbedder') })
+      .click({ timeout: 15_000 })
+
+    await expect(app.window, 'lands on this story’s memory tab').toHaveURL(
+      new RegExp(`/story-settings/${String(storyId)}\\?tab=memory$`),
+      { timeout: 20_000 },
+    )
+    await expect(storySettings.memoryPanel(app.window), 'the memory panel is mounted').toBeVisible()
+    // The action's second half: the panel is the swap dialog's only mount host,
+    // so routing without opening it would strand the user one click short.
+    await expect(
+      storySettings.swapDialogTitle(app.window),
+      'the swap dialog opened on top of it',
+    ).toBeVisible({ timeout: 15_000 })
+  })
+
+  test('retries against a model installed after the failure', async () => {
+    test.setTimeout(180_000)
+    expect(userDataDir, 'the running app’s userData').toBeDefined()
+
+    // Into the SAME userData the app is running against. Init is lazy and a
+    // failed pipeline build is evicted rather than cached (electron/embedder/service.ts),
+    // so the next call has to pick the files up with no restart.
+    await installEmbedderModel(userDataDir!)
+
+    await app.window.goBack()
+    await expect(reader.composer(app.window)).toBeVisible({ timeout: 20_000 })
+
+    await reader.retrySystemEntry(app.window).click()
+    await expect(app.window.getByText(REPLY_MARKER, { exact: false })).toBeVisible({
+      timeout: 120_000,
+    })
+
+    // The reversed action is back on the branch, so Retry resubmitted the whole
+    // turn rather than resuming a half-committed one.
+    expect(await scalar(MARKER_ENTRY_SQL, [HERO_BRANCH]), 'the action recommitted').toBe(1)
+    expect(
+      await scalar(
+        `SELECT count(*) FROM story_entries WHERE branch_id = ? AND content LIKE '%${REPLY_MARKER}%'`,
+        [HERO_BRANCH],
+      ),
+      'the reply committed',
+    ).toBe(1)
+    // The reply cannot commit unless the blocking stage cleared every flag it
+    // found, so a non-zero count here means retrieval stopped blocking on them.
+    // (The opportunistic drain can reach the same rows, so this pins the state,
+    // not which writer got there first.)
+    expect(
+      await scalar(STALE_SUM_SQL, [HERO_BRANCH, ...Array(4).fill(HERO_BRANCH)]),
+      'the branch it refused to generate on is embedded',
+    ).toBe(0)
+    await expect
+      .poll(
+        async () =>
+          scalar(`SELECT count(*) FROM story_entries WHERE branch_id = ? AND kind = 'system'`, [
+            HERO_BRANCH,
+          ]),
+        { timeout: 15_000 },
+      )
+      .toBe(0)
+
+    // Everything above is also true of a Retry that generated without
+    // retrieving: the counts prove the NARRATIVE ran, and the drain clears the
+    // stale rows either way. Only the prompt distinguishes a re-run pass from a
+    // skipped one, so a short-circuit — a memoised "branch is synced", an
+    // intermediate carried across the retried run — would generate against a
+    // stale index with an empty bundle and every assertion above would hold.
+    // The chapters block is the marker because it is the only one with no
+    // structural path: entities, lore and threads all render from the floor too,
+    // so their headers appear whether or not the ranker ran. A chapter is ranked
+    // or absent. (Happenings are equally exclusive but this fixture seats none.)
+    const retried = mock.requests.findLast((r) => r.streamed)
+    expect(retried, 'the retry reached the provider').toBeDefined()
+    expect(
+      JSON.stringify(retried!.body),
+      'the retry composed a memory bundle rather than skipping retrieval',
+    ).toContain('# Earlier chapters')
+  })
+})

--- a/e2e/tests/retrieval.spec.ts
+++ b/e2e/tests/retrieval.spec.ts
@@ -1,0 +1,148 @@
+import { expect, test } from '@playwright/test'
+
+import { queryApp } from '../harness/db'
+import { installEmbedderModel } from '../harness/embedder'
+import { launchApp, type LaunchedApp } from '../harness/launch'
+import { startMockLlm, type MockLlm, type MockRequest } from '../harness/mock-llm'
+import {
+  createSeededUserDataDir,
+  markBranchEmbeddingStale,
+  removeUserDataDir,
+  setProviderEndpoint,
+} from '../harness/seed'
+import { home } from '../locators/home'
+import { reader } from '../locators/reader'
+
+const HERO_TITLE = 'The Veilstone Courier'
+const HERO_BRANCH = 'br_hero_main'
+
+const REPLY = 'E2E-RETRIEVAL-REPLY — the amulet answers, warm against the rib.'
+
+// Deliberately on top of hap_ambush ("The alley ambush / Vorne's people corner
+// Kael; Mira pulls him clear"): this string IS Q1, and a happening only reaches
+// the bundle by clearing RANKER_DEFAULTS.minScoreThreshold. No E2E marker
+// prefix — it would be noise in the embedded query, and nothing reads it back.
+const ACTION = 'Ask Mira what really happened during the alley ambush.'
+
+const AWARENESS_SUM_SQL = `SELECT COALESCE(SUM(retrieval_count), 0) FROM happening_awareness WHERE branch_id = ?`
+const AWARENESS_DELTA_SQL = `SELECT count(*) FROM deltas WHERE branch_id = ? AND target_table = 'happening_awareness'`
+
+// The whole retrieval seam on one turn: the blocking sync stage embeds the
+// branch's dirty rows, KNN + the ranker build a bundle, the bundle reaches the
+// prompt the app actually sends, and the happenings it injected bump
+// retrieval_count through a reversible delta. See docs/memory/retrieval.md.
+test.describe('retrieval — a turn injects a retrieved bundle', () => {
+  let app: LaunchedApp
+  let mock: MockLlm
+  let userDataDir: string | undefined
+  let dim: number
+
+  test.beforeAll(async () => {
+    // Cold cache downloads ~24 MB from Hugging Face before launch.
+    test.setTimeout(180_000)
+    const seeded = createSeededUserDataDir()
+    userDataDir = seeded.userDataDir
+    ;({ dim } = await installEmbedderModel(userDataDir))
+    // The seed leaves every happening fresh, so happenings_vec_* would stay
+    // empty and the ranked-happening path — the only one with a DB-observable
+    // side effect — could never fire.
+    markBranchEmbeddingStale(seeded.dbPath, HERO_BRANCH)
+    mock = await startMockLlm()
+    mock.setNarrative(REPLY)
+    setProviderEndpoint(seeded.dbPath, mock.url)
+    app = await launchApp({ userDataDir, cleanupUserData: true })
+  })
+
+  test.afterAll(async () => {
+    await app?.close()
+    await mock?.close()
+    removeUserDataDir(userDataDir)
+  })
+
+  async function scalar(sql: string, params: unknown[] = []): Promise<number> {
+    const [[value]] = await queryApp(app.window, sql, params)
+    return Number(value)
+  }
+
+  // The mock records the request body verbatim; the prompt never renders, so
+  // this is the only place to observe it. Stringified rather than re-flattened
+  // per message: the headers below are distinctive enough that the surrounding
+  // JSON escaping cannot manufacture a false match.
+  function promptOf(request: MockRequest): string {
+    return JSON.stringify(request.body)
+  }
+
+  test('embeds the branch, injects a ranked bundle, and bumps retrieval_count reversibly', async () => {
+    // A real embed pass over every row on the branch precedes the turn.
+    test.setTimeout(180_000)
+    // Guards the vec0 table name asserted below against a catalog dim change.
+    expect(dim).toBe(384)
+
+    await home.openStory(app.window, HERO_TITLE).click()
+    await expect(reader.composer(app.window)).toBeVisible({ timeout: 20_000 })
+
+    const awarenessBefore = await scalar(AWARENESS_SUM_SQL, [HERO_BRANCH])
+    // Nothing has retrieved on this branch yet, so a bump is the only writer
+    // that can move either number.
+    expect(await scalar(AWARENESS_DELTA_SQL, [HERO_BRANCH]), 'no seeded awareness deltas').toBe(0)
+
+    // Submitted without waiting for the background drain on purpose: the sync
+    // stage is blocking, so the bundle below is complete whatever the drain has
+    // reached — and the drain bails at its next batch boundary once the run is
+    // active (lib/embedder/drain.ts), leaving the sync as the writer in flight.
+    await reader.composer(app.window).fill(ACTION)
+    await reader.send(app.window).click()
+    await expect(app.window.getByText('E2E-RETRIEVAL-REPLY', { exact: false })).toBeVisible({
+      timeout: 90_000,
+    })
+
+    // Every happening on the branch is embedded and KNN-readable. Compared
+    // against the source count, not `> 0`: a sync that embedded one table's
+    // first batch and stopped would still pass a bare non-zero check.
+    const happenings = await scalar(`SELECT count(*) FROM happenings WHERE branch_id = ?`, [
+      HERO_BRANCH,
+    ])
+    expect(happenings, 'the seed has happenings to embed').toBeGreaterThan(0)
+    expect(
+      await scalar(`SELECT count(*) FROM happenings_vec_384 WHERE branch_id = ?`, [HERO_BRANCH]),
+      'a vector per happening on the branch',
+    ).toBe(happenings)
+
+    const narrative = mock.requests.findLast((r) => r.streamed)
+    expect(narrative, 'a streaming narrative call was made').toBeDefined()
+    const prompt = promptOf(narrative!)
+    // Ranker output: `# What has happened` has exactly one source,
+    // retrievedHappenings (lib/prompts/bundled/memory-blocks.ts), which is the
+    // selected happenings bundle and nothing else.
+    expect(prompt, 'the retrieved happenings block reached the prompt').toContain(
+      '# What has happened',
+    )
+    // Structural floor, not the ranker — but it is still retrieval's output: a
+    // failed pass leaves generation-context's floor undefined and every pinned
+    // bundle empty, so the header disappears with it.
+    expect(prompt, 'the structural lore floor reached the prompt').toContain('# Relevant lore')
+
+    // Injecting a happening bumps the awareness rows behind it. Only rows whose
+    // character is in scene are loaded, so this can only move if the POV scope,
+    // the ranker and the delta writer all agreed.
+    const awarenessAfter = await scalar(AWARENESS_SUM_SQL, [HERO_BRANCH])
+    expect(awarenessAfter, 'retrieval_count advanced').toBeGreaterThan(awarenessBefore)
+    // Each bump is +1 and carries exactly one delta, so the log and the counters
+    // have to agree — a bump written outside the delta layer, or a delta that
+    // moved a counter by more than one, breaks the equality and not the
+    // inequality above.
+    expect(
+      await scalar(AWARENESS_DELTA_SQL, [HERO_BRANCH]),
+      'one logged delta per counted bump',
+    ).toBe(awarenessAfter - awarenessBefore)
+
+    // The slice's acceptance criterion: the bump is reversible. The turn's
+    // reversal window is anchored at the user_action's create delta, which the
+    // bumps sit after, so one undo has to take them with it.
+    await reader.actionsTrigger(app.window).click()
+    await reader.undoRow(app.window).click()
+    await expect
+      .poll(async () => scalar(AWARENESS_SUM_SQL, [HERO_BRANCH]), { timeout: 15_000 })
+      .toBe(awarenessBefore)
+  })
+})

--- a/e2e/tests/structured-force-on.spec.ts
+++ b/e2e/tests/structured-force-on.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test'
 
+import { installEmbedderModel } from '../harness/embedder'
 import { t } from '../harness/i18n'
 import { launchApp, type LaunchedApp } from '../harness/launch'
 import { startMockLlm, type MockLlm } from '../harness/mock-llm'
@@ -25,8 +26,13 @@ test.describe('force-on structured output', () => {
   let userDataDir: string | undefined
 
   test.beforeAll(async () => {
+    // Retrieval blocks ahead of narrative, so a turn without an installed
+    // embedder never reaches the reply (model-management.md → Embed failure is
+    // blocking). Cold cache downloads ~24 MB from Hugging Face before launch.
+    test.setTimeout(180_000)
     const seeded = createSeededUserDataDir()
     userDataDir = seeded.userDataDir
+    await installEmbedderModel(userDataDir)
     mock = await startMockLlm()
     mock.setNarrative('E2E-FORCEON-REPLY the courier waits.')
     setProviderEndpoint(seeded.dbPath, mock.url)

--- a/e2e/tests/suggestions.spec.ts
+++ b/e2e/tests/suggestions.spec.ts
@@ -3,6 +3,7 @@ import { expect, test, type Page } from '@playwright/test'
 import type { EntryMetadata } from '@/lib/db'
 
 import { queryApp } from '../harness/db'
+import { installEmbedderModel } from '../harness/embedder'
 import { t } from '../harness/i18n'
 import { launchApp, type LaunchedApp } from '../harness/launch'
 import { startMockLlm, type MockLlm } from '../harness/mock-llm'
@@ -88,8 +89,13 @@ test.describe('next-turn suggestions — narrative (piggyback) fold', () => {
   let userDataDir: string | undefined
 
   test.beforeAll(async () => {
+    // Retrieval blocks ahead of narrative, so a turn without an installed
+    // embedder never reaches the reply (model-management.md → Embed failure is
+    // blocking). Cold cache downloads ~24 MB from Hugging Face before launch.
+    test.setTimeout(180_000)
     const seeded = createSeededUserDataDir()
     userDataDir = seeded.userDataDir
+    await installEmbedderModel(userDataDir)
     mock = await startMockLlm()
     mock.setNarrative(NARRATIVE_WITH_TAGS)
     setProviderEndpoint(seeded.dbPath, mock.url)
@@ -237,8 +243,13 @@ test.describe('next-turn suggestions — classifier fold', () => {
   let userDataDir: string | undefined
 
   test.beforeAll(async () => {
+    // Retrieval blocks ahead of narrative, so a turn without an installed
+    // embedder never reaches the reply (model-management.md → Embed failure is
+    // blocking). Cold cache downloads ~24 MB from Hugging Face before launch.
+    test.setTimeout(180_000)
     const seeded = createSeededUserDataDir()
     userDataDir = seeded.userDataDir
+    await installEmbedderModel(userDataDir)
     mock = await startMockLlm()
     mock.setNarrative(CLASSIFIER_NARRATIVE)
     mock.setStructured('per-turn-classifier-suggestions', {

--- a/e2e/tests/turn.spec.ts
+++ b/e2e/tests/turn.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test'
 
 import { queryApp } from '../harness/db'
+import { installEmbedderModel } from '../harness/embedder'
 import { t } from '../harness/i18n'
 import { launchApp, type LaunchedApp } from '../harness/launch'
 import { startMockLlm, type MockLlm } from '../harness/mock-llm'
@@ -16,8 +17,13 @@ test.describe('reader turn against the mock LLM', () => {
   let userDataDir: string | undefined
 
   test.beforeAll(async () => {
+    // Retrieval blocks ahead of narrative, so a turn without an installed
+    // embedder never reaches the reply (model-management.md → Embed failure is
+    // blocking). Cold cache downloads ~24 MB from Hugging Face before launch.
+    test.setTimeout(180_000)
     const seeded = createSeededUserDataDir()
     userDataDir = seeded.userDataDir
+    await installEmbedderModel(userDataDir)
     mock = await startMockLlm()
     mock.setNarrative(REPLY)
     setProviderEndpoint(seeded.dbPath, mock.url)

--- a/hooks/use-open-region-tokens.test.tsx
+++ b/hooks/use-open-region-tokens.test.tsx
@@ -169,6 +169,24 @@ describe('useOpenRegionTokens', () => {
     expect(latest).toBeGreaterThan(0)
   })
 
+  // A branch switch moves the open story before the reader re-hydrates the
+  // working set, so the map can still hold the branch being left.
+  it('ignores entries the working set still holds for another branch', () => {
+    entriesStore.hydrate('b1', [row('e1', LONG), row('e2', SHORT)])
+    openStory()
+    currentStoryStore.set({
+      ...currentStoryStore.getCurrentStory()!,
+      branchId: 'b2',
+    })
+    render(<Probe nonce={0} />)
+    expect(latest).toBe(0)
+    // Positive control: the same rows count once the open branch is theirs again.
+    cleanup()
+    openStory()
+    render(<Probe nonce={0} />)
+    expect(latest).toBeCloseTo(pctOf(LONG, SHORT), 10)
+  })
+
   it('returns 0 for a caller with no story of its own yet', () => {
     entriesStore.hydrate('b1', [row('e2', SHORT)])
     openStory()

--- a/hooks/use-open-region-tokens.test.tsx
+++ b/hooks/use-open-region-tokens.test.tsx
@@ -25,12 +25,8 @@ vi.mock('@/lib/retrieval', async (importOriginal) => {
 })
 
 const THRESHOLD = 24_000
-// Ordinary prose, not one repeated character. tiktoken's split regex leaves
-// 'x'.repeat(4000) as a single word, and the BPE merge over it costs ~600ms
-// against ~0ms for the same length of real text — enough of them here to blow
-// the 5s default on CI while passing locally.
-const LONG = 'the quick brown fox jumps over the lazy dog. '.repeat(90)
-const SHORT = 'the quick brown fox jumps over the lazy dog. '.repeat(9)
+const LONG = 'x'.repeat(4000)
+const SHORT = 'x'.repeat(400)
 
 function entry(
   id: string,

--- a/hooks/use-open-region-tokens.test.tsx
+++ b/hooks/use-open-region-tokens.test.tsx
@@ -1,0 +1,194 @@
+// @vitest-environment jsdom
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { STORY_SETTINGS_DEFAULTS, storyDefinitionSchema, type StoryEntry } from '@/lib/db'
+import { countTokens } from '@/lib/retrieval'
+import { currentStoryStore, entriesStore } from '@/lib/stores'
+
+import { openRegionProgress, useOpenRegionTokens } from './use-open-region-tokens'
+
+// Counts walk iterations so the memo claim is measured, not asserted: the pure
+// function calls this once per entry it visits.
+const probe = vi.hoisted(() => ({ walked: 0 }))
+
+vi.mock('@/lib/retrieval', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  const real = actual.countEntryTokens as (entryId: string, content: string) => number
+  return {
+    ...actual,
+    countEntryTokens: (entryId: string, content: string) => {
+      probe.walked += 1
+      return real(entryId, content)
+    },
+  }
+})
+
+const THRESHOLD = 24_000
+const LONG = 'x'.repeat(4000)
+const SHORT = 'x'.repeat(400)
+
+function entry(
+  id: string,
+  content: string,
+  chapterId: string | null = null,
+  kind: StoryEntry['kind'] = 'ai_reply',
+): Pick<StoryEntry, 'id' | 'content' | 'chapterId' | 'kind'> {
+  return { id, content, chapterId, kind }
+}
+
+function pctOf(...contents: string[]): number {
+  return (contents.reduce((sum, c) => sum + countTokens(c), 0) / THRESHOLD) * 100
+}
+
+describe('openRegionProgress', () => {
+  it('counts only entries in the open region', () => {
+    expect(
+      openRegionProgress([entry('a', LONG, 'ch_1'), entry('b', SHORT)], THRESHOLD),
+    ).toBeCloseTo(pctOf(SHORT), 10)
+    // Positive control: the excluded entry is not inert — it counts once its
+    // chapterId is null, so the assertion above is about the skip, not the row.
+    expect(openRegionProgress([entry('a', LONG, null), entry('b', SHORT)], THRESHOLD)).toBeCloseTo(
+      pctOf(LONG, SHORT),
+      10,
+    )
+  })
+
+  it('excludes system entries', () => {
+    expect(openRegionProgress([entry('sys', SHORT, null, 'system')], THRESHOLD)).toBe(0)
+    // Positive control: same body under a non-system kind is counted.
+    expect(openRegionProgress([entry('ai', SHORT, null, 'ai_reply')], THRESHOLD)).toBeCloseTo(
+      pctOf(SHORT),
+      10,
+    )
+  })
+
+  it('clamps at 100 past the threshold', () => {
+    expect(openRegionProgress([entry('a', LONG)], 100)).toBe(100)
+    // Positive control: below the threshold the same body reports its raw share.
+    expect(openRegionProgress([entry('a', LONG)], 100_000)).toBeCloseTo(
+      (countTokens(LONG) / 100_000) * 100,
+      10,
+    )
+  })
+
+  it('returns 0 for an empty branch and for a non-usable threshold', () => {
+    expect(openRegionProgress([], THRESHOLD)).toBe(0)
+    for (const bad of [0, -1, Number.NaN]) {
+      expect(openRegionProgress([entry('a', SHORT)], bad)).toBe(0)
+    }
+    // Positive control: the same entry reports non-zero against a usable threshold.
+    expect(openRegionProgress([entry('a', SHORT)], THRESHOLD)).toBeGreaterThan(0)
+  })
+})
+
+const DEFINITION = storyDefinitionSchema.parse({
+  mode: 'adventure',
+  leadEntityId: 'char_00000000-0000-4000-8000-000000000001',
+  narration: 'first',
+  genre: { label: 'Fantasy', promptBody: 'high fantasy' },
+  tone: { label: 'Wry', promptBody: 'wry' },
+  setting: 'A keep on a hill.',
+  calendarSystemId: 'gregorian',
+  worldTimeOrigin: { year: 0 },
+})
+
+function row(id: string, content: string, chapterId: string | null = null): StoryEntry {
+  return {
+    id,
+    branchId: 'b1',
+    position: Number(id.slice(1)),
+    kind: 'ai_reply',
+    content,
+    chapterId,
+    metadata: { sceneEntities: [], currentLocationId: null, worldTime: 0 },
+    createdAt: 1,
+  }
+}
+
+function openStory(chapterTokenThreshold = THRESHOLD): void {
+  currentStoryStore.set({
+    storyId: 's1',
+    branchId: 'b1',
+    definition: DEFINITION,
+    settings: { ...STORY_SETTINGS_DEFAULTS, chapterTokenThreshold },
+  })
+}
+
+let latest = 0
+
+function Probe({ storyId = 's1' }: { nonce: number; storyId?: string | null }) {
+  latest = useOpenRegionTokens(storyId)
+  return null
+}
+
+describe('useOpenRegionTokens', () => {
+  beforeEach(() => {
+    entriesStore.__reset()
+    currentStoryStore.__reset()
+    probe.walked = 0
+    latest = 0
+  })
+
+  afterEach(cleanup)
+
+  it('reads the open region off the entries store and the threshold off the open story', () => {
+    entriesStore.hydrate('b1', [row('e1', LONG, 'ch_1'), row('e2', SHORT)])
+    openStory()
+    render(<Probe nonce={0} />)
+    expect(latest).toBeCloseTo(pctOf(SHORT), 10)
+  })
+
+  it('returns 0 with no open story, so a cold-loaded route renders an empty strip', () => {
+    entriesStore.hydrate('b1', [row('e2', SHORT)])
+    render(<Probe nonce={0} />)
+    expect(latest).toBe(0)
+    // Positive control: the same rows report non-zero once a story is open.
+    cleanup()
+    openStory()
+    render(<Probe nonce={0} />)
+    expect(latest).toBeGreaterThan(0)
+  })
+
+  // The strip belongs to the surface's own story. Reading whichever story
+  // happens to be open would show story A's open region against A's threshold
+  // on story B's settings screen — reachable by opening a reader, then
+  // navigating to another story's settings, which never clears the open story.
+  it("returns 0 when the open story is not the caller's", () => {
+    entriesStore.hydrate('b1', [row('e2', SHORT)])
+    openStory()
+    render(<Probe nonce={0} storyId="s2" />)
+    expect(latest).toBe(0)
+    // Positive control: the same store state reports non-zero for its own story.
+    cleanup()
+    render(<Probe nonce={0} storyId="s1" />)
+    expect(latest).toBeGreaterThan(0)
+  })
+
+  it('returns 0 for a caller with no story of its own yet', () => {
+    entriesStore.hydrate('b1', [row('e2', SHORT)])
+    openStory()
+    render(<Probe nonce={0} storyId={null} />)
+    expect(latest).toBe(0)
+  })
+
+  it('does not re-walk the branch on a re-render with no entries write', () => {
+    entriesStore.hydrate('b1', [row('e1', SHORT), row('e2', SHORT)])
+    openStory()
+    const { rerender } = render(<Probe nonce={0} />)
+    const walkedOnce = probe.walked
+    expect(walkedOnce).toBe(2)
+
+    rerender(<Probe nonce={1} />)
+    rerender(<Probe nonce={2} />)
+    expect(probe.walked).toBe(walkedOnce)
+
+    // Positive control: an entries write does re-walk, so the assertion above
+    // is about the memo holding, not about the walk never running.
+    act(() => {
+      entriesStore.patch('b1', { op: 'update', id: 'e2', columns: { content: LONG } })
+    })
+    expect(probe.walked).toBeGreaterThan(walkedOnce)
+    expect(latest).toBeCloseTo(pctOf(SHORT, LONG), 10)
+  })
+})

--- a/hooks/use-open-region-tokens.test.tsx
+++ b/hooks/use-open-region-tokens.test.tsx
@@ -25,8 +25,12 @@ vi.mock('@/lib/retrieval', async (importOriginal) => {
 })
 
 const THRESHOLD = 24_000
-const LONG = 'x'.repeat(4000)
-const SHORT = 'x'.repeat(400)
+// Ordinary prose, not one repeated character. tiktoken's split regex leaves
+// 'x'.repeat(4000) as a single word, and the BPE merge over it costs ~600ms
+// against ~0ms for the same length of real text — enough of them here to blow
+// the 5s default on CI while passing locally.
+const LONG = 'the quick brown fox jumps over the lazy dog. '.repeat(90)
+const SHORT = 'the quick brown fox jumps over the lazy dog. '.repeat(9)
 
 function entry(
   id: string,

--- a/hooks/use-open-region-tokens.ts
+++ b/hooks/use-open-region-tokens.ts
@@ -44,5 +44,19 @@ export function useOpenRegionTokens(storyId: string | null | undefined): number 
   const threshold = currentStoryStore.useCurrentStory((open) =>
     open != null && open.storyId === storyId ? open.settings.chapterTokenThreshold : 0,
   )
-  return useMemo(() => openRegionProgress([...rows.values()], threshold), [rows, threshold])
+  // Branch-filtered like the reader's own read of this map: the working set holds
+  // one branch, but a branch switch moves the open story before the re-hydrate
+  // lands, and counting the outgoing branch's entries against the incoming
+  // branch's threshold reports a region this branch does not have.
+  const branchId = currentStoryStore.useCurrentStory((open) =>
+    open != null && open.storyId === storyId ? open.branchId : null,
+  )
+  return useMemo(
+    () =>
+      openRegionProgress(
+        [...rows.values()].filter((e) => e.branchId === branchId),
+        threshold,
+      ),
+    [rows, branchId, threshold],
+  )
 }

--- a/hooks/use-open-region-tokens.ts
+++ b/hooks/use-open-region-tokens.ts
@@ -1,0 +1,48 @@
+import { useMemo } from 'react'
+
+import { type StoryEntry } from '@/lib/db'
+import { countEntryTokens } from '@/lib/retrieval'
+import { currentStoryStore, entriesStore } from '@/lib/stores'
+
+// Picked off the row rather than restated: `kind` stays the schema's union, so
+// the 'system' literal below is checked instead of being any string.
+type ProgressEntry = Pick<StoryEntry, 'id' | 'content' | 'chapterId' | 'kind'>
+
+/**
+ * Percent of the story's chapter token threshold the open region consumes, 0–100.
+ *
+ * Open region = non-`system` entries whose `chapterId` is still null
+ * (data-model.md → Chapters / memory system); seeded and imported stories
+ * arrive with chapters already closed, so it is not the whole branch, and
+ * `system` rows are technical-only, never prose the threshold is measured
+ * against. Counts only the entries passed in — the reader holds a trailing
+ * window, so a longer open region under-reports. A non-positive or non-finite
+ * threshold reads as 0.
+ */
+export function openRegionProgress(entries: readonly ProgressEntry[], threshold: number): number {
+  if (!Number.isFinite(threshold) || threshold <= 0) return 0
+  let tokens = 0
+  for (const e of entries) {
+    if (e.kind === 'system' || e.chapterId !== null) continue
+    tokens += countEntryTokens(e.id, e.content)
+  }
+  return Math.min(100, (tokens / threshold) * 100)
+}
+
+/**
+ * Progress for `storyId`'s open region, or 0 when that story is not the open
+ * one. The scope argument is required because both stores below are global and
+ * nothing clears them on navigation: a surface that read them unscoped would
+ * show the last-opened story's progress against its threshold.
+ */
+export function useOpenRegionTokens(storyId: string | null | undefined): number {
+  // Select the raw map, per the reader: a fresh array from the selector breaks
+  // useSyncExternalStore's snapshot-stability contract. The map identity moves
+  // only on an entries write — stream chunks land in reader-local state — so
+  // the memo spares the walk on the per-chunk re-renders.
+  const rows = entriesStore.useEntries((m) => m)
+  const threshold = currentStoryStore.useCurrentStory((open) =>
+    open != null && open.storyId === storyId ? open.settings.chapterTokenThreshold : 0,
+  )
+  return useMemo(() => openRegionProgress([...rows.values()], threshold), [rows, threshold])
+}

--- a/lib/abort.test.ts
+++ b/lib/abort.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { boundedSignal } from './abort'
+
+describe('boundedSignal', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  // Callers route an expiry to a provider fault and a cancel to the abort arm.
+  // Both abort the same call, so this flag is the only thing separating them.
+  it('reports expired for a timeout and not for an outer cancel', () => {
+    const outer = new AbortController()
+    const cancelled = boundedSignal(outer.signal, 1000)
+    outer.abort()
+
+    const timedOut = boundedSignal(new AbortController().signal, 1000)
+    vi.advanceTimersByTime(1000)
+
+    expect(timedOut.signal.aborted).toBe(true)
+    expect(timedOut.expired()).toBe(true)
+    expect(cancelled.signal.aborted).toBe(true)
+    expect(cancelled.expired()).toBe(false)
+  })
+
+  it('relays an already-aborted outer signal without waiting for the timer', () => {
+    const outer = new AbortController()
+    outer.abort()
+
+    const bounded = boundedSignal(outer.signal, 1000)
+
+    expect(bounded.signal.aborted).toBe(true)
+    expect(bounded.expired()).toBe(false)
+  })
+
+  // A timer left armed past the call fires while it winds down, flipping a clean
+  // cancellation into an apparent provider timeout.
+  it('does not expire after an outer cancel clears the timer', () => {
+    const outer = new AbortController()
+    const bounded = boundedSignal(outer.signal, 1000)
+
+    outer.abort()
+    vi.advanceTimersByTime(5000)
+
+    expect(bounded.expired()).toBe(false)
+  })
+
+  it('does not expire after dispose', () => {
+    const bounded = boundedSignal(undefined, 1000)
+
+    bounded.dispose()
+    vi.advanceTimersByTime(5000)
+
+    expect(bounded.expired()).toBe(false)
+    expect(bounded.signal.aborted).toBe(false)
+  })
+})

--- a/lib/abort.ts
+++ b/lib/abort.ts
@@ -1,0 +1,32 @@
+// AbortSignal.timeout / .any are statics Hermes has historically lacked, so
+// this composes the same behavior from AbortController + setTimeout, matching
+// lib/embedder/download/model-card.ts.
+export function boundedSignal(
+  outer: AbortSignal | undefined,
+  ms: number,
+): { signal: AbortSignal; expired: () => boolean; dispose: () => void } {
+  const controller = new AbortController()
+  let expired = false
+  const timer = setTimeout(() => {
+    expired = true
+    controller.abort()
+  }, ms)
+  // Clears the timer, not just relays: left armed it can still fire while the
+  // aborted call winds down, and `expired` is what tells a cancel from a
+  // timeout — a late fire would burn a retry on a clean cancellation.
+  const relay = () => {
+    clearTimeout(timer)
+    controller.abort()
+  }
+  if (outer?.aborted) relay()
+  else outer?.addEventListener('abort', relay)
+  return {
+    signal: controller.signal,
+    /** Stays readable after dispose: the flag is captured, not derived. */
+    expired: () => expired,
+    dispose: () => {
+      clearTimeout(timer)
+      outer?.removeEventListener('abort', relay)
+    },
+  }
+}

--- a/lib/actions/embedder-swap/app-deps.test.ts
+++ b/lib/actions/embedder-swap/app-deps.test.ts
@@ -5,13 +5,17 @@ import {
   APP_SETTINGS_SINGLETON_ID,
   appSettings,
   buildStorySettings,
+  execRaw,
   setSwapTargetOp,
   storyDefinitionSchema,
+  VEC_FAMILIES,
   type DbCtx,
+  type EmbeddedFieldRow,
   type ProviderInstance,
   type StorySettings,
 } from '@/lib/db'
 import { createTestDb } from '@/lib/db/__tests__/test-db'
+import { embedRowsToVecOps, embedTexts, type EmbedderConfig } from '@/lib/embedder'
 import {
   currentStoryStore,
   embedderSwapStore,
@@ -24,6 +28,7 @@ import {
 
 import {
   cancelStorySwap,
+  composeRetrievalEmbedDeps,
   makeCallbackGuards,
   reindexStoryNow,
   RelabelBlockedError,
@@ -43,6 +48,18 @@ import {
   SwapNotInProgressError,
   type SwapParams,
 } from './engine'
+
+// Wrapped, not replaced: every other test here relies on the real embed surface,
+// so the spies default to the genuine implementations and only the retrieval-dep
+// tests below override them.
+vi.mock('@/lib/embedder', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    embedTexts: vi.fn(actual.embedTexts as typeof embedTexts),
+    embedRowsToVecOps: vi.fn(actual.embedRowsToVecOps as typeof embedRowsToVecOps),
+  }
+})
 
 vi.mock('./engine', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>()
@@ -428,6 +445,7 @@ describe('relabelStory', () => {
   afterEach(() => {
     storiesStore.__reset()
     currentStoryStore.__reset()
+    embedderSwapStore.__reset()
     vi.restoreAllMocks()
   })
 
@@ -490,6 +508,29 @@ describe('relabelStory', () => {
         ctx,
       ),
     ).rejects.toBeInstanceOf(RelabelBlockedError)
+  })
+
+  // The reader gates its composer on progressFor, not on the in-process lock it
+  // cannot see. Without a progress entry a relabel leaves the composer live, and
+  // the turn the user writes is rejected by submitTurn with no affordance.
+  it('publishes swap progress for its duration', async () => {
+    const { ctx } = await seedStores(storySettings({ embeddingBackend: 'local' }, MINILM, null))
+
+    expect(embedderSwapStore.progressFor(embedderSwapStore.getState(), 's1')).toBeNull()
+
+    let during: unknown = 'never ran'
+    await relabelStory('s1', { modelId: 'e2e/minilm-copy', backend: 'local' }, {
+      ...ctx,
+      runInTransaction: async (ops) => {
+        during = embedderSwapStore.progressFor(embedderSwapStore.getState(), 's1')
+        return ctx.runInTransaction(ops)
+      },
+    } as DbCtx)
+
+    // Shape, not non-null: the sentinel is a string, so `not.toBeNull()` would
+    // pass even if the hook never fired.
+    expect(during).toMatchObject({ storyId: 's1', cancelRequested: false })
+    expect(embedderSwapStore.progressFor(embedderSwapStore.getState(), 's1')).toBeNull()
   })
 })
 
@@ -755,5 +796,99 @@ describe('crash recovery resolves its target from the marker', () => {
       providerId: 'prov1',
       modelId: PROVIDER_MODEL,
     })
+  })
+})
+
+describe('composeRetrievalEmbedDeps', () => {
+  const LOCAL_CONFIG: EmbedderConfig = { backend: 'local', modelId: MINILM, dim: 384 }
+  const PROVIDER_CONFIG: EmbedderConfig = {
+    backend: 'provider',
+    providerId: 'prov1',
+    modelId: PROVIDER_MODEL,
+    dim: 1536,
+    truncation: null,
+  }
+
+  afterEach(() => {
+    storiesStore.__reset()
+    currentStoryStore.__reset()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('embeds the query stack at query intent, never document', async () => {
+    vi.mocked(embedTexts).mockResolvedValue({ vectors: [], dim: 384 })
+
+    await composeRetrievalEmbedDeps(LOCAL_CONFIG).embedTexts(['q1', 'q2'])
+
+    // The whole argument list, because the intent is the load-bearing one: the
+    // local model's query prefix is what puts these vectors in the same space as
+    // the stored rows, and 'document' would degrade every similarity silently.
+    expect(embedTexts).toHaveBeenCalledWith(
+      LOCAL_CONFIG,
+      ['q1', 'q2'],
+      'query',
+      undefined,
+      undefined,
+    )
+  })
+
+  it('resolves the provider instance a provider-backed config is served by', async () => {
+    await seedStores(storySettings({ embeddingBackend: 'provider' }, PROVIDER_MODEL, 'prov1'), [
+      cachedProvider('prov1', [{ id: PROVIDER_MODEL }]),
+    ])
+    vi.mocked(embedTexts).mockResolvedValue({ vectors: [], dim: 1536 })
+
+    await composeRetrievalEmbedDeps(PROVIDER_CONFIG).embedTexts(['q1'])
+
+    // Positive control against the `undefined` the local case asserts above: a
+    // dropped providerFor() would send a provider embed with no instance to call.
+    expect(embedTexts).toHaveBeenCalledWith(
+      PROVIDER_CONFIG,
+      ['q1'],
+      'query',
+      expect.objectContaining({ id: 'prov1' }),
+      undefined,
+    )
+  })
+
+  it('unwraps the ops from a row embed and keeps the raw-DDL seam', async () => {
+    const ops = [{ sql: 'INSERT INTO entities_vec VALUES (?)', params: ['x'] }]
+    vi.mocked(embedRowsToVecOps).mockResolvedValue({ ops, dim: 384 })
+    const rows: EmbeddedFieldRow[] = [
+      { kind: 'entity', id: 'ent_1', branchId: 'b1', fields: ['Kael', 'A knight.'] },
+    ]
+
+    await expect(composeRetrievalEmbedDeps(LOCAL_CONFIG).embedRows(rows)).resolves.toBe(ops)
+
+    // execRaw, not the ops batch: vec0 CREATE VIRTUAL TABLE cannot run inside the
+    // atomic transaction the sync stage then applies these ops in.
+    expect(embedRowsToVecOps).toHaveBeenCalledWith(
+      LOCAL_CONFIG,
+      rows,
+      execRaw,
+      undefined,
+      undefined,
+    )
+  })
+
+  it('loads the dirty set across every vec family for the branches it is given', async () => {
+    const seen: { sql: string; params: unknown[] }[] = []
+    vi.stubGlobal('window', {
+      aventurasDb: {
+        query: async (sql: string, params: unknown[]) => {
+          seen.push({ sql, params })
+          return { rows: [] }
+        },
+      },
+    })
+
+    await expect(composeRetrievalEmbedDeps(LOCAL_CONFIG).loadStaleRows(['b1'])).resolves.toEqual([])
+
+    // One query per family, each scoped to the branch — a stub that answered []
+    // without reading anything would leave `seen` empty.
+    expect(seen).toHaveLength(Object.keys(VEC_FAMILIES).length)
+    expect(seen.every((q) => q.params.includes('b1'))).toBe(true)
+    expect(seen.every((q) => q.sql.includes('embedding_stale'))).toBe(true)
   })
 })

--- a/lib/actions/embedder-swap/app-deps.ts
+++ b/lib/actions/embedder-swap/app-deps.ts
@@ -590,10 +590,10 @@ export async function relabelStory(
     // model the catalog has never heard of (a renamed local copy, an id served
     // elsewhere), so an unknown target simply yields an unknown dim and no guard.
     const resolution = resolveStorySwapConfig(storyId, target)
-    // Bracketed like runStagingSwap: relabel takes runExclusive, so
-    // isStorySwapPending refuses turns for its duration, but without a progress
-    // entry the reader's own gate stays blind and lets the user write a turn
-    // that submitTurn then rejects.
+    // Bracketed like runStagingSwap: relabel holds the embedder admission for its
+    // duration (through runUserEmbedderAction), so isStorySwapPending refuses
+    // turns, but without a progress entry the reader's own gate stays blind and
+    // lets the user write a turn that submitTurn then rejects.
     embedderSwapStore.beginProgress(storyId)
     try {
       await relabelModel(composeSwapDeps(storyId, ctx), {

--- a/lib/actions/embedder-swap/app-deps.ts
+++ b/lib/actions/embedder-swap/app-deps.ts
@@ -19,13 +19,16 @@ import {
   type DbCtx,
   type EmbeddedFieldRow,
   type EmbeddingTarget,
+  type SqlOp,
   type StorySettings,
   type VecTargetKind,
 } from '@/lib/db'
 import { logger } from '@/lib/diagnostics'
 import {
   createDrainController,
+  embedderReadDim,
   embedRowsToVecOps,
+  embedTexts,
   type DrainDeps,
   resolveEmbedderConfig,
   type EmbedderAppDefaults,
@@ -99,20 +102,109 @@ const GENERATION_IN_FLIGHT_REJECTION: StoryEmbedderActionRejection = {
 const messageOf = (error: unknown): string =>
   error instanceof Error ? error.message : String(error)
 
-// Per-story single-flight lock (engine caller contract): concurrent engine calls
-// for one story would both pass the advisory swap-target guard and stage vectors
-// under different targets, orphaning the loser's rows. Reject rather than queue.
+type StoryAdmission =
+  | { owner: 'turn'; holders: number }
+  | { owner: 'embedder'; release: () => void }
+
+// Turns read/write the served vec family; embedder operations mutate its ownership.
+// Turn holders may overlap because the pipeline gate still chooses the generation,
+// but any holder excludes an embedder mutation before either side writes.
+const storyAdmissions = new Map<string, StoryAdmission>()
+
+// Per-story engine handle retained separately from admission: cancellation awaits
+// the live swap promise, while turn admission only needs to know who owns the gate.
 const inFlight = new Map<string, Promise<unknown>>()
 
-export async function runExclusive<T>(storyId: string, fn: () => Promise<T>): Promise<T> {
-  if (inFlight.has(storyId)) throw new SwapBusyError(storyId)
-  const run = fn()
+export type TurnAdmissionResult<T> =
+  | { admitted: true; value: T }
+  | { admitted: false; blockedBy: 'embedder-swap' }
+
+export async function withTurnAdmission<T>(
+  storyId: string,
+  fn: () => Promise<T>,
+): Promise<TurnAdmissionResult<T>> {
+  const active = storyAdmissions.get(storyId)
+  if (active?.owner === 'embedder') return { admitted: false, blockedBy: 'embedder-swap' }
+
+  const admission = active ?? { owner: 'turn' as const, holders: 0 }
+  admission.holders += 1
+  storyAdmissions.set(storyId, admission)
+  try {
+    return { admitted: true, value: await fn() }
+  } finally {
+    admission.holders -= 1
+    if (admission.holders === 0 && storyAdmissions.get(storyId) === admission) {
+      storyAdmissions.delete(storyId)
+    }
+  }
+}
+
+function acquireEmbedderAdmission(storyId: string): (() => void) | null {
+  if (storyAdmissions.has(storyId)) return null
+  const admission: StoryAdmission = {
+    owner: 'embedder',
+    release: () => {
+      if (storyAdmissions.get(storyId) === admission) storyAdmissions.delete(storyId)
+    },
+  }
+  storyAdmissions.set(storyId, admission)
+  return admission.release
+}
+
+/**
+ * Whether a swap owns this story's vec tables right now. Two authorities for the
+ * same reason `resolveDrainConfig` needs both: the marker only reaches the store
+ * once `syncStoresAfterEngine` runs, so a swap started this session is invisible
+ * in `settings` while it matters most, and the in-process lock knows nothing
+ * about a marker left by a previous process.
+ */
+export function isStorySwapPending(storyId: string): boolean {
+  if (inFlight.has(storyId)) return true
+  const open = currentStoryStore.getCurrentStory()
+  return open?.storyId === storyId && open.settings.embedding_swap_target != null
+}
+
+async function runAdmittedEmbedder<T>(
+  storyId: string,
+  fn: () => Promise<T>,
+  releaseAdmission: () => void,
+): Promise<T> {
+  let run: Promise<T>
+  try {
+    run = fn()
+  } catch (error) {
+    releaseAdmission()
+    throw error
+  }
   inFlight.set(storyId, run)
   try {
     return await run
   } finally {
     inFlight.delete(storyId)
+    releaseAdmission()
   }
+}
+
+export async function runExclusive<T>(storyId: string, fn: () => Promise<T>): Promise<T> {
+  const releaseAdmission = acquireEmbedderAdmission(storyId)
+  if (releaseAdmission == null) throw new SwapBusyError(storyId)
+  return runAdmittedEmbedder(storyId, fn, releaseAdmission)
+}
+
+async function runUserEmbedderAction<T>(
+  storyId: string,
+  fn: () => Promise<T>,
+): Promise<T | StoryEmbedderActionRejection> {
+  if (storyAdmissions.get(storyId)?.owner === 'turn') {
+    return Promise.resolve(GENERATION_IN_FLIGHT_REJECTION)
+  }
+  const releaseAdmission = acquireEmbedderAdmission(storyId)
+  if (releaseAdmission == null) throw new SwapBusyError(storyId)
+  if (generationStore.isUserEditBlocked()) {
+    releaseAdmission()
+    return Promise.resolve(GENERATION_IN_FLIGHT_REJECTION)
+  }
+  return runAdmittedEmbedder(storyId, fn, releaseAdmission)
 }
 
 // The store/UI callbacks are wrapped so a throwing subscriber can never propagate
@@ -211,14 +303,39 @@ function providerFor(config: EmbedderConfig): ProviderInstanceWithStub | undefin
     .providers.find((provider) => provider.id === config.providerId)
 }
 
-// Single-sources the engine/drain embed composition: raw DDL through execRaw,
-// provider instance resolved from the config's own providerId. The drain takes the
-// ops alone — only a swap's phase-2 sweep needs the dim its staging landed on.
+// Single-sources the embed composition for the swap engine, the drain worker and
+// the blocking sync stage: raw DDL through execRaw, provider instance resolved
+// from the config's own providerId. Only a swap's phase-2 sweep needs the dim its
+// staging landed on; the other two take the ops alone.
 const makeEmbedRows = (): SwapDeps['embedRows'] => (config, rows) =>
   embedRowsToVecOps(config, rows, execRaw, providerFor(config))
 
 const makeDrainEmbedRows = (): DrainDeps['embedRows'] => async (config, rows) =>
   (await embedRowsToVecOps(config, rows, execRaw, providerFor(config))).ops
+
+/**
+ * The embed surface a retrieval pass needs, resolved off the open story. Unlike
+ * the drain's, both calls take a signal: a turn blocks on them, so a stalled
+ * provider has to be interruptible rather than parking the turn indefinitely.
+ */
+export function composeRetrievalEmbedDeps(config: EmbedderConfig): {
+  embedTexts: (
+    texts: string[],
+    abortSignal?: AbortSignal,
+  ) => Promise<{ vectors: Float32Array[]; dim: number }>
+  embedRows: (rows: EmbeddedFieldRow[], abortSignal?: AbortSignal) => Promise<SqlOp[]>
+  loadStaleRows: (branchIds: readonly string[]) => Promise<EmbeddedFieldRow[]>
+} {
+  return {
+    // 'query' intent, not 'document': the local model's query prefix is what
+    // puts the three query vectors in the same space as the stored rows.
+    embedTexts: (texts, abortSignal) =>
+      embedTexts(config, texts, 'query', providerFor(config), abortSignal),
+    embedRows: async (rows, abortSignal) =>
+      (await embedRowsToVecOps(config, rows, execRaw, providerFor(config), abortSignal)).ops,
+    loadStaleRows,
+  }
+}
 
 function composeSwapDeps(storyId: string, ctx: DbCtx): SwapDeps {
   return {
@@ -341,8 +458,8 @@ async function runStagingSwap(
   ctx: DbCtx,
   invoke: (deps: SwapDeps, params: SwapParams) => Promise<'completed' | 'cancelled'>,
   resolveTarget: (settings: StorySettings) => EmbeddingTarget,
-): Promise<'completed' | 'cancelled'> {
-  return runExclusive(storyId, async () => {
+): Promise<'completed' | 'cancelled' | StoryEmbedderActionRejection> {
+  return runUserEmbedderAction(storyId, async () => {
     const { settings, branchIds } = await loadSwapContext(storyId, ctx)
     const target = resolveTarget(settings)
     const resolution = resolveStorySwapConfig(storyId, target)
@@ -373,7 +490,6 @@ export function startStorySwap(
   target: EmbeddingTarget,
   ctx: DbCtx = defaultCtx(),
 ): Promise<'completed' | 'cancelled' | StoryEmbedderActionRejection> {
-  if (generationStore.isUserEditBlocked()) return Promise.resolve(GENERATION_IN_FLIGHT_REJECTION)
   return runStagingSwap(storyId, ctx, startSwap, () => target)
 }
 
@@ -381,7 +497,6 @@ export function resumeStorySwap(
   storyId: string,
   ctx: DbCtx = defaultCtx(),
 ): Promise<'completed' | 'cancelled' | StoryEmbedderActionRejection> {
-  if (generationStore.isUserEditBlocked()) return Promise.resolve(GENERATION_IN_FLIGHT_REJECTION)
   return runStagingSwap(storyId, ctx, resumeSwap, (settings) => {
     if (settings.embedding_swap_target == null) throw new SwapNotInProgressError(storyId)
     return markerTarget(settings)
@@ -392,7 +507,6 @@ export function reindexStoryNow(
   storyId: string,
   ctx: DbCtx = defaultCtx(),
 ): Promise<'completed' | 'cancelled' | StoryEmbedderActionRejection> {
-  if (generationStore.isUserEditBlocked()) return Promise.resolve(GENERATION_IN_FLIGHT_REJECTION)
   return runStagingSwap(storyId, ctx, reindexStory, (settings) => ({
     modelId: settings.embedding_model_id,
     backend: settings.embeddingBackend,
@@ -457,26 +571,12 @@ export async function cancelStorySwap(
   })
 }
 
-/**
- * The dim a target would be READ at, or null when only an embed could answer.
- * A local target's dim is the catalog's; a provider target truncating to the
- * story's locked `effectiveDim` is read at that dim, and an untruncated provider
- * target is native — unknowable until it responds.
- */
-function targetReadDim(config: EmbedderConfig): number | null {
-  if (config.backend === 'local' || config.truncation == null) return config.dim
-  return config.dim == null
-    ? config.truncation.effectiveDim
-    : Math.min(config.truncation.effectiveDim, config.dim)
-}
-
 export async function relabelStory(
   storyId: string,
   target: EmbeddingTarget,
   ctx: DbCtx = defaultCtx(),
 ): Promise<void | StoryEmbedderActionRejection> {
-  if (generationStore.isUserEditBlocked()) return GENERATION_IN_FLIGHT_REJECTION
-  await runExclusive(storyId, async () => {
+  return runUserEmbedderAction(storyId, async () => {
     const { settings, branchIds } = await loadSwapContext(storyId, ctx)
     // Relabel's pre-delete is destructive toward target-model rows; a swap in
     // flight would have staged exactly those, so refuse until it settles.
@@ -490,14 +590,23 @@ export async function relabelStory(
     // model the catalog has never heard of (a renamed local copy, an id served
     // elsewhere), so an unknown target simply yields an unknown dim and no guard.
     const resolution = resolveStorySwapConfig(storyId, target)
-    await relabelModel(composeSwapDeps(storyId, ctx), {
-      storyId,
-      branchIds,
-      oldModelId: settings.embedding_model_id,
-      target,
-      targetReadDim: resolution.ok ? targetReadDim(resolution.config) : null,
-    })
-    await refreshStores(storyId, ctx)
+    // Bracketed like runStagingSwap: relabel takes runExclusive, so
+    // isStorySwapPending refuses turns for its duration, but without a progress
+    // entry the reader's own gate stays blind and lets the user write a turn
+    // that submitTurn then rejects.
+    embedderSwapStore.beginProgress(storyId)
+    try {
+      await relabelModel(composeSwapDeps(storyId, ctx), {
+        storyId,
+        branchIds,
+        oldModelId: settings.embedding_model_id,
+        target,
+        targetReadDim: resolution.ok ? embedderReadDim(resolution.config) : null,
+      })
+      await refreshStores(storyId, ctx)
+    } finally {
+      embedderSwapStore.clearProgress(storyId)
+    }
   })
 }
 

--- a/lib/actions/embedder-swap/engine.ts
+++ b/lib/actions/embedder-swap/engine.ts
@@ -119,6 +119,9 @@ function targetOf(config: EmbedderConfig): EmbeddingTarget {
     : { modelId: config.modelId, backend: 'local' }
 }
 
+// Near-identical to embedderReadDim, but deliberately null — not the truncation's
+// effectiveDim — when the native dim is unknown, so phase 1 adopts the dim the
+// server actually served instead of committing to a guess.
 function configStorageDim(config: EmbedderConfig): number | null {
   if (config.backend === 'local') return config.dim
   if (config.dim == null) return null

--- a/lib/actions/embedder-swap/index.ts
+++ b/lib/actions/embedder-swap/index.ts
@@ -16,8 +16,10 @@ export {
 export {
   buildDrainController,
   cancelStorySwap,
+  composeRetrievalEmbedDeps,
   kickStoryDrain,
   countStoryEmbeddableRows,
+  isStorySwapPending,
   refreshEmbeddingStatus,
   reindexStoryNow,
   relabelStory,

--- a/lib/actions/happenings/register-awareness.test.ts
+++ b/lib/actions/happenings/register-awareness.test.ts
@@ -1,7 +1,8 @@
-import { and, eq } from 'drizzle-orm'
-import { describe, expect, it } from 'vitest'
+import { and, asc, eq } from 'drizzle-orm'
+import { describe, expect, it, vi } from 'vitest'
 
-import { branches, happeningAwareness, stories } from '@/lib/db'
+import type { Delta, HappeningAwareness } from '@/lib/db'
+import { branches, deltas, happeningAwareness, stories } from '@/lib/db'
 import { createTestDb } from '@/lib/db/__tests__/test-db'
 import { happeningAwarenessStore } from '@/lib/stores'
 
@@ -10,14 +11,24 @@ import { applyDeltaAction } from '../delta/apply-delta-action'
 import { __resetRegistry } from '../delta/registry'
 import { reverseReplayDeltas } from '../delta/reverse-replay'
 
-async function setup() {
+const BRANCH = 'br_1'
+const OTHER_BRANCH = 'br_2'
+
+async function setup(rows: HappeningAwareness[] = []) {
   __resetRegistry()
   registerHappeningAwareness()
   const { db, runInTransaction } = await createTestDb()
   await db.insert(stories).values({ id: 'story_1', title: 'T', createdAt: 1, updatedAt: 1 })
-  await db.insert(branches).values({ id: 'br_1', storyId: 'story_1', name: 'main', createdAt: 1 })
+  await db.insert(branches).values([
+    { id: BRANCH, storyId: 'story_1', name: 'main', createdAt: 1 },
+    { id: OTHER_BRANCH, storyId: 'story_1', name: 'fork', createdAt: 1 },
+  ])
+  if (rows.length > 0) await db.insert(happeningAwareness).values(rows)
   happeningAwarenessStore.__reset()
-  happeningAwarenessStore.hydrate('br_1', [])
+  happeningAwarenessStore.hydrate(
+    BRANCH,
+    rows.filter((r) => r.branchId === BRANCH),
+  )
   return { db, ctx: { db, runInTransaction } }
 }
 
@@ -257,5 +268,247 @@ describe('happening_awareness upsert', () => {
     const rows = await awarenessRows(db, 'char_a', 'hap_1')
     expect(rows.length).toBe(1)
     expect(rows[0].source).toBeNull()
+  })
+})
+
+function awarenessRow(
+  id: string,
+  retrievalCount: number,
+  opts: { branchId?: string } = {},
+): HappeningAwareness {
+  return {
+    id,
+    branchId: opts.branchId ?? BRANCH,
+    happeningId: `hap_${id}`,
+    characterId: `char_${id}`,
+    learnedAtEntryId: null,
+    decayResistance: null,
+    retrievalCount,
+    source: null,
+  }
+}
+
+type Ctx = Awaited<ReturnType<typeof setup>>['ctx']
+
+// priorCount is explicit because the handler no longer reads it — the retrieval
+// pass supplies the value it saw, so a caller passing a stale one is the failure
+// mode these tests have to be able to express.
+function bump(
+  id: string,
+  priorCount: number,
+  opts: { payloadBranchId?: string; actionId?: string } = {},
+) {
+  return {
+    action: {
+      kind: 'bumpAwarenessRetrieval' as const,
+      source: 'ai_classifier' as const,
+      payload: { branchId: opts.payloadBranchId ?? BRANCH, id, priorCount },
+    },
+    actionId: opts.actionId ?? 'act_1',
+    branchId: BRANCH,
+  }
+}
+
+async function countOf(ctx: Ctx, id: string, branchId = BRANCH): Promise<number | undefined> {
+  const rows = await ctx.db.select().from(happeningAwareness).where(eq(happeningAwareness.id, id))
+  return rows.find((r) => r.branchId === branchId)?.retrievalCount
+}
+
+async function deltaRows(ctx: Ctx): Promise<Delta[]> {
+  return (await ctx.db.select().from(deltas).orderBy(asc(deltas.logPosition))) as Delta[]
+}
+
+describe('bumpAwarenessRetrieval', () => {
+  it('increments the counter by one and mirrors it into the working-set store', async () => {
+    const { ctx } = await setup([awarenessRow('haw_1', 4)])
+
+    const result = await applyDeltaAction(bump('haw_1', 4), ctx)
+
+    expect(result.status).toBe('ok')
+    expect(await countOf(ctx, 'haw_1')).toBe(5)
+    expect(happeningAwarenessStore.getById('haw_1')?.retrievalCount).toBe(5)
+  })
+
+  // The periodic classifier and a turn do not block each other, so a classifier
+  // run that aborts after retrieval snapshotted its awareness rows reverse-
+  // replays them away mid-turn. The handler no longer reads the row, so it can
+  // no longer see this and reject as 'noop': it logs a delta whose UPDATE
+  // matches nothing. What still has to hold is that the turn survives and the
+  // table is untouched — failing here would reverse the user's whole turn over
+  // a counter.
+  it('survives a vanished bump target without touching the table', async () => {
+    const { ctx } = await setup([awarenessRow('haw_1', 4)])
+
+    const result = await applyDeltaAction(bump('haw_gone', 4), ctx)
+
+    expect(result.status).toBe('ok')
+    // No row created, and the surviving row is untouched.
+    expect(await ctx.db.select().from(happeningAwareness)).toHaveLength(1)
+    expect(await countOf(ctx, 'haw_1')).toBe(4)
+    // The delta is logged against a row that is gone; undo has to no-op on it
+    // rather than resurrect it or throw.
+    expect(await deltaRows(ctx)).toHaveLength(1)
+    expect(await reverseReplayDeltas('act_1', ctx)).toBe(1)
+    expect(await ctx.db.select().from(happeningAwareness)).toHaveLength(1)
+  })
+
+  // Second arm so the increment cannot be a constant that happens to fit the
+  // case above.
+  it('starts a never-retrieved row at one', async () => {
+    const { ctx } = await setup([awarenessRow('haw_1', 0)])
+
+    await applyDeltaAction(bump('haw_1', 0), ctx)
+
+    expect(await countOf(ctx, 'haw_1')).toBe(1)
+  })
+
+  // The reason the payload carries priorCount at all. One bump fires per aware
+  // in-scene character per seated happening, all ahead of the narrative stream,
+  // and the cost lands hardest on slow devices that are not on hand to measure.
+  // Reads must therefore not scale with the bump count — a per-bump SELECT
+  // creeping back in is invisible to every other assertion here.
+  it('reads nothing per bump, so the cost does not scale with scene size', async () => {
+    const { ctx } = await setup([
+      awarenessRow('haw_1', 0),
+      awarenessRow('haw_2', 0),
+      awarenessRow('haw_3', 0),
+    ])
+    const select = vi.spyOn(ctx.db, 'select')
+
+    await applyDeltaAction(bump('haw_1', 0), ctx)
+    const afterOne = select.mock.calls.length
+    await applyDeltaAction(bump('haw_2', 0), ctx)
+    await applyDeltaAction(bump('haw_3', 0), ctx)
+
+    // Pinned as a constant, not a ratio: a ratio stays linear whether or not the
+    // handler reads, so it would pass with the SELECT back in. This one read is
+    // applyDeltaAction's own bookkeeping; the handler adds none, and re-adding
+    // one doubles both numbers.
+    const READS_PER_BUMP = 1
+    expect(afterOne).toBe(READS_PER_BUMP)
+    expect(select.mock.calls.length).toBe(READS_PER_BUMP * 3)
+    expect(await countOf(ctx, 'haw_3')).toBe(1)
+  })
+
+  // The prior count now arrives from the caller, so a stale one writes a wrong
+  // count that no later pass can distinguish from a real one. Nothing in
+  // production produces this today — injectedAwareness is duplicate-free and
+  // read in the same pass — but it is the cost of dropping the handler's read,
+  // and it should fail loudly here if anyone ever reuses a payload.
+  it('writes the caller-supplied prior plus one, even when it is stale', async () => {
+    const { ctx } = await setup([awarenessRow('haw_1', 9)])
+
+    await applyDeltaAction(bump('haw_1', 2), ctx)
+
+    expect(await countOf(ctx, 'haw_1')).toBe(3)
+  })
+
+  it('logs one update delta whose undo payload is the PRIOR value, not the increment', async () => {
+    const { ctx } = await setup([awarenessRow('haw_1', 4)])
+
+    await applyDeltaAction(bump('haw_1', 4), ctx)
+
+    const rows = await deltaRows(ctx)
+    expect(rows.length).toBe(1)
+    expect(rows[0]).toMatchObject({
+      targetTable: 'happening_awareness',
+      targetId: 'haw_1',
+      op: 'update',
+      actionId: 'act_1',
+      undoPayload: { retrievalCount: 4 },
+    })
+  })
+
+  it('reverse-replay of the turn restores the pre-turn count', async () => {
+    const { ctx } = await setup([awarenessRow('haw_1', 4)])
+    await applyDeltaAction(bump('haw_1', 4), ctx)
+
+    expect(await reverseReplayDeltas('act_1', ctx)).toBe(1)
+
+    expect(await countOf(ctx, 'haw_1')).toBe(4)
+    expect(happeningAwarenessStore.getById('haw_1')?.retrievalCount).toBe(4)
+  })
+
+  // Distinct from the single-bump reverse above: two deltas land under one
+  // action_id, each carrying the value it replaced, and reverse-replay walks
+  // them newest-first (log_position DESC), so the count goes 6 → 5 → 4. Oldest
+  // first would land on 5, since the older delta's replaced value is applied
+  // before the newer one overwrites it.
+  it('reverses two bumps of the same row in one reversal window back to the original count', async () => {
+    const { ctx } = await setup([awarenessRow('haw_1', 4)])
+    await applyDeltaAction(bump('haw_1', 4), ctx)
+    await applyDeltaAction(bump('haw_1', 5), ctx)
+    expect(await countOf(ctx, 'haw_1')).toBe(6)
+
+    expect(await reverseReplayDeltas('act_1', ctx)).toBe(2)
+
+    expect(await countOf(ctx, 'haw_1')).toBe(4)
+  })
+
+  it('applies to two different rows in one turn without cross-talk', async () => {
+    const { ctx } = await setup([awarenessRow('haw_1', 0), awarenessRow('haw_2', 5)])
+
+    for (const [id, prior] of [
+      ['haw_1', 0],
+      ['haw_2', 5],
+    ] as const) {
+      const result = await applyDeltaAction(bump(id, prior), ctx)
+      expect(result.status).toBe('ok')
+    }
+
+    expect(await countOf(ctx, 'haw_1')).toBe(1)
+    expect(await countOf(ctx, 'haw_2')).toBe(6)
+  })
+
+  it('rejects a branch mismatch and leaves the counter alone', async () => {
+    const { ctx } = await setup([awarenessRow('haw_1', 4)])
+
+    const result = await applyDeltaAction(bump('haw_1', 4, { payloadBranchId: 'br_other' }), ctx)
+
+    expect(result).toMatchObject({ status: 'rejected' })
+    expect(result.status === 'rejected' && result.reason).toContain('branch mismatch')
+    expect(await countOf(ctx, 'haw_1')).toBe(4)
+    expect(await deltaRows(ctx)).toEqual([])
+  })
+
+  it('never inserts a row for a missing target', async () => {
+    const { ctx } = await setup([awarenessRow('haw_present', 3)])
+
+    // Accepted now that the handler does not read — an UPDATE cannot insert, so
+    // the guarantee this test exists for is the table, not the outcome.
+    expect((await applyDeltaAction(bump('haw_missing', 0), ctx)).status).toBe('ok')
+
+    expect(await ctx.db.select().from(happeningAwareness)).toHaveLength(1)
+    // Positive control: the same db, the same call shape, an id that IS there.
+    expect((await applyDeltaAction(bump('haw_present', 3), ctx)).status).toBe('ok')
+    expect(await countOf(ctx, 'haw_present')).toBe(4)
+  })
+
+  // The payload guard only compares the two branch ids; nothing there stops the
+  // WRITE from matching a same-id row on a sibling branch, which the composite
+  // (branch_id, id) PK makes legal. Sole row in the table, so no scan order can
+  // hide an unscoped UPDATE.
+  it('does not touch a same-id row that lives on a sibling branch', async () => {
+    const { ctx } = await setup([awarenessRow('haw_1', 9, { branchId: OTHER_BRANCH })])
+
+    await applyDeltaAction(bump('haw_1', 4), ctx)
+
+    // 9, not 5: an unscoped UPDATE would assign the run branch's next value here.
+    expect(await countOf(ctx, 'haw_1', OTHER_BRANCH)).toBe(9)
+  })
+
+  // The write side of the same seam. `next` is computed in JS, not as
+  // `retrieval_count = retrieval_count + 1`, so an unscoped UPDATE would ASSIGN
+  // the run branch's value to the sibling row — moving it 9 → 5, not 9 → 10.
+  it('bumps only the run branch when both branches carry the id', async () => {
+    const { ctx } = await setup([
+      awarenessRow('haw_1', 9, { branchId: OTHER_BRANCH }),
+      awarenessRow('haw_1', 4),
+    ])
+
+    await applyDeltaAction(bump('haw_1', 4), ctx)
+
+    expect(await countOf(ctx, 'haw_1')).toBe(5)
+    expect(await countOf(ctx, 'haw_1', OTHER_BRANCH)).toBe(9)
   })
 })

--- a/lib/actions/happenings/register-awareness.ts
+++ b/lib/actions/happenings/register-awareness.ts
@@ -22,6 +22,10 @@ declare module '@/lib/actions/action-map' {
   interface PipelineActionMap {
     upsertHappeningAwareness: { source: DeltaSource; payload: AwarenessUpsertPayload }
     deleteHappeningAwareness: { source: DeltaSource; payload: { branchId: string; id: string } }
+    bumpAwarenessRetrieval: {
+      source: DeltaSource
+      payload: { branchId: string; id: string; priorCount: number }
+    }
   }
 }
 
@@ -140,6 +144,47 @@ const deleteHandler: ActionHandler = async (action, branchId, ctx) => {
   }
 }
 
+// chapter-close.md → 3d awareness pin tuning ranks awareness rows by
+// retrieval_count, so a turn the user rolled back must leave nothing counted.
+const bumpRetrievalHandler: ActionHandler = (action, branchId, ctx) => {
+  if (action.kind !== 'bumpAwarenessRetrieval')
+    throw new Error(`handler/kind mismatch: ${action.kind}`)
+  const { branchId: bid, id, priorCount } = action.payload
+  if (bid !== branchId)
+    return { status: 'rejected', reason: `branch mismatch: delta ${branchId} vs target ${bid}` }
+
+  // No read of its own: the retrieval pass already selected these rows, so the
+  // prior count rides on the payload. One bump fires per aware in-scene
+  // character per seated happening, all of them ahead of the narrative stream,
+  // and a read each would double the round trips on the device least able to
+  // absorb them.
+  //
+  // The cost is that a row deleted between the pass and this apply is no longer
+  // detectable here — the periodic classifier can reverse-replay its awareness
+  // rows away mid-turn, since it and a turn do not block each other. That now
+  // writes a delta whose UPDATE matches nothing and whose undo no-ops, rather
+  // than the 'noop' rejection this returned while it still read the row. The
+  // turn must survive it either way: failing would reverse the user's whole
+  // turn over a counter that feeds chapter-close ranking.
+  const next = priorCount + 1
+  return {
+    status: 'ok',
+    targetTable: 'happening_awareness',
+    targetId: id,
+    op: 'update',
+    // retrievalCount has no columnSchemas entry, so reverse-replay restores it by assignment.
+    undoPayload: { retrievalCount: priorCount },
+    ops: [
+      ctx.db
+        .update(happeningAwareness)
+        .set({ retrievalCount: next })
+        .where(and(eq(happeningAwareness.branchId, bid), eq(happeningAwareness.id, id)))
+        .toSQL(),
+    ],
+    patch: { op: 'update', id, columns: { retrievalCount: next } },
+  }
+}
+
 export function registerHappeningAwareness(): void {
   register({
     table: 'happening_awareness',
@@ -149,7 +194,11 @@ export function registerHappeningAwareness(): void {
       branchCol: happeningAwareness.branchId,
     },
     columnSchemas: {},
-    handlers: { upsertHappeningAwareness: upsertHandler, deleteHappeningAwareness: deleteHandler },
+    handlers: {
+      upsertHappeningAwareness: upsertHandler,
+      deleteHappeningAwareness: deleteHandler,
+      bumpAwarenessRetrieval: bumpRetrievalHandler,
+    },
     patcher: (branchId, p) => happeningAwarenessStore.patch(branchId, p),
   })
 }

--- a/lib/actions/index.ts
+++ b/lib/actions/index.ts
@@ -15,6 +15,7 @@ export { defineAction } from './define-action'
 export {
   buildDrainController,
   cancelStorySwap,
+  composeRetrievalEmbedDeps,
   kickStoryDrain,
   countStoryEmbeddableRows,
   refreshEmbeddingStatus,

--- a/lib/actions/turns/submit-turn.test.ts
+++ b/lib/actions/turns/submit-turn.test.ts
@@ -3,20 +3,90 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   branches,
+  stories,
   storyDefinitionSchema,
   storyEntries,
   storySettingsSchema,
   type StoryEntry,
 } from '@/lib/db'
 import { definePipeline, getPipeline, PER_TURN_KIND, type PhaseResult } from '@/lib/pipeline'
-import { currentStoryStore, entriesStore, hydrateAppSettings, undoRedoStore } from '@/lib/stores'
+import { runRetrieval, type RankedType, type RetrievalSuccess } from '@/lib/retrieval'
+import {
+  currentStoryStore,
+  entriesStore,
+  hydrateAppSettings,
+  rehydrateStories,
+  undoRedoStore,
+} from '@/lib/stores'
 
 import { submitTurn } from './submit-turn'
 import { expectRan, makeHarness, resetSingletons } from '../../pipeline/__tests__/harness'
+import { startStorySwap } from '../embedder-swap/app-deps'
+
+// The retrieval phase's own coverage lives in per-turn-retrieval.test.ts; here
+// it only has to let the turn through, and its real pass would reach for a DB
+// bridge this harness has no counterpart for.
+vi.mock('@/lib/retrieval', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, runRetrieval: vi.fn(async () => OK_RETRIEVAL) }
+})
+
+vi.mock('../embedder-swap/engine', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, startSwap: vi.fn(async () => 'completed' as const) }
+})
+
+const EMPTY_BUNDLE: RankedType = {
+  selected: [],
+  traces: [],
+  funnel: {
+    poolSize: 0,
+    preFilteredSize: 0,
+    selectedCount: 0,
+    tokensUsed: 0,
+    typeBudget: 0,
+  },
+}
+
+// Typed against the real outcome rather than cast: the narrative phase reads
+// this into buildGenerationContext, which projects a dozen template variables
+// off it, so a fabricated shape would render a prompt no production pass can
+// produce.
+const OK_RETRIEVAL: RetrievalSuccess = {
+  ok: true,
+  floor: {
+    sceneEntities: [],
+    currentLocation: null,
+    activeThreads: [],
+    alwaysEntities: [],
+    alwaysLore: [],
+    alwaysThreads: [],
+    seatedIds: new Set<string>(),
+  },
+  bundles: {
+    entities: EMPTY_BUNDLE,
+    lore: EMPTY_BUNDLE,
+    happenings: EMPTY_BUNDLE,
+    threads: EMPTY_BUNDLE,
+    chapters: EMPTY_BUNDLE,
+  },
+  queries: {
+    q1: { text: '', source: 'user_action' },
+    q2: { text: '', source: 'structural_digest' },
+    q3: { text: '', source: 'prose_extract' },
+    presence: [false, false, false],
+    embedTexts: [],
+  },
+  staleCounts: { entities: 0, lore: 0, happenings: 0, threads: 0, chapters: 0 },
+  injectedAwareness: [],
+  selectedLocationIds: [],
+  timings: { totalMs: 0, syncMs: 0, embedMs: 0, knnMs: 0, rankMs: 0 },
+}
 
 // The phase streams via the real openai-compatible provider path; stub global
-// fetch (a call-time seam, unlike a module mock which the setup-file's eager
-// load of this module graph would defeat) with a canned OpenAI SSE stream so the
+// fetch (a call-time seam, unlike a module mock of the AI/provider graph, which
+// the setup-file's eager load of that graph would defeat — `@/lib/retrieval`
+// above sits outside it and mocks fine) with a canned OpenAI SSE stream so the
 // happy path gets deterministic streamed tokens without a network round-trip.
 function sseFetch(tokens: readonly string[]): typeof fetch {
   const chunks = tokens.map(
@@ -80,7 +150,10 @@ const STORY_SETTINGS = storySettingsSchema.parse({
   classifierCadence: 8,
   piggybackMode: 'off',
   embeddingBackend: 'local',
-  embedding_model_id: 'm',
+  // A catalog id, not a placeholder: the retrieval phase resolves this story's
+  // embedder config and blocks the turn when it can't (model-management.md →
+  // Embed failure is blocking).
+  embedding_model_id: 'Xenova/all-MiniLM-L6-v2',
   retrievalBudgets: { entities: 1, lore: 1, happenings: 1, threads: 1, chapters: 1 },
   composerModesEnabled: true,
   composerWrapPov: 'first',
@@ -106,8 +179,18 @@ const STORY_SETTINGS = storySettingsSchema.parse({
 
 // narrativePhase (pipeline.ts) reads the open story from currentStoryStore, not
 // from the run's own storyId/branchId — mirrors the real app opening a story
-// before the composer can submit a turn.
-function openStory(storyId: string, branchId: string) {
+// before the composer can submit a turn. storiesStore is populated from the same
+// committed row because the retrieval phase resolves the embedder config there.
+async function openStory(
+  db: Awaited<ReturnType<typeof makeHarness>>['db'],
+  storyId: string,
+  branchId: string,
+): Promise<void> {
+  await db
+    .update(stories)
+    .set({ definition: STORY_DEFINITION, settings: STORY_SETTINGS })
+    .where(eq(stories.id, storyId))
+  await rehydrateStories(db)
   currentStoryStore.set({
     storyId,
     branchId,
@@ -130,9 +213,9 @@ describe('submitTurn', () => {
     resetSingletons()
   })
 
-  it('registers a three-phase pill-and-banner hard-gate per-turn pipeline', async () => {
-    const { ctx } = await makeHarness()
-    openStory('s1', 'b1')
+  it('registers a four-phase pill-and-banner hard-gate per-turn pipeline', async () => {
+    const { ctx, db } = await makeHarness()
+    await openStory(db, 's1', 'b1')
     entriesStore.hydrate('b1', [])
     await hydrateAppSettings(async () => WORKING_CONFIG)
 
@@ -140,15 +223,85 @@ describe('submitTurn', () => {
 
     const pipeline = getPipeline(PER_TURN_KIND)
     expect(pipeline.kind).toBe(PER_TURN_KIND)
-    expect(pipeline.phases).toHaveLength(3)
+    expect(pipeline.phases).toHaveLength(4)
     expect(pipeline.affordance).toBe('pill-and-banner')
     expect(pipeline.gateBehavior).toBe('hard-gate')
     expect(pipeline.concurrencyPolicy.blockedBy).toEqual([PER_TURN_KIND, 'chapter-close'])
   })
 
+  // A swap owns the vec tables: the turn's sync stage would embed under the
+  // story's current model and clear embedding_stale on rows phase 2 deletes.
+  it('refuses a turn while a swap is pending, before writing the user action', async () => {
+    const { ctx, db } = await makeHarness()
+    await openStory(db, 's1', 'b1')
+    entriesStore.hydrate('b1', [])
+    await hydrateAppSettings(async () => WORKING_CONFIG)
+    const open = currentStoryStore.getCurrentStory()
+    if (open == null) throw new Error('story not open')
+    currentStoryStore.set({
+      ...open,
+      settings: { ...open.settings, embedding_swap_target: 'bge-m3' },
+    })
+
+    const result = await submitTurn(
+      { storyId: 's1', branchId: 'b1' },
+      { content: 'Hello there', composerMode: 'say' },
+      ctx,
+    )
+
+    expect(result).toEqual({ outcome: 'rejected', blockedBy: 'embedder-swap' })
+    expect(branchEntries('b1')).toEqual([])
+    const rows = await db.select().from(storyEntries).where(eq(storyEntries.branchId, 'b1'))
+    expect(rows).toEqual([])
+  })
+
+  it('rejects a swap requested while a turn is waiting to commit its user action', async () => {
+    const { ctx, db } = await makeHarness()
+    await openStory(db, 's1', 'b1')
+    entriesStore.hydrate('b1', [])
+    await hydrateAppSettings(async () => WORKING_CONFIG)
+
+    let writeStarted!: () => void
+    const started = new Promise<void>((resolve) => {
+      writeStarted = resolve
+    })
+    let releaseWrite!: () => void
+    const writeGate = new Promise<void>((resolve) => {
+      releaseWrite = resolve
+    })
+    let gateNextTransaction = true
+    const turnCtx = {
+      ...ctx,
+      runInTransaction: async (ops: Parameters<typeof ctx.runInTransaction>[0]) => {
+        if (gateNextTransaction) {
+          gateNextTransaction = false
+          writeStarted()
+          await writeGate
+        }
+        return ctx.runInTransaction(ops)
+      },
+    }
+
+    const turn = submitTurn(
+      { storyId: 's1', branchId: 'b1' },
+      { content: 'Hello there', composerMode: 'say' },
+      turnCtx,
+    )
+    await started
+
+    const swap = startStorySwap(
+      's1',
+      { modelId: STORY_SETTINGS.embedding_model_id, backend: 'local' },
+      ctx,
+    )
+    const swapResult = await swap.finally(releaseWrite)
+    expectRan(await turn)
+    expect(swapResult).toEqual({ status: 'rejected', reason: 'generation in flight' })
+  })
+
   it('completes a turn: persists the user action and the streamed AI reply', async () => {
-    const { ctx } = await makeHarness()
-    openStory('s1', 'b1')
+    const { ctx, db } = await makeHarness()
+    await openStory(db, 's1', 'b1')
     entriesStore.hydrate('b1', [])
     await hydrateAppSettings(async () => WORKING_CONFIG)
 
@@ -177,7 +330,7 @@ describe('submitTurn', () => {
   })
 
   it('inherits scene state from the tail entry onto the user_action, and the ai_reply inherits it too', async () => {
-    const { ctx } = await makeHarness()
+    const { ctx, db } = await makeHarness()
     const opening: StoryEntry = {
       id: 'seed-opening',
       branchId: 'b1',
@@ -193,7 +346,7 @@ describe('submitTurn', () => {
       createdAt: 1,
     }
     await ctx.db.insert(storyEntries).values(opening)
-    openStory('s1', 'b1')
+    await openStory(db, 's1', 'b1')
     entriesStore.hydrate('b1', [opening])
     await hydrateAppSettings(async () => WORKING_CONFIG)
 
@@ -221,7 +374,7 @@ describe('submitTurn', () => {
   })
 
   it('inherits worldTime from the last non-system entry when a system tail lingers', async () => {
-    const { ctx } = await makeHarness()
+    const { ctx, db } = await makeHarness()
     const opening: StoryEntry = {
       id: 'seed-opening',
       branchId: 'b1',
@@ -246,7 +399,7 @@ describe('submitTurn', () => {
       createdAt: 2,
     }
     await ctx.db.insert(storyEntries).values([opening, systemTail])
-    openStory('s1', 'b1')
+    await openStory(db, 's1', 'b1')
     entriesStore.hydrate('b1', [opening, systemTail])
     await hydrateAppSettings(async () => WORKING_CONFIG)
 
@@ -265,7 +418,7 @@ describe('submitTurn', () => {
   })
 
   it('positions the new user action at MAX(position)+1, not the store row count', async () => {
-    const { ctx } = await makeHarness()
+    const { ctx, db } = await makeHarness()
     // Non-contiguous tail: gaps mean the store's row count (4) is LOWER than the
     // real MAX(position) (5), so a count-based position would collide at 5.
     const seeded: StoryEntry[] = [1, 2, 3, 5].map((position) => ({
@@ -279,7 +432,7 @@ describe('submitTurn', () => {
       createdAt: position,
     }))
     for (const row of seeded) await ctx.db.insert(storyEntries).values(row)
-    openStory('s1', 'b1')
+    await openStory(db, 's1', 'b1')
     entriesStore.hydrate('b1', seeded)
     await hydrateAppSettings(async () => WORKING_CONFIG)
 
@@ -298,8 +451,8 @@ describe('submitTurn', () => {
   })
 
   it('assigns distinct positions to two turns submitted concurrently on the same branch', async () => {
-    const { ctx } = await makeHarness()
-    openStory('s1', 'b1')
+    const { ctx, db } = await makeHarness()
+    await openStory(db, 's1', 'b1')
     entriesStore.hydrate('b1', [])
     await hydrateAppSettings(async () => WORKING_CONFIG)
 
@@ -316,6 +469,66 @@ describe('submitTurn', () => {
     // MAX(position)+1 read would otherwise collide both turns on the same slot.
     const positions = branchEntries('b1').map((e) => e.position)
     expect(new Set(positions).size).toBe(positions.length)
+  })
+
+  it('refuses a queued turn when a swap marker appears before the queue advances', async () => {
+    const { ctx, db } = await makeHarness()
+    await openStory(db, 's1', 'b1')
+    entriesStore.hydrate('b1', [])
+    await hydrateAppSettings(async () => WORKING_CONFIG)
+
+    let phaseStarted!: () => void
+    const started = new Promise<void>((resolve) => {
+      phaseStarted = resolve
+    })
+    let releaseTurn!: () => void
+    const turnGate = new Promise<void>((resolve) => {
+      releaseTurn = resolve
+    })
+    definePipeline({
+      kind: PER_TURN_KIND,
+      phases: [
+        {
+          name: 'p',
+          run: async function* (): AsyncGenerator<never, PhaseResult> {
+            phaseStarted()
+            await turnGate
+            return { status: 'completed' }
+          },
+        },
+      ],
+      concurrencyPolicy: { blockedBy: [PER_TURN_KIND] },
+      affordance: 'pill-only',
+      gateBehavior: 'hard-gate',
+    })
+
+    const first = submitTurn(
+      { storyId: 's1', branchId: 'b1' },
+      { content: 'first', composerMode: 'do' },
+      ctx,
+    )
+    await started
+
+    const second = submitTurn(
+      { storyId: 's1', branchId: 'b1' },
+      { content: 'second', composerMode: 'do' },
+      ctx,
+    )
+
+    const open = currentStoryStore.getCurrentStory()
+    if (open == null) throw new Error('story not open')
+    currentStoryStore.set({
+      ...open,
+      settings: { ...open.settings, embedding_swap_target: 'bge-m3' },
+    })
+    releaseTurn()
+    expectRan(await first)
+    await expect(second).resolves.toEqual({ outcome: 'rejected', blockedBy: 'embedder-swap' })
+    expect(
+      branchEntries('b1')
+        .filter((entry) => entry.kind === 'user_action')
+        .map((entry) => entry.content),
+    ).toEqual(['first'])
   })
 
   it('reverses the user_action and leaves no orphan when pipeline admission is rejected', async () => {
@@ -375,8 +588,8 @@ describe('submitTurn', () => {
   })
 
   it('clears the redo stack on success (a new turn is a new unrelated action)', async () => {
-    const { ctx } = await makeHarness()
-    openStory('s1', 'b1')
+    const { ctx, db } = await makeHarness()
+    await openStory(db, 's1', 'b1')
     entriesStore.hydrate('b1', [])
     await hydrateAppSettings(async () => WORKING_CONFIG)
     undoRedoStore.pushRedoGroup([])
@@ -388,8 +601,8 @@ describe('submitTurn', () => {
   })
 
   it('fails the turn and writes no ai_reply when the provider stream errors', async () => {
-    const { ctx } = await makeHarness()
-    openStory('s1', 'b1')
+    const { ctx, db } = await makeHarness()
+    await openStory(db, 's1', 'b1')
     entriesStore.hydrate('b1', [])
     await hydrateAppSettings(async () => WORKING_CONFIG)
     // Matches the live "TypeError: Failed to fetch" — a network reject, not an
@@ -415,6 +628,37 @@ describe('submitTurn', () => {
     // the user_action shares the turn's actionId (C6), so abortRun's
     // reverse-replay drops it too — same clean-rollback path as preflight
     // failure. The composer preserves the text for retry, not a persisted row.
+    expect(branchEntries('b1')).toHaveLength(0)
+  })
+
+  it('blocks the turn and reverses the user action when the retrieval pass fails', async () => {
+    const { ctx, db } = await makeHarness()
+    await openStory(db, 's1', 'b1')
+    entriesStore.hydrate('b1', [])
+    await hydrateAppSettings(async () => WORKING_CONFIG)
+    vi.mocked(runRetrieval).mockResolvedValueOnce({
+      ok: false,
+      failure: { reason: 'call', detail: 'embedder session died', staleCount: 3 },
+    })
+
+    const result = expectRan(
+      await submitTurn(
+        { storyId: 's1', branchId: 'b1' },
+        { content: 'Hello there', composerMode: 'say' },
+        ctx,
+      ),
+    )
+
+    // The blocking half of "embed failure is blocking" (model-management.md →
+    // Embed failure is blocking): the turn dies before the narrative call, and
+    // the already-committed user_action reverses with the rest of the run.
+    expect(result.outcome).toBe('failed')
+    expect(result.error).toEqual({
+      kind: 'embedder',
+      reason: 'call',
+      detail: 'embedder session died',
+      staleCount: 3,
+    })
     expect(branchEntries('b1')).toHaveLength(0)
   })
 

--- a/lib/actions/turns/submit-turn.ts
+++ b/lib/actions/turns/submit-turn.ts
@@ -11,9 +11,12 @@ import {
 
 import { applyDeltaAction } from '../delta/apply-delta-action'
 import { DeltaReplayError, reverseReplayDeltas } from '../delta/reverse-replay'
+import { isStorySwapPending, withTurnAdmission } from '../embedder-swap/app-deps'
 import type { DbCtx } from '../types'
 
 export type SubmitTurnMeta = { content: string; composerMode: string }
+
+const SWAP_REJECTION = { outcome: 'rejected', blockedBy: 'embedder-swap' } as const
 
 // This app is local-first, single-process (no BaaS/backend serving concurrent
 // writers — data-model.md), so an in-process per-branch queue is a complete
@@ -44,87 +47,94 @@ export async function submitTurn(
   ensurePerTurnPipelineRegistered()
 
   return withBranchQueue(ids.branchId, async () => {
-    // Shared across the user_action's delta and the pipeline run it kicks off,
-    // so CTRL-Z reverses the whole turn as one group (milestone.md C6).
-    const turnActionId = generateId('act')
+    const admission = await withTurnAdmission(ids.storyId, async () => {
+      // Checked under the same admission as live swaps. The in-memory gate covers
+      // this process; the marker still covers a swap recovered from an earlier one.
+      if (isStorySwapPending(ids.storyId)) return SWAP_REJECTION
 
-    // Tail position from committed rows, not the in-memory store's count: real
-    // branches have position gaps, so a count lands mid-story and collides.
-    // Queued per-branch so a second submit can't read the same MAX before the
-    // first one's insert lands.
-    const [tail] = await ctx.db
-      .select({ position: storyEntries.position })
-      .from(storyEntries)
-      .where(eq(storyEntries.branchId, ids.branchId))
-      .orderBy(desc(storyEntries.position))
-      .limit(1)
-    // Scene state (membership, location, worldTime) inherits from the last
-    // non-system entry: a system tail carries null metadata and would reset
-    // it. M2 has no classifier, so this propagates the opening's values
-    // forward until piggyback/classifier (M3+) emits fresh ones. Position
-    // still comes from the overall tail so numbering never collides.
-    const [sceneTail] = await ctx.db
-      .select({ metadata: storyEntries.metadata })
-      .from(storyEntries)
-      .where(and(eq(storyEntries.branchId, ids.branchId), ne(storyEntries.kind, 'system')))
-      .orderBy(desc(storyEntries.position))
-      .limit(1)
-    const position = (tail?.position ?? 0) + 1
-    const entryId = generateId('entry')
-    const createdAt = Date.now()
-    const metadata: EntryMetadata = inheritedEntryMetadata(sceneTail?.metadata)
+      // Shared across the user_action's delta and the pipeline run it kicks off,
+      // so CTRL-Z reverses the whole turn as one group (milestone.md C6).
+      const turnActionId = generateId('act')
 
-    const result = await applyDeltaAction(
-      {
-        action: {
-          kind: 'createStoryEntry',
-          source: 'user_edit',
-          payload: {
-            entry: {
-              id: entryId,
-              branchId: ids.branchId,
-              position,
-              kind: 'user_action',
-              content: meta.content,
-              chapterId: null,
-              metadata,
-              createdAt,
+      // Tail position from committed rows, not the in-memory store's count: real
+      // branches have position gaps, so a count lands mid-story and collides.
+      // Queued per-branch so a second submit can't read the same MAX before the
+      // first one's insert lands.
+      const [tail] = await ctx.db
+        .select({ position: storyEntries.position })
+        .from(storyEntries)
+        .where(eq(storyEntries.branchId, ids.branchId))
+        .orderBy(desc(storyEntries.position))
+        .limit(1)
+      // Scene state (membership, location, worldTime) inherits from the last
+      // non-system entry: a system tail carries null metadata and would reset
+      // it. M2 has no classifier, so this propagates the opening's values
+      // forward until piggyback/classifier (M3+) emits fresh ones. Position
+      // still comes from the overall tail so numbering never collides.
+      const [sceneTail] = await ctx.db
+        .select({ metadata: storyEntries.metadata })
+        .from(storyEntries)
+        .where(and(eq(storyEntries.branchId, ids.branchId), ne(storyEntries.kind, 'system')))
+        .orderBy(desc(storyEntries.position))
+        .limit(1)
+      const position = (tail?.position ?? 0) + 1
+      const entryId = generateId('entry')
+      const createdAt = Date.now()
+      const metadata: EntryMetadata = inheritedEntryMetadata(sceneTail?.metadata)
+
+      const result = await applyDeltaAction(
+        {
+          action: {
+            kind: 'createStoryEntry',
+            source: 'user_edit',
+            payload: {
+              entry: {
+                id: entryId,
+                branchId: ids.branchId,
+                position,
+                kind: 'user_action',
+                content: meta.content,
+                chapterId: null,
+                metadata,
+                createdAt,
+              },
             },
           },
+          actionId: turnActionId,
+          branchId: ids.branchId,
+          entryId: null,
         },
-        actionId: turnActionId,
-        branchId: ids.branchId,
-        entryId: null,
-      },
-      ctx,
-    )
-    if (result.status === 'rejected')
-      throw new Error(`submitTurn: user_action write rejected: ${result.reason}`)
+        ctx,
+      )
+      if (result.status === 'rejected')
+        throw new Error(`submitTurn: user_action write rejected: ${result.reason}`)
 
-    const runCtx: RunCtx = {
-      storyId: ids.storyId,
-      branchId: ids.branchId,
-      actionId: turnActionId,
-      db: ctx.db,
-      runInTransaction: ctx.runInTransaction,
-    }
-    // Held for the whole run, not just the user_action insert above:
-    // narrativePhase (pipeline.ts) does its own MAX(position)+1 read for the
-    // ai_reply, which needs the same per-branch exclusion.
-    const runResult = await runPipeline(PER_TURN_KIND, runCtx)
-    if (runResult.outcome === 'rejected') {
-      // A rejected admission never reaches abortRun (orchestrator.ts) — no run
-      // was ever reserved — so the user_action committed above is never
-      // reversed the way a failed/aborted run's is (C6). Reverse it here so no
-      // orphaned entry survives a turn that never actually started.
-      try {
-        await reverseReplayDeltas(turnActionId, ctx)
-      } catch (e) {
-        // Deltas are reversed even if the post-commit store sync failed; the
-        // caller still sees the rejection, same tolerance abortRun applies.
-        if (!(e instanceof DeltaReplayError)) throw e
+      const runCtx: RunCtx = {
+        storyId: ids.storyId,
+        branchId: ids.branchId,
+        actionId: turnActionId,
+        db: ctx.db,
+        runInTransaction: ctx.runInTransaction,
       }
-    }
-    return runResult
+      // Held for the whole run, not just the user_action insert above:
+      // narrativePhase (pipeline.ts) does its own MAX(position)+1 read for the
+      // ai_reply, which needs the same per-branch exclusion.
+      const runResult = await runPipeline(PER_TURN_KIND, runCtx)
+      if (runResult.outcome === 'rejected') {
+        // A rejected admission never reaches abortRun (orchestrator.ts) — no run
+        // was ever reserved — so the user_action committed above is never
+        // reversed the way a failed/aborted run's is (C6). Reverse it here so no
+        // orphaned entry survives a turn that never actually started.
+        try {
+          await reverseReplayDeltas(turnActionId, ctx)
+        } catch (e) {
+          // Deltas are reversed even if the post-commit store sync failed; the
+          // caller still sees the rejection, same tolerance abortRun applies.
+          if (!(e instanceof DeltaReplayError)) throw e
+        }
+      }
+      return runResult
+    })
+    return admission.admitted ? admission.value : SWAP_REJECTION
   })
 }

--- a/lib/pipeline/definitions/generation-context.test.ts
+++ b/lib/pipeline/definitions/generation-context.test.ts
@@ -1,7 +1,18 @@
 import { describe, expect, it } from 'vitest'
 
+import { STORY_SETTINGS_DEFAULTS, type StorySettings } from '@/lib/db'
 import { IdBiMap } from '@/lib/ids'
 import { renderTemplate, TEMPLATE_IDS, VARIABLES } from '@/lib/prompts'
+import type {
+  Candidate,
+  CandidateKind,
+  EntityRow,
+  LoreRow,
+  RetrievalSuccess,
+  RetrievalType,
+  StructuralFloor,
+  ThreadRow,
+} from '@/lib/retrieval'
 
 import { buildGenerationContext, PROMPT_ENTITY_FIELDS } from './generation-context'
 
@@ -16,7 +27,15 @@ const definition = {
   worldTimeOrigin: { year: 0 },
 }
 
-const settings = { partialChapterBuffer: 3, suggestionCategories: [] } as never
+// composePromptBuffer reads three settings, and `as never` on a partial literal
+// hides a missing one as `undefined` rather than failing to compile.
+function storySettings(overrides: Partial<StorySettings> = {}): StorySettings {
+  return { ...STORY_SETTINGS_DEFAULTS, ...overrides }
+}
+
+// protectedBuffer 0 makes the shared window exactly partialChapterBuffer; the
+// spillover floor has its own cases below.
+const settings = storySettings({ partialChapterBuffer: 3, protectedBuffer: 0 })
 
 function entry(id: string, position: number, content: string, kind = 'ai_reply') {
   return {
@@ -31,8 +50,103 @@ function entry(id: string, position: number, content: string, kind = 'ai_reply')
   }
 }
 
+const LOC_A = 'loc_00000000-0000-4000-8000-0000000000a1'
+const LOC_B = 'loc_00000000-0000-4000-8000-0000000000b2'
+
+function sceneMetadata(currentLocationId: string | null, sceneEntities: string[] = []) {
+  return { sceneEntities, currentLocationId, worldTime: 0 }
+}
+
+function candidate(kind: CandidateKind, id: string, displayName: string): Candidate {
+  return {
+    kind,
+    id,
+    displayName,
+    renderedText: `${displayName} rendered`,
+    sims: [0, 0, 0],
+    vector: new Float32Array([1, 0, 0]),
+    chaptersOld: 0,
+    pinSignal: 0,
+    commonKnowledge: false,
+    keywordHits: [],
+    occurredAtEntryId: null,
+    awarenessIds: [],
+    embeddingStale: false,
+  }
+}
+
+function ranked(selected: readonly Candidate[]) {
+  return {
+    selected,
+    traces: [],
+    funnel: {
+      poolSize: selected.length,
+      preFilteredSize: selected.length,
+      selectedCount: selected.length,
+      tokensUsed: 0,
+      typeBudget: 0,
+    },
+  }
+}
+
+const EMPTY_FLOOR: StructuralFloor = {
+  sceneEntities: [],
+  currentLocation: null,
+  activeThreads: [],
+  alwaysEntities: [],
+  alwaysLore: [],
+  alwaysThreads: [],
+  seatedIds: new Set(),
+}
+
+function entityRow(id: string, name: string): EntityRow {
+  return { id, kind: 'character', status: 'active', injectionMode: 'auto', name, description: null }
+}
+
+function loreRow(id: string, title: string): LoreRow {
+  return { id, title, body: null, injectionMode: 'always', priority: 0 }
+}
+
+function threadRow(id: string, title: string): ThreadRow {
+  return { id, status: 'active', injectionMode: 'auto', title, description: null }
+}
+
+// The union of what loadSourceRows hangs off a floor row (embeddingStale on
+// every type, keywords on lore — lib/retrieval/source-rows.ts). Spread onto all
+// four fixtures so one projection assertion covers the union; StructuralFloor's
+// declared types omit both, so only a runtime fixture carries them in.
+const LOADED_EXTRAS = { embeddingStale: true, keywords: ['ghost'] }
+
+const keysOf = (bucket: unknown) => (bucket as object[]).map((r) => Object.keys(r).sort())
+
+function retrievalOutcome(
+  over: {
+    floor?: Partial<StructuralFloor>
+    selected?: Partial<Record<RetrievalType, Candidate[]>>
+  } = {},
+): RetrievalSuccess {
+  const bundleFor = (type: RetrievalType) => ranked(over.selected?.[type] ?? [])
+  const spec = { text: '', source: 'user_action' as const }
+  return {
+    ok: true,
+    floor: { ...EMPTY_FLOOR, ...over.floor },
+    bundles: {
+      entities: bundleFor('entities'),
+      lore: bundleFor('lore'),
+      happenings: bundleFor('happenings'),
+      threads: bundleFor('threads'),
+      chapters: bundleFor('chapters'),
+    },
+    queries: { q1: spec, q2: spec, q3: spec, presence: [false, false, false], embedTexts: [] },
+    staleCounts: { entities: 0, lore: 0, happenings: 0, threads: 0, chapters: 0 },
+    injectedAwareness: [],
+    selectedLocationIds: [],
+    timings: { totalMs: 0, syncMs: 0, embedMs: 0, knnMs: 0, rankMs: 0 },
+  }
+}
+
 describe('buildGenerationContext', () => {
-  it('drops system entries outright and keeps the full caller-scoped window', () => {
+  it('drops system entries outright', () => {
     const entries = [
       entry('e1', 1, 'one'),
       entry('e2', 2, 'two'),
@@ -43,9 +157,11 @@ describe('buildGenerationContext', () => {
     const ctx = buildGenerationContext({
       branchId: 'b1',
       entries,
+      // Wide enough that composition windows nothing out, so the assertion
+      // isolates the system-kind exclusion.
+      settings: storySettings({ partialChapterBuffer: 10, protectedBuffer: 0 }),
       entities: [],
       definition,
-      settings,
       idMap: new IdBiMap(),
     })
     const contents = (ctx.entries as { content: string }[]).map((e) => e.content)
@@ -53,7 +169,7 @@ describe('buildGenerationContext', () => {
     expect(contents).not.toContain('ERROR')
   })
 
-  it('exposes partialChapterBuffer through userSettings for template-side windowing', () => {
+  it('exposes all three buffer knobs through userSettings', () => {
     const ctx = buildGenerationContext({
       branchId: 'b1',
       entries: [],
@@ -62,7 +178,11 @@ describe('buildGenerationContext', () => {
       settings,
       idMap: new IdBiMap(),
     })
-    expect(ctx.userSettings).toEqual({ partialChapterBuffer: 3 })
+    expect(ctx.userSettings).toEqual({
+      fullChapterInBuffer: false,
+      partialChapterBuffer: 3,
+      protectedBuffer: 0,
+    })
   })
 
   it('emits every variable the generationContext registry pins', () => {
@@ -195,7 +315,10 @@ describe('buildGenerationContext', () => {
     expect(ctx.sceneEntities).toEqual([])
   })
 
-  it('renders the per-turn template windowed to partialChapterBuffer', () => {
+  // End-to-end, not a mechanism check: the builder composes the window and the
+  // template renders it whole, so the composed list is asserted on its own
+  // before the render assertions ride on top of it.
+  it('renders the per-turn template over exactly the composed window', () => {
     const entries = [
       entry('e1', 1, 'first-line'),
       entry('e2', 2, 'second-line'),
@@ -211,13 +334,20 @@ describe('buildGenerationContext', () => {
       settings,
       idMap: new IdBiMap(),
     })
+    expect((ctx.entries as { content: string }[]).map((e) => e.content)).toEqual([
+      'third-line',
+      'fourth-line',
+      'The gate creaks open.',
+    ])
+
     const prompt = renderTemplate(TEMPLATE_IDS.perTurnNarrative, ctx)
     expect(prompt).toContain('# Setting')
     expect(prompt).toContain('# Genre')
     expect(prompt).not.toContain('# Tone') // whitespace-only tone.promptBody guarded out
     expect(prompt).toContain('The gate creaks open.')
     expect(prompt).toContain('third-line')
-    expect(prompt).not.toContain('first-line') // outside the 3-entry window
+    expect(prompt).toContain('fourth-line')
+    expect(prompt).not.toContain('first-line') // composed out, three entries back
     expect(prompt).not.toContain('second-line')
   })
 
@@ -238,8 +368,7 @@ describe('buildGenerationContext', () => {
   })
 
   it('always carries suggestionSlots; suggestionsFire gates only the instruction', () => {
-    const paletteSettings = {
-      partialChapterBuffer: 3,
+    const paletteSettings = storySettings({
       suggestionCategories: [
         {
           id: 'cat_a',
@@ -250,7 +379,7 @@ describe('buildGenerationContext', () => {
           order: 0,
         },
       ],
-    } as never
+    })
     const base = { branchId: 'b1', entries: [], entities: [], definition, idMap: new IdBiMap() }
 
     // The slots are the story's palette, not an instruction to emit — a caller
@@ -276,7 +405,7 @@ describe('buildGenerationContext', () => {
       entries: [],
       entities: [],
       definition,
-      settings: { partialChapterBuffer: 3, suggestionCategories: [] } as never,
+      settings: storySettings({ suggestionCategories: [] }),
       idMap: new IdBiMap(),
       suggestionsFire: true,
     })
@@ -289,8 +418,7 @@ describe('buildGenerationContext', () => {
       entries: [],
       entities: [],
       definition,
-      settings: {
-        partialChapterBuffer: 3,
+      settings: storySettings({
         suggestionCategories: [
           {
             id: 'cat_a',
@@ -309,7 +437,7 @@ describe('buildGenerationContext', () => {
             order: 1,
           },
         ],
-      } as never,
+      }),
       idMap: new IdBiMap(),
       suggestionsFire: true,
     })
@@ -324,8 +452,7 @@ describe('buildGenerationContext', () => {
       entries: [],
       entities: [],
       definition,
-      settings: {
-        partialChapterBuffer: 3,
+      settings: storySettings({
         suggestionCategories: [
           {
             id: 'cat_a',
@@ -336,7 +463,7 @@ describe('buildGenerationContext', () => {
             order: 0,
           },
         ],
-      } as never,
+      }),
       idMap: new IdBiMap(),
       suggestionsFire: true,
     })
@@ -350,7 +477,7 @@ describe('buildGenerationContext', () => {
       entries: [],
       entities: [],
       definition,
-      settings: { partialChapterBuffer: 3, suggestionCount: 5, suggestionCategories: [] } as never,
+      settings: storySettings({ suggestionCount: 5 }),
       idMap: new IdBiMap(),
     })
     expect(ctx.suggestionCount).toBe(5)
@@ -411,5 +538,437 @@ describe('buildGenerationContext', () => {
       idMap: new IdBiMap(),
     })
     expect(unknownCtx.calendarVocabulary).toBeNull()
+  })
+
+  it('emits no runtime key the generationContext registry does not define', () => {
+    const ctx = buildGenerationContext({
+      branchId: 'b1',
+      entries: [],
+      entities: [],
+      definition,
+      settings,
+      idMap: new IdBiMap(),
+    })
+    const defined = VARIABLES.generationContext.map((v) => v.name)
+    expect(Object.keys(ctx).filter((key) => !defined.includes(key))).toEqual([])
+  })
+})
+
+// `total` entries, the last `openTail` of them in the open region (chapterId
+// null); everything before that closed under one chapter.
+function branchEntries(total: number, openTail: number) {
+  return Array.from({ length: total }, (_, i) => ({
+    ...entry(`e${i + 1}`, i + 1, `line-${i + 1}`),
+    chapterId: i < total - openTail ? 'chap_x' : null,
+  })) as never[]
+}
+
+const contentsOf = (ctx: Record<string, unknown>) =>
+  (ctx.entries as { content: string }[]).map((e) => e.content)
+
+describe('buildGenerationContext — composed prompt buffer', () => {
+  const base = () => ({ branchId: 'b1', entities: [], definition, idMap: new IdBiMap() })
+
+  it('windows partial mode to partialChapterBuffer, tail-first', () => {
+    const ctx = buildGenerationContext({
+      ...base(),
+      entries: branchEntries(40, 15),
+      settings: storySettings({
+        fullChapterInBuffer: false,
+        partialChapterBuffer: 4,
+        protectedBuffer: 0,
+      }),
+    })
+    expect(contentsOf(ctx)).toEqual(['line-37', 'line-38', 'line-39', 'line-40'])
+  })
+
+  // Distinguishes the two modes on the same fixture: partial gives 4, full 15.
+  // Reachable only from chapterId, so it also pins that composition runs before
+  // the entry -> { content } map strips it.
+  it('takes the whole open region in full mode', () => {
+    const ctx = buildGenerationContext({
+      ...base(),
+      entries: branchEntries(40, 15),
+      settings: storySettings({
+        fullChapterInBuffer: true,
+        partialChapterBuffer: 4,
+        protectedBuffer: 0,
+      }),
+    })
+    expect(contentsOf(ctx)).toHaveLength(15)
+    expect(contentsOf(ctx)[0]).toBe('line-26')
+    expect(contentsOf(ctx).at(-1)).toBe('line-40')
+  })
+
+  // cadence.md -> Composition rule: a short open region is filled from the
+  // previous chapter up to protectedBuffer, so the window crosses the boundary.
+  it('widens past the open region to satisfy the protectedBuffer floor', () => {
+    const ctx = buildGenerationContext({
+      ...base(),
+      entries: branchEntries(40, 3),
+      settings: storySettings({
+        fullChapterInBuffer: false,
+        partialChapterBuffer: 4,
+        protectedBuffer: 22,
+      }),
+    })
+    expect(contentsOf(ctx)).toHaveLength(22)
+    expect(contentsOf(ctx)[0]).toBe('line-19')
+  })
+
+  // Contract pin for the piggyback fallback classifier, which passes exactly
+  // the tail pair it wants extracted rather than a branch: under the shipped
+  // defaults the composition must not truncate a caller window that short.
+  it('leaves a two-entry caller window intact under the default knobs', () => {
+    const ctx = buildGenerationContext({
+      ...base(),
+      entries: branchEntries(2, 2),
+      settings: storySettings(),
+    })
+    expect(contentsOf(ctx)).toEqual(['line-1', 'line-2'])
+  })
+
+  // The boundary the pin above sits on, and the cost of crossing it. take is
+  // max(protectedBuffer, min(openCount, wanted)), so a protectedBuffer of 0 over
+  // a region with no open entries composes to nothing at all and the classifier
+  // gets its extraction instruction with no prose beneath it. Reachable from M5,
+  // when chapter-close starts stamping chapterId on recent entries.
+  it('composes that same pair away at protectedBuffer 0 once both entries are chaptered', () => {
+    const ctx = buildGenerationContext({
+      ...base(),
+      entries: branchEntries(2, 0),
+      settings: storySettings({ protectedBuffer: 0 }),
+    })
+    expect(contentsOf(ctx)).toEqual([])
+  })
+})
+
+// The composed window IS the prompt window (cadence.md → Composition rule): a
+// template that re-trimmed `entries` by partialChapterBuffer would send the
+// narrative and the chips two different stories. Full mode opens the widest gap
+// between the composed window and that knob.
+describe('buildGenerationContext — composed window reaches the bundled templates whole', () => {
+  const settings = storySettings({
+    fullChapterInBuffer: true,
+    partialChapterBuffer: 3,
+    protectedBuffer: 0,
+  })
+  const context = () =>
+    buildGenerationContext({
+      branchId: 'b1',
+      entries: branchEntries(40, 12),
+      entities: [],
+      definition,
+      settings,
+      idMap: new IdBiMap(),
+    })
+
+  it('composes wider than partialChapterBuffer, so a re-trim would be visible', () => {
+    expect(contentsOf(context())).toHaveLength(12)
+    expect(contentsOf(context()).length).toBeGreaterThan(settings.partialChapterBuffer)
+  })
+
+  it.each([TEMPLATE_IDS.perTurnNarrative, TEMPLATE_IDS.suggestionRefresh])(
+    'renders every composed entry in %s',
+    (templateId) => {
+      const ctx = context()
+      const prompt = renderTemplate(templateId, ctx)
+      const composed = contentsOf(ctx)
+      expect(composed).toHaveLength(12)
+      for (const content of composed) expect(prompt).toContain(content)
+    },
+  )
+})
+
+const CHAR_ID = 'char_00000000-0000-4000-8000-0000000000c1'
+const CHAR_ID_2 = 'char_00000000-0000-4000-8000-0000000000c2'
+const LORE_ID = 'lore_00000000-0000-4000-8000-0000000000d1'
+const HAP_ID = 'hap_00000000-0000-4000-8000-0000000000e1'
+const THR_ID = 'thr_00000000-0000-4000-8000-0000000000f1'
+const THR_ID_2 = 'thr_00000000-0000-4000-8000-0000000000f2'
+const CHAP_ID = 'chap_00000000-0000-4000-8000-00000000a001'
+
+const RETRIEVED_KEYS = [
+  'retrievedEntities',
+  'retrievedLore',
+  'retrievedHappenings',
+  'retrievedThreads',
+  'retrievedChapters',
+] as const
+
+const namesOf = (bucket: unknown) => (bucket as { displayName: string }[]).map((r) => r.displayName)
+
+// Pre-seeded so a placeholder assertion pins the id it came from rather than
+// the order substituteIds happens to walk the context keys in.
+function seededIdMap(...ids: string[]): IdBiMap {
+  const idMap = new IdBiMap()
+  for (const id of ids) idMap.allocate(id)
+  return idMap
+}
+
+describe('buildGenerationContext — retrieval bundles', () => {
+  const base = () => ({
+    branchId: 'b1',
+    entries: [] as never[],
+    entities: [],
+    definition,
+    settings,
+    idMap: seededIdMap(CHAR_ID),
+  })
+
+  const populated = () =>
+    retrievalOutcome({
+      selected: {
+        entities: [candidate('entity', CHAR_ID, 'Mara')],
+        lore: [candidate('lore', LORE_ID, 'The Compact')],
+        happenings: [candidate('happening', HAP_ID, 'The siege')],
+        threads: [candidate('thread', THR_ID, 'Find the heir')],
+        chapters: [candidate('chapter', CHAP_ID, 'Chapter One')],
+      },
+    })
+
+  it('emits an empty array for every retrieved bucket when no retrieval ran', () => {
+    const ctx = buildGenerationContext({ ...base(), retrieval: undefined })
+    for (const key of RETRIEVED_KEYS) expect(ctx[key]).toEqual([])
+  })
+
+  // Positive control for the emptiness assertion above: the same five keys
+  // carry their own bundle and only their own.
+  it('routes each bundle to its own bucket', () => {
+    const ctx = buildGenerationContext({ ...base(), retrieval: populated() })
+    expect(namesOf(ctx.retrievedEntities)).toEqual(['Mara'])
+    expect(namesOf(ctx.retrievedLore)).toEqual(['The Compact'])
+    expect(namesOf(ctx.retrievedHappenings)).toEqual(['The siege'])
+    expect(namesOf(ctx.retrievedThreads)).toEqual(['Find the heir'])
+    expect(namesOf(ctx.retrievedChapters)).toEqual(['Chapter One'])
+  })
+
+  // Why those three and nothing else: see promptRows in generation-context.ts.
+  it('projects a candidate to id / displayName / renderedText only', () => {
+    const ctx = buildGenerationContext({ ...base(), retrieval: populated() })
+    const row = (ctx.retrievedLore as Record<string, unknown>[])[0]!
+    expect(Object.keys(row).sort()).toEqual(['displayName', 'id', 'renderedText'])
+    expect(row.renderedText).toBe('The Compact rendered')
+  })
+
+  it('substitutes retrieved row ids to placeholders, like the entities list', () => {
+    const ctx = buildGenerationContext({ ...base(), retrieval: populated() })
+    expect((ctx.retrievedEntities as { id: string }[])[0]!.id).toBe('c1')
+  })
+})
+
+describe('buildGenerationContext — structural floor', () => {
+  const base = () => ({
+    branchId: 'b1',
+    entries: [] as never[],
+    entities: [],
+    definition,
+    settings,
+    idMap: seededIdMap(LOC_A),
+  })
+
+  const populated = () =>
+    retrievalOutcome({
+      floor: {
+        sceneEntities: [entityRow(CHAR_ID, 'Mara')],
+        currentLocation: entityRow(LOC_A, 'The keep'),
+        activeThreads: [threadRow(THR_ID, 'Find the heir')],
+        alwaysEntities: [entityRow(CHAR_ID_2, 'Corvin')],
+        alwaysLore: [loreRow(LORE_ID, 'The Compact')],
+        alwaysThreads: [threadRow(THR_ID_2, 'The debt')],
+      },
+    })
+
+  it('emits empty lists and a null location when no retrieval ran', () => {
+    const ctx = buildGenerationContext({ ...base(), retrieval: undefined })
+    expect(ctx.structuralSceneEntities).toEqual([])
+    expect(ctx.structuralActiveThreads).toEqual([])
+    expect(ctx.structuralPinnedEntities).toEqual([])
+    expect(ctx.structuralPinnedLore).toEqual([])
+    expect(ctx.structuralPinnedThreads).toEqual([])
+    expect(ctx.structuralLocation).toBeNull()
+  })
+
+  it('carries every floor field to its own bucket', () => {
+    const ctx = buildGenerationContext({ ...base(), retrieval: populated() })
+    expect((ctx.structuralSceneEntities as { name: string }[]).map((e) => e.name)).toEqual(['Mara'])
+    expect((ctx.structuralLocation as { name: string }).name).toBe('The keep')
+    expect((ctx.structuralActiveThreads as { title: string }[]).map((t) => t.title)).toEqual([
+      'Find the heir',
+    ])
+  })
+
+  // Why they are not one concatenated list: see the structuralPinned* keys in
+  // generation-context.ts.
+  it('keeps the pinned rows in per-type buckets a template can tell apart', () => {
+    const ctx = buildGenerationContext({ ...base(), retrieval: populated() })
+    expect((ctx.structuralPinnedEntities as { name: string }[]).map((e) => e.name)).toEqual([
+      'Corvin',
+    ])
+    expect((ctx.structuralPinnedLore as { title: string }[]).map((l) => l.title)).toEqual([
+      'The Compact',
+    ])
+    expect((ctx.structuralPinnedThreads as { title: string }[]).map((t) => t.title)).toEqual([
+      'The debt',
+    ])
+  })
+
+  it('substitutes floor row ids to placeholders', () => {
+    const ctx = buildGenerationContext({ ...base(), retrieval: populated() })
+    expect((ctx.structuralLocation as { id: string }).id).toBe('l1')
+  })
+
+  // The floor is built over LOADED source rows, so every row here still carries
+  // embeddingStale (and lore's keywords) at runtime; StructuralFloor's declared
+  // shape hides that from the compiler, which is why it needs a runtime pin.
+  it('projects floor rows to render fields only, dropping retrieval bookkeeping', () => {
+    const ctx = buildGenerationContext({
+      ...base(),
+      retrieval: retrievalOutcome({
+        floor: {
+          sceneEntities: [{ ...entityRow(CHAR_ID, 'Mara'), ...LOADED_EXTRAS } as EntityRow],
+          currentLocation: { ...entityRow(LOC_A, 'The keep'), ...LOADED_EXTRAS } as EntityRow,
+          activeThreads: [{ ...threadRow(THR_ID, 'Find the heir'), ...LOADED_EXTRAS } as ThreadRow],
+          alwaysLore: [{ ...loreRow(LORE_ID, 'The Compact'), ...LOADED_EXTRAS } as LoreRow],
+        },
+      }),
+    })
+    expect(keysOf(ctx.structuralSceneEntities)).toEqual([
+      ['description', 'id', 'kind', 'name', 'status'],
+    ])
+    expect(Object.keys(ctx.structuralLocation as object).sort()).toEqual([
+      'description',
+      'id',
+      'kind',
+      'name',
+      'status',
+    ])
+    expect(keysOf(ctx.structuralActiveThreads)).toEqual([['description', 'id', 'status', 'title']])
+    expect(keysOf(ctx.structuralPinnedLore)).toEqual([['body', 'id', 'title']])
+  })
+
+  // Positive control for the projection assertions: the same leaked fields are
+  // present on the rows going in, so those key lists are a filter's output and
+  // not just the fixture's own shape.
+  it('receives floor rows that do carry the bookkeeping it drops', () => {
+    const leaked = { ...entityRow(CHAR_ID, 'Mara'), ...LOADED_EXTRAS }
+    expect(Object.keys(leaked)).toContain('embeddingStale')
+    expect(Object.keys(leaked)).toContain('keywords')
+  })
+})
+
+describe('buildGenerationContext — locationIds', () => {
+  const LOC_C = 'loc_00000000-0000-4000-8000-0000000000c3'
+  const LOC_D = 'loc_00000000-0000-4000-8000-0000000000d4'
+
+  const place = (id: string, name: string): EntityRow => ({
+    ...entityRow(id, name),
+    kind: 'location',
+  })
+
+  const base = () => ({
+    branchId: 'b1',
+    entries: [] as never[],
+    entities: [],
+    definition,
+    settings,
+    idMap: seededIdMap(LOC_A, LOC_B, LOC_C, LOC_D, CHAR_ID, CHAR_ID_2),
+  })
+
+  it('is empty when no retrieval ran', () => {
+    expect(buildGenerationContext({ ...base(), retrieval: undefined }).locationIds).toEqual([])
+  })
+
+  it('collects every place the prompt renders an ID for, in reading order', () => {
+    const ctx = buildGenerationContext({
+      ...base(),
+      retrieval: {
+        ...retrievalOutcome({
+          floor: {
+            sceneEntities: [place(LOC_B, 'The yard')],
+            currentLocation: place(LOC_A, 'The keep'),
+            alwaysEntities: [place(LOC_C, 'The shrine')],
+          },
+          selected: { entities: [candidate('entity', LOC_D, 'The market')] },
+        }),
+        selectedLocationIds: [LOC_D],
+      },
+    })
+    expect(ctx.locationIds).toEqual(['l2', 'l1', 'l3', 'l4'])
+  })
+
+  it('leaves out entities that are not places, from either the floor or the ranker', () => {
+    const ctx = buildGenerationContext({
+      ...base(),
+      retrieval: {
+        ...retrievalOutcome({
+          floor: {
+            sceneEntities: [entityRow(CHAR_ID, 'Mara')],
+            currentLocation: place(LOC_A, 'The keep'),
+            alwaysEntities: [entityRow(CHAR_ID_2, 'Corvin')],
+          },
+          selected: { entities: [candidate('entity', CHAR_ID_2, 'Corvin')] },
+        }),
+        // The pass reports no ranked place, so the ranked character below must
+        // not reach the list even though it renders with a bracketed ID.
+        selectedLocationIds: [],
+      },
+    })
+    expect(ctx.locationIds).toEqual(['l1'])
+    // Positive control: those same rows do render with IDs of their own.
+    expect((ctx.structuralSceneEntities as { id: string }[]).map((e) => e.id)).toEqual(['c1'])
+    expect((ctx.retrievedEntities as { id: string }[]).map((e) => e.id)).toEqual(['c2'])
+  })
+
+  it('de-duplicates a place the floor and the ranker both name', () => {
+    const ctx = buildGenerationContext({
+      ...base(),
+      retrieval: {
+        ...retrievalOutcome({
+          floor: { currentLocation: place(LOC_A, 'The keep') },
+          selected: { entities: [candidate('entity', LOC_A, 'The keep')] },
+        }),
+        selectedLocationIds: [LOC_A],
+      },
+    })
+    expect(ctx.locationIds).toEqual(['l1'])
+  })
+})
+
+describe('buildGenerationContext — currentLocationId', () => {
+  // LOC_A is l1 and LOC_B is l2, so the two entries below are distinguishable.
+  const base = () => ({
+    branchId: 'b1',
+    entities: [],
+    definition,
+    settings,
+    idMap: seededIdMap(LOC_A, LOC_B),
+  })
+
+  it('reads the narrative tail, not an earlier entry, and substitutes the id', () => {
+    const ctx = buildGenerationContext({
+      ...base(),
+      entries: [
+        { ...entry('e1', 1, 'one'), metadata: sceneMetadata(LOC_A) },
+        { ...entry('e2', 2, 'two'), metadata: sceneMetadata(LOC_B) },
+      ] as never[],
+    })
+    expect(ctx.currentLocationId).toBe('l2')
+  })
+
+  it('falls back to null when the tail carries no location', () => {
+    const ctx = buildGenerationContext({ ...base(), entries: [entry('e1', 1, 'one')] as never[] })
+    expect(ctx.currentLocationId).toBeNull()
+  })
+
+  it('ignores a system row at the tail', () => {
+    const ctx = buildGenerationContext({
+      ...base(),
+      entries: [
+        { ...entry('e1', 1, 'one'), metadata: sceneMetadata(LOC_A) },
+        { ...entry('sys', 2, 'ERROR', 'system'), metadata: sceneMetadata(LOC_B) },
+      ] as never[],
+    })
+    expect(ctx.currentLocationId).toBe('l1')
   })
 })

--- a/lib/pipeline/definitions/generation-context.ts
+++ b/lib/pipeline/definitions/generation-context.ts
@@ -2,6 +2,14 @@ import { describeCalendarVocabulary, getCalendar } from '@/lib/calendar'
 import type { Entity, StoryDefinition, StorySettings, StoryEntry } from '@/lib/db'
 import { substituteIds, type IdBiMap } from '@/lib/ids'
 import { buildSuggestionSlots } from '@/lib/piggyback'
+import {
+  composePromptBuffer,
+  type Candidate,
+  type EntityRow,
+  type LoreRow,
+  type RetrievalSuccess,
+  type ThreadRow,
+} from '@/lib/retrieval'
 
 type BuildArgs = {
   // Scopes both collections below. Callers already read per-branch, but no
@@ -10,8 +18,10 @@ type BuildArgs = {
   branchId: string
   // The branch's loaded entries, ascending by position. Every consumer draws
   // from that one set and differs only in how much of it it passes, so this is
-  // a truncation seam, not a per-kind query. Recency windowing is template-side
-  // via the `recent` filter, not done here.
+  // a truncation seam, not a per-kind query. What reaches a template is
+  // composePromptBuffer's window over this list, so a caller handing over a
+  // deliberate short tail can still have it cut — or emptied — by the story's
+  // own buffer knobs, which the caller does not control.
   entries: readonly StoryEntry[]
   entities: readonly Entity[]
   definition: StoryDefinition
@@ -33,7 +43,19 @@ type BuildArgs = {
   // (reader-composer.md → Next-turn suggestions). Only the suggestion-refresh
   // phase has it; blank everywhere else.
   refreshGuidance?: string
+  // This turn's successful retrieval pass. Absent for the two folds that never
+  // retrieve — the piggyback fallback classifier and suggestion-refresh — which
+  // then render every bucket empty.
+  retrieval?: RetrievalSuccess
 }
+
+/** A ranked bundle row as a template sees it. */
+export type RetrievedRow = { id: string; displayName: string; renderedText: string }
+
+/** A structural-floor row as a template sees it, per source type. */
+export type FloorEntity = Pick<EntityRow, 'id' | 'kind' | 'status' | 'name' | 'description'>
+export type FloorLore = Pick<LoreRow, 'id' | 'title' | 'body'>
+export type FloorThread = Pick<ThreadRow, 'id' | 'status' | 'title' | 'description'>
 
 // Defense-in-depth: emit '' for whitespace-only definitional prose so a header
 // stays guarded regardless of the template's blank-check idiom. The bundled
@@ -70,6 +92,43 @@ function promptEntity(entity: Entity): Record<string, unknown> {
   }
 }
 
+// Only the fields a prompt renders: `renderedText` is the exact string the
+// ranker measured the type budget against, and the Float32Array vector beside
+// it would be walked into a numeric-keyed object by substituteIds.
+function promptRows(selected: readonly Candidate[] | undefined): RetrievedRow[] {
+  return (selected ?? []).map((c) => ({
+    id: c.id,
+    displayName: c.displayName,
+    renderedText: c.renderedText,
+  }))
+}
+
+// Projected for the same reason as promptRows, plus one the types hide: the
+// floor is built over loaded source rows, so every row below still carries
+// `embeddingStale` (and lore's `keywords`) at runtime even though StructuralFloor
+// declares the narrower shape. Only this projection actually drops them.
+const floorEntity = (e: EntityRow): FloorEntity => ({
+  id: e.id,
+  kind: e.kind,
+  status: e.status,
+  name: e.name,
+  description: e.description,
+})
+
+const floorEntities = (rows: readonly EntityRow[] | undefined): FloorEntity[] =>
+  (rows ?? []).map(floorEntity)
+
+const floorLore = (rows: readonly LoreRow[] | undefined): FloorLore[] =>
+  (rows ?? []).map((l) => ({ id: l.id, title: l.title, body: l.body }))
+
+const floorThreads = (rows: readonly ThreadRow[] | undefined): FloorThread[] =>
+  (rows ?? []).map((t) => ({
+    id: t.id,
+    status: t.status,
+    title: t.title,
+    description: t.description,
+  }))
+
 // The one context builder for the `generationContext` group: every story
 // agent's phase calls this and its template picks from the same variable set
 // (pinned in templateContextMap; parity-tested here).
@@ -84,11 +143,14 @@ export function buildGenerationContext(args: BuildArgs): Record<string, unknown>
     piggybackFires = false,
     suggestionsFire = false,
     refreshGuidance = '',
+    retrieval,
   } = args
 
   // Both exclusions are unconditional defense-in-depth: system entries are
   // technical-only rows (removed on generate) that templates must never see,
   // and a foreign-branch row would describe a story this prompt isn't telling.
+  // Not redundant with composePromptBuffer's own system filter — the scene and
+  // location tail reads below depend on this one.
   const narrative = entries.filter((e) => e.kind !== 'system' && e.branchId === branchId)
   const branchEntities = entities.filter((e) => e.branchId === branchId)
 
@@ -107,15 +169,52 @@ export function buildGenerationContext(args: BuildArgs): Record<string, unknown>
   // false — asking is that call's whole premise, not a per-run condition.
   const suggestionSlots = buildSuggestionSlots(settings.suggestionCategories).slots
 
+  const tail = narrative.at(-1)
+  const floor = retrieval?.floor
+
+  // Every place the prompt brackets an id for, in the order the blocks render.
+  // A template that instead named "the ids above" would point <current_location>
+  // at a set that can be all characters: ranked rows reach a template as
+  // RetrievedRow, which carries no EntityKind, so their kinds come off the
+  // retrieval outcome, which still held the source row.
+  const locationIds = [
+    ...(floor?.sceneEntities ?? []).filter((e) => e.kind === 'location').map((e) => e.id),
+    ...(floor?.currentLocation?.kind === 'location' ? [floor.currentLocation.id] : []),
+    ...(floor?.alwaysEntities ?? []).filter((e) => e.kind === 'location').map((e) => e.id),
+    ...(retrieval?.selectedLocationIds ?? []),
+  ]
+
   const context = {
-    entries: narrative.map((e) => ({ content: e.content })),
+    // cadence.md → Composition rule: the two-mode window plus its
+    // protectedBuffer spillover is not expressible as a template `| recent: N`.
+    entries: composePromptBuffer(narrative, settings).map((e) => ({ content: e.content })),
     entities: branchEntities.map(promptEntity),
-    // Writers inherit scene membership forward (submit-turn, per-turn), so the
-    // non-system tail always carries the current scene state.
-    sceneEntities: narrative.at(-1)?.metadata?.sceneEntities ?? [],
+    // Writers inherit scene state forward (submit-turn, per-turn), so the
+    // non-system tail always carries the current scene and location.
+    sceneEntities: tail?.metadata?.sceneEntities ?? [],
+    currentLocationId: tail?.metadata?.currentLocationId ?? null,
     definition: normalizedDefinition,
     calendarVocabulary: calendar ? describeCalendarVocabulary(calendar) : null,
-    userSettings: { partialChapterBuffer: settings.partialChapterBuffer },
+    userSettings: {
+      fullChapterInBuffer: settings.fullChapterInBuffer,
+      partialChapterBuffer: settings.partialChapterBuffer,
+      protectedBuffer: settings.protectedBuffer,
+    },
+    retrievedEntities: promptRows(retrieval?.bundles.entities.selected),
+    retrievedLore: promptRows(retrieval?.bundles.lore.selected),
+    retrievedHappenings: promptRows(retrieval?.bundles.happenings.selected),
+    retrievedThreads: promptRows(retrieval?.bundles.threads.selected),
+    retrievedChapters: promptRows(retrieval?.bundles.chapters.selected),
+    structuralSceneEntities: floorEntities(floor?.sceneEntities),
+    structuralLocation: floor?.currentLocation ? floorEntity(floor.currentLocation) : null,
+    structuralActiveThreads: floorThreads(floor?.activeThreads),
+    // Kept per type rather than concatenated: no field tags a row with its own
+    // type, and an entity's `name` against lore's and threads' `title` leaves
+    // one loop nothing uniform to render.
+    structuralPinnedEntities: floorEntities(floor?.alwaysEntities),
+    structuralPinnedLore: floorLore(floor?.alwaysLore),
+    structuralPinnedThreads: floorThreads(floor?.alwaysThreads),
+    locationIds: [...new Set(locationIds)],
     intermediates: {},
     piggybackFires,
     // Re-gated on the derived slots, not just the caller's flag: a caller

--- a/lib/pipeline/definitions/per-turn-piggyback.test.ts
+++ b/lib/pipeline/definitions/per-turn-piggyback.test.ts
@@ -128,6 +128,7 @@ describe('per-turn-piggyback', () => {
         intermediates: { idMap: new IdBiMap() },
         log: makeLogger('act_1'),
         db: {} as never,
+        runInTransaction: async () => undefined,
         storyId: 's1',
         branchId: 'b1',
       }
@@ -139,9 +140,85 @@ describe('per-turn-piggyback', () => {
         done: true,
         value: {
           status: 'failed',
-          error: { kind: 'orchestrator', detail: 'piggyback-fallback: no open story' },
+          error: { kind: 'orchestrator', detail: 'piggyback-fallback: no open story for branch' },
         },
       })
+    })
+
+    // Same working-set guards the retrieval and narrative folds carry: this
+    // phase writes scene state back onto the tail entry, so a store hydrated
+    // for another branch would classify one branch's prose against another's
+    // cast and land the patch on the wrong row.
+    it.each([
+      {
+        case: 'the open story is another branch',
+        open: { storyId: 's1', branchId: 'b2' },
+        loaded: 'b1',
+        detail: 'piggyback-fallback: no open story for branch',
+      },
+      {
+        case: 'the open story is another story',
+        open: { storyId: 's2', branchId: 'b1' },
+        loaded: 'b1',
+        detail: 'piggyback-fallback: no open story for branch',
+      },
+      {
+        case: 'the entries store holds another branch',
+        open: { storyId: 's1', branchId: 'b1' },
+        loaded: 'b2',
+        detail: 'piggyback-fallback: entries store loaded for another branch',
+      },
+    ])('refuses a desynced store when $case', async ({ open, loaded, detail }) => {
+      currentStoryStore.set({
+        ...open,
+        definition,
+        settings: baseSettings({ piggybackMode: 'off' }),
+      })
+      entriesStore.hydrate(loaded, [])
+
+      const gen = piggybackFallbackClassifierPhase({
+        actionId: 'act_1',
+        abortSignal: new AbortController().signal,
+        intermediates: { idMap: new IdBiMap() },
+        log: makeLogger('act_1'),
+        db: {} as never,
+        runInTransaction: async () => undefined,
+        storyId: 's1',
+        branchId: 'b1',
+      })
+      const res = await gen.next()
+
+      expect(res).toEqual({
+        done: true,
+        value: { status: 'failed', error: { kind: 'orchestrator', detail } },
+      })
+      expect(generateStructuredMock).not.toHaveBeenCalled()
+    })
+
+    // Positive control for the three refusals above: the same setup with every
+    // identity agreeing runs the phase instead of failing it.
+    it('runs when the open story and the entries store both match the run', async () => {
+      currentStoryStore.set({
+        storyId: 's1',
+        branchId: 'b1',
+        definition,
+        settings: baseSettings({ piggybackMode: 'off' }),
+      })
+      entriesStore.hydrate('b1', [])
+
+      const gen = piggybackFallbackClassifierPhase({
+        actionId: 'act_1',
+        abortSignal: new AbortController().signal,
+        intermediates: { idMap: new IdBiMap() },
+        log: makeLogger('act_1'),
+        db: {} as never,
+        runInTransaction: async () => undefined,
+        storyId: 's1',
+        branchId: 'b1',
+      })
+      const res = await gen.next()
+
+      expect(res).toEqual({ done: true, value: { status: 'completed' } })
     })
 
     it('completes early without calling generateStructured if fallback should not fire', async () => {
@@ -160,6 +237,7 @@ describe('per-turn-piggyback', () => {
         },
         log: makeLogger('act_1'),
         db: {} as never,
+        runInTransaction: async () => undefined,
         storyId: 's1',
         branchId: 'b1',
       }
@@ -186,6 +264,7 @@ describe('per-turn-piggyback', () => {
         intermediates: { idMap: new IdBiMap() },
         log: makeLogger('act_1'),
         db: {} as never,
+        runInTransaction: async () => undefined,
         storyId: 's1',
         branchId: 'b1',
       }
@@ -222,6 +301,7 @@ describe('per-turn-piggyback', () => {
         intermediates: { idMap: new IdBiMap() },
         log: makeLogger('act_1'),
         db: {} as never,
+        runInTransaction: async () => undefined,
         storyId: 's1',
         branchId: 'b1',
       }
@@ -281,6 +361,7 @@ describe('per-turn-piggyback', () => {
         intermediates: { idMap: new IdBiMap() },
         log: makeLogger('act_1'),
         db: {} as never,
+        runInTransaction: async () => undefined,
         storyId: 's1',
         branchId: 'b1',
       }
@@ -365,6 +446,7 @@ describe('per-turn-piggyback', () => {
         intermediates: { idMap: new IdBiMap() },
         log: makeLogger('act_1'),
         db: {} as never,
+        runInTransaction: async () => undefined,
         storyId: 's1',
         branchId: 'b1',
       }
@@ -446,6 +528,7 @@ describe('per-turn-piggyback', () => {
         intermediates: { idMap: new IdBiMap() },
         log: makeLogger('act_1'),
         db: {} as never,
+        runInTransaction: async () => undefined,
         storyId: 's1',
         branchId: 'b1',
       }
@@ -511,6 +594,7 @@ describe('per-turn-piggyback', () => {
         intermediates: { idMap: new IdBiMap() },
         log: makeLogger('act_1'),
         db: {} as never,
+        runInTransaction: async () => undefined,
         storyId: 's1',
         branchId: 'b1',
       }
@@ -576,6 +660,7 @@ describe('per-turn-piggyback', () => {
         intermediates: { idMap: new IdBiMap() },
         log: makeLogger('act_1'),
         db: {} as never,
+        runInTransaction: async () => undefined,
         storyId: 's1',
         branchId: 'b1',
       }
@@ -651,6 +736,7 @@ describe('per-turn-piggyback', () => {
         intermediates: { idMap: new IdBiMap() },
         log: makeLogger('act_1'),
         db: {} as never,
+        runInTransaction: async () => undefined,
         storyId: 's1',
         branchId: 'b1',
       }
@@ -729,6 +815,7 @@ describe('per-turn-piggyback', () => {
         },
         log: makeLogger('act_1'),
         db: {} as never,
+        runInTransaction: async () => undefined,
         storyId: 's1',
         branchId: 'b1',
       }
@@ -812,6 +899,7 @@ describe('per-turn-piggyback', () => {
         },
         log: makeLogger('act_1'),
         db: {} as never,
+        runInTransaction: async () => undefined,
         storyId: 's1',
         branchId: 'b1',
       }
@@ -865,6 +953,7 @@ describe('per-turn-piggyback', () => {
         },
         log: makeLogger('act_1'),
         db: {} as never,
+        runInTransaction: async () => undefined,
         storyId: 's1',
         branchId: 'b1',
       }
@@ -906,6 +995,7 @@ describe('per-turn-piggyback', () => {
         intermediates: { idMap: new IdBiMap() },
         log: makeLogger('act_1'),
         db: {} as never,
+        runInTransaction: async () => undefined,
         storyId: 's1',
         branchId: 'b1',
       }
@@ -978,6 +1068,7 @@ describe('per-turn-piggyback', () => {
         intermediates: { idMap: new IdBiMap() },
         log: makeLogger('act_1'),
         db: {} as never,
+        runInTransaction: async () => undefined,
         storyId: 's1',
         branchId: 'b1',
       }
@@ -1032,6 +1123,7 @@ describe('per-turn-piggyback', () => {
         intermediates: { idMap: new IdBiMap() },
         log: makeLogger('act_1'),
         db: {} as never,
+        runInTransaction: async () => undefined,
         storyId: 's1',
         branchId: 'b1',
       }
@@ -1093,6 +1185,7 @@ describe('per-turn-piggyback', () => {
         intermediates: { idMap: new IdBiMap() },
         log: makeLogger('act_1'),
         db: {} as never,
+        runInTransaction: async () => undefined,
         storyId: 's1',
         branchId: 'b1',
       }
@@ -1157,6 +1250,7 @@ describe('per-turn-piggyback', () => {
         intermediates: { idMap: new IdBiMap() },
         log: logger,
         db: {} as never,
+        runInTransaction: async () => undefined,
         storyId: 's1',
         branchId: 'b1',
       }
@@ -1209,6 +1303,7 @@ describe('per-turn-piggyback', () => {
         intermediates: { idMap: new IdBiMap() },
         log: logger,
         db: {} as never,
+        runInTransaction: async () => undefined,
         storyId: 's1',
         branchId: 'b1',
       }
@@ -1252,6 +1347,7 @@ describe('per-turn-piggyback', () => {
         intermediates: { idMap: new IdBiMap() },
         log: logger,
         db: {} as never,
+        runInTransaction: async () => undefined,
         storyId: 's1',
         branchId: 'b1',
       }

--- a/lib/pipeline/definitions/per-turn-piggyback.ts
+++ b/lib/pipeline/definitions/per-turn-piggyback.ts
@@ -20,9 +20,10 @@ import type {
   ResolverInput,
 } from '@/lib/pipeline/types'
 import { renderTemplate, TEMPLATE_IDS } from '@/lib/prompts'
-import { appSettingsStore, currentStoryStore, entitiesStore, entriesStore } from '@/lib/stores'
+import { appSettingsStore } from '@/lib/stores'
 
 import { buildGenerationContext } from './generation-context'
+import { loadPerTurnWorkingSet } from './working-set'
 
 export const PIGGYBACK_FALLBACK_PHASE_NAME = 'piggyback-fallback-classifier'
 
@@ -120,26 +121,19 @@ async function generateClassifierState<T extends { worldTimeDelta: number }>(
 export async function* piggybackFallbackClassifierPhase(
   ctx: PhaseContext,
 ): AsyncGenerator<PhaseEmittedEvent, PhaseResult> {
-  const open = currentStoryStore.getCurrentStory()
-  if (!open)
-    return {
-      status: 'failed',
-      error: { kind: 'orchestrator', detail: 'piggyback-fallback: no open story' },
-    }
-
+  // Ahead of the working set on purpose: a run whose narrative fold already
+  // produced the block does nothing here, so there is no store state for it to
+  // be out of sync with.
   const outcome = ctx.intermediates.piggybackOutcome as PiggybackOutcome | undefined
   if (!shouldFallbackFire(outcome)) return { status: 'completed' }
 
-  const entries = [...entriesStore.getEntries().values()]
-    .filter((e) => e.branchId === ctx.branchId)
-    .sort((a, b) => a.position - b.position)
+  const working = loadPerTurnWorkingSet(ctx, 'piggyback-fallback')
+  if (!working.ok) return working.result
+  const { open, entries, entities } = working.set
+
   const tail = entries.at(-1)
   if (!tail) return { status: 'completed' }
   const previousEntry = entries.at(-2)
-
-  const entities = [...entitiesStore.getEntities().values()].filter(
-    (e) => e.branchId === ctx.branchId,
-  )
 
   const suggestionEmission = resolveSuggestionEmission(open.settings)
   // Only ask when chips aren't already in hand: a <state>-failed /

--- a/lib/pipeline/definitions/per-turn-retrieval.test.ts
+++ b/lib/pipeline/definitions/per-turn-retrieval.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   STORY_SETTINGS_DEFAULTS,
@@ -265,6 +265,13 @@ beforeEach(() => {
   runRetrievalMock.mockReset().mockResolvedValue(OK_OUTCOME)
   refreshEmbeddingStatusMock.mockReset().mockResolvedValue(undefined)
   resetAllStores()
+})
+
+// A hook, not an inline call after the awaited phase: a mock that throws rejects
+// that await, and fake timers left installed turn one failure into a cascade of
+// unrelated ones. No-op when the test never installed them.
+afterEach(() => {
+  vi.useRealTimers()
 })
 
 describe('per-turn phase order (C6)', () => {
@@ -576,7 +583,6 @@ describe('retrieval phase — abort', () => {
     })
 
     const { result } = await runRetrievalPhase()
-    vi.useRealTimers()
 
     expect(result).toMatchObject({
       status: 'failed',

--- a/lib/pipeline/definitions/per-turn-retrieval.test.ts
+++ b/lib/pipeline/definitions/per-turn-retrieval.test.ts
@@ -30,11 +30,19 @@ import { RETRIEVAL_INTERMEDIATE_KEY, RETRIEVAL_PHASE_NAME } from './per-turn-ret
 import { getPipeline } from '../authoring/registry'
 import type { PhaseEmittedEvent, PhaseResult } from '../types'
 
-const { runRetrievalMock } = vi.hoisted(() => ({ runRetrievalMock: vi.fn() }))
+const { runRetrievalMock, refreshEmbeddingStatusMock } = vi.hoisted(() => ({
+  runRetrievalMock: vi.fn(),
+  refreshEmbeddingStatusMock: vi.fn(),
+}))
 
 vi.mock('@/lib/retrieval', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>()
   return { ...actual, runRetrieval: runRetrievalMock }
+})
+
+vi.mock('@/lib/actions', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, refreshEmbeddingStatus: refreshEmbeddingStatusMock }
 })
 
 const definition = {
@@ -255,6 +263,7 @@ function lastParams(): RetrievalParams {
 beforeEach(() => {
   vi.restoreAllMocks()
   runRetrievalMock.mockReset().mockResolvedValue(OK_OUTCOME)
+  refreshEmbeddingStatusMock.mockReset().mockResolvedValue(undefined)
   resetAllStores()
 })
 
@@ -622,6 +631,24 @@ describe('retrieval phase — abort', () => {
       expect.objectContaining({ onRowsSynced: expect.any(Function) }),
       expect.anything(),
     )
+  })
+
+  // The hook runs after the sync stage has committed, so a rejected recount must
+  // not fail a turn that can still complete — and must not vanish either.
+  it('survives a post-sync recount that rejects, warning instead of failing', async () => {
+    seedOpenStory()
+    refreshEmbeddingStatusMock.mockRejectedValue(new Error('recount hit a locked db'))
+    runRetrievalMock.mockImplementation(async (deps: { onRowsSynced?: () => Promise<void> }) => {
+      await deps.onRowsSynced?.()
+      return OK_OUTCOME
+    })
+
+    const { result, log } = await runRetrievalPhase()
+
+    expect(result).toEqual({ status: 'completed' })
+    expect(log.warn).toHaveBeenCalledWith('retrieval.status_refresh_failed', {
+      detail: 'recount hit a locked db',
+    })
   })
 })
 

--- a/lib/pipeline/definitions/per-turn-retrieval.test.ts
+++ b/lib/pipeline/definitions/per-turn-retrieval.test.ts
@@ -1,0 +1,955 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  STORY_SETTINGS_DEFAULTS,
+  type Entity,
+  type EntryMetadata,
+  type Story,
+  type StoryEntry,
+  type StorySettings,
+} from '@/lib/db'
+import type { Logger } from '@/lib/diagnostics'
+import type {
+  InjectedAwareness,
+  RankedType,
+  RetrievalParams,
+  RetrievalSuccess,
+  RetrievalTimings,
+  RetrievalType,
+} from '@/lib/retrieval'
+import {
+  currentStoryStore,
+  entitiesStore,
+  entriesStore,
+  resetAllStores,
+  storiesStore,
+} from '@/lib/stores'
+
+import { ensurePerTurnPipelineRegistered, PER_TURN_KIND } from './per-turn'
+import { RETRIEVAL_INTERMEDIATE_KEY, RETRIEVAL_PHASE_NAME } from './per-turn-retrieval'
+import { getPipeline } from '../authoring/registry'
+import type { PhaseEmittedEvent, PhaseResult } from '../types'
+
+const { runRetrievalMock } = vi.hoisted(() => ({ runRetrievalMock: vi.fn() }))
+
+vi.mock('@/lib/retrieval', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, runRetrieval: runRetrievalMock }
+})
+
+const definition = {
+  mode: 'adventure' as const,
+  leadEntityId: 'char_hero',
+  narration: 'first' as const,
+  genre: { label: 'Fantasy', promptBody: 'High fantasy.' },
+  tone: { label: 'Wry', promptBody: 'Dry humor.' },
+  setting: 'A keep on a hill.',
+  calendarSystemId: 'gregorian',
+  worldTimeOrigin: { year: 0 },
+}
+
+const EMPTY_BUNDLE: RankedType = {
+  selected: [],
+  traces: [],
+  funnel: {
+    poolSize: 0,
+    preFilteredSize: 0,
+    selectedCount: 0,
+    tokensUsed: 0,
+    typeBudget: 0,
+  },
+}
+
+function okOutcome({
+  staleCounts = { entities: 0, lore: 0, happenings: 0, threads: 0, chapters: 0 },
+  injectedAwareness = [{ id: 'haw_1', retrievalCount: 0 }],
+  timings = { totalMs: 12, syncMs: 3, embedMs: 4, knnMs: 2, rankMs: 1 },
+  bundleOverrides = {},
+}: {
+  staleCounts?: Record<RetrievalType, number>
+  injectedAwareness?: InjectedAwareness[]
+  timings?: RetrievalTimings
+  bundleOverrides?: Partial<Record<RetrievalType, RankedType>>
+} = {}): RetrievalSuccess {
+  return {
+    ok: true,
+    floor: {
+      sceneEntities: [],
+      currentLocation: null,
+      activeThreads: [],
+      alwaysEntities: [],
+      alwaysLore: [],
+      alwaysThreads: [],
+      seatedIds: new Set<string>(),
+    },
+    bundles: {
+      entities: EMPTY_BUNDLE,
+      lore: EMPTY_BUNDLE,
+      happenings: EMPTY_BUNDLE,
+      threads: EMPTY_BUNDLE,
+      chapters: EMPTY_BUNDLE,
+      ...bundleOverrides,
+    },
+    queries: {
+      q1: { text: '', source: 'user_action' },
+      q2: { text: '', source: 'structural_digest' },
+      q3: { text: '', source: 'prose_extract' },
+      presence: [false, false, false],
+      embedTexts: [],
+    },
+    staleCounts,
+    injectedAwareness,
+    selectedLocationIds: [],
+    timings,
+  }
+}
+
+function bumpEvent(id: string, priorCount = 0): PhaseEmittedEvent {
+  return {
+    type: 'delta_emitted',
+    action: {
+      kind: 'bumpAwarenessRetrieval',
+      source: 'ai_classifier',
+      payload: { branchId: 'b1', id, priorCount },
+    },
+  }
+}
+
+const OK_OUTCOME = okOutcome()
+
+function storyRow(settings: StorySettings, id = 's1'): Story {
+  return {
+    id,
+    title: 'A story',
+    description: null,
+    tags: [],
+    coverAssetId: null,
+    accentColor: null,
+    status: 'active',
+    favorite: 0,
+    lastOpenedAt: null,
+    definition,
+    settings,
+    createdAt: 1,
+    updatedAt: 1,
+    currentBranchId: 'b1',
+  }
+}
+
+function entry(
+  position: number,
+  kind: StoryEntry['kind'],
+  content: string,
+  metadata: EntryMetadata | null = null,
+): StoryEntry {
+  return {
+    id: `entry_${position}`,
+    branchId: 'b1',
+    position,
+    kind,
+    content,
+    chapterId: null,
+    metadata,
+    createdAt: position,
+  }
+}
+
+function meta(overrides: Partial<EntryMetadata> = {}): EntryMetadata {
+  return { sceneEntities: [], currentLocationId: null, worldTime: 0, ...overrides }
+}
+
+function entity(id: string, kind: Entity['kind'], name: string): Entity {
+  return {
+    id,
+    branchId: 'b1',
+    kind,
+    name,
+    description: null,
+    status: 'active',
+    retiredReason: null,
+    injectionMode: 'auto',
+    nameCollisionFlag: 0,
+    state: null,
+    tags: [],
+    embeddingStale: 0,
+    createdAt: 1,
+    updatedAt: 1,
+  }
+}
+
+function seedOpenStory(
+  opts: {
+    settings?: Partial<StorySettings>
+    entries?: StoryEntry[]
+    entities?: Entity[]
+    entriesBranch?: string
+    storyId?: string
+  } = {},
+): StorySettings {
+  const settings: StorySettings = { ...STORY_SETTINGS_DEFAULTS, ...opts.settings }
+  currentStoryStore.set({
+    storyId: opts.storyId ?? 's1',
+    branchId: 'b1',
+    definition,
+    settings,
+  })
+  entriesStore.hydrate(opts.entriesBranch ?? 'b1', opts.entries ?? [])
+  entitiesStore.hydrate('b1', opts.entities ?? [])
+  vi.spyOn(storiesStore, 'getStories').mockReturnValue({
+    rows: [storyRow(settings, opts.storyId ?? 's1')],
+    openFailures: {},
+  })
+  return settings
+}
+
+function openOnBranch(branchId: string): void {
+  const open = currentStoryStore.getCurrentStory()
+  if (!open) throw new Error('seedOpenStory must run first')
+  currentStoryStore.set({ ...open, branchId })
+}
+
+async function runRetrievalPhase(abortSignal = new AbortController().signal): Promise<{
+  result: PhaseResult
+  events: PhaseEmittedEvent[]
+  intermediates: Record<string, unknown>
+  log: { [K in keyof Logger]: ReturnType<typeof vi.fn> }
+}> {
+  ensurePerTurnPipelineRegistered()
+  const node = getPipeline(PER_TURN_KIND).phases.find((n) => n.name === RETRIEVAL_PHASE_NAME)
+  if (!node || !('run' in node)) throw new Error('expected a single-run retrieval phase node')
+  const intermediates: Record<string, unknown> = {}
+  // A fake logger rather than makeLogger: the real one drops everything when the
+  // diagnostics gate is off, which is the default in unit tests.
+  const log = { error: vi.fn(), warn: vi.fn(), debug: vi.fn() }
+  const gen = node.run({
+    actionId: 'act_1',
+    abortSignal,
+    intermediates,
+    log,
+    db: {} as never,
+    runInTransaction: async () => undefined,
+    storyId: 's1',
+    branchId: 'b1',
+  })
+  const events: PhaseEmittedEvent[] = []
+  let next = await gen.next()
+  while (!next.done) {
+    events.push(next.value)
+    next = await gen.next()
+  }
+  return { result: next.value, events, intermediates, log }
+}
+
+function abortedSignal(): AbortSignal {
+  const controller = new AbortController()
+  controller.abort()
+  return controller.signal
+}
+
+function lastParams(): RetrievalParams {
+  const call = runRetrievalMock.mock.calls.at(-1)
+  if (!call) throw new Error('runRetrieval was never called')
+  return call[1] as RetrievalParams
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  runRetrievalMock.mockReset().mockResolvedValue(OK_OUTCOME)
+  resetAllStores()
+})
+
+describe('per-turn phase order (C6)', () => {
+  it('inserts retrieval before narrative and after user-action-translation', () => {
+    ensurePerTurnPipelineRegistered()
+    const names = getPipeline(PER_TURN_KIND).phases.map((p) => p.name)
+    expect(names).toContain(RETRIEVAL_PHASE_NAME)
+    expect(names.indexOf(RETRIEVAL_PHASE_NAME)).toBeGreaterThan(
+      names.indexOf('user-action-translation'),
+    )
+    expect(names.indexOf(RETRIEVAL_PHASE_NAME)).toBeLessThan(names.indexOf('narrative'))
+  })
+
+  it('leaves the piggyback fallback classifier after narrative', () => {
+    ensurePerTurnPipelineRegistered()
+    const names = getPipeline(PER_TURN_KIND).phases.map((p) => p.name)
+    expect(names.indexOf('narrative')).toBeLessThan(names.indexOf('piggyback-fallback-classifier'))
+  })
+
+  it('declares no resolver inputs — retrieval makes no LLM call', () => {
+    ensurePerTurnPipelineRegistered()
+    const phases = getPipeline(PER_TURN_KIND).phases
+    const retrieval = phases.find((p) => p.name === RETRIEVAL_PHASE_NAME)
+    const narrative = phases.find((p) => p.name === 'narrative')
+    expect(retrieval && 'resolves' in retrieval ? retrieval.resolves : undefined).toBeUndefined()
+    // Positive control: `resolves` is a real, populated field on the phases that
+    // DO make a call, so the assertion above discriminates rather than reading
+    // a key the node shape never carries.
+    expect(narrative && 'resolves' in narrative ? narrative.resolves : undefined).toEqual([
+      { target: 'narrative' },
+    ])
+  })
+})
+
+describe('retrieval phase — store-desync guards', () => {
+  it('fails when no story is open for the run branch', async () => {
+    seedOpenStory({ storyId: 's2' })
+
+    const { result } = await runRetrievalPhase()
+
+    expect(result).toEqual({
+      status: 'failed',
+      error: { kind: 'orchestrator', detail: 'retrieval: no open story for branch' },
+    })
+    expect(runRetrievalMock).not.toHaveBeenCalled()
+  })
+
+  // Distinct from the story mismatch above: the open story is the right STORY on
+  // the wrong BRANCH, and every other store here is loaded for the run's branch,
+  // so only the branch arm of the guard can catch it.
+  it('fails when the open story sits on another branch of the same story', async () => {
+    seedOpenStory()
+    openOnBranch('b-other')
+
+    const { result } = await runRetrievalPhase()
+
+    expect(result).toEqual({
+      status: 'failed',
+      error: { kind: 'orchestrator', detail: 'retrieval: no open story for branch' },
+    })
+    expect(runRetrievalMock).not.toHaveBeenCalled()
+  })
+
+  it('fails when the entries store is loaded for another branch', async () => {
+    seedOpenStory({ entriesBranch: 'b-other' })
+
+    const { result } = await runRetrievalPhase()
+
+    expect(result).toEqual({
+      status: 'failed',
+      error: {
+        kind: 'orchestrator',
+        detail: 'retrieval: entries store loaded for another branch',
+      },
+    })
+    expect(runRetrievalMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('retrieval phase — embedder config', () => {
+  it('fails blocking when the embedder config does not resolve', async () => {
+    seedOpenStory({ settings: { embeddingBackend: 'provider', embedding_provider_id: undefined } })
+
+    const { result } = await runRetrievalPhase()
+
+    expect(result).toEqual({
+      status: 'failed',
+      error: {
+        kind: 'embedder',
+        reason: 'init',
+        detail: 'embedder not configured: no-provider',
+        // Nothing counted anything — this failed before the dirty set was read.
+        staleCount: null,
+      },
+    })
+    expect(runRetrievalMock).not.toHaveBeenCalled()
+  })
+
+  it('fails blocking when the config resolves but its read dim is still unknown', async () => {
+    seedOpenStory({
+      settings: {
+        embeddingBackend: 'provider',
+        embedding_provider_id: 'prov-1',
+        embedding_model_id: 'text-embedding-3-small',
+      },
+    })
+
+    const { result } = await runRetrievalPhase()
+
+    // toEqual, not toMatchObject: only `detail` separates this from the
+    // config-resolution failure above, so dropping it would let a config
+    // resolver that rejects the unknown provider id pass as this guard.
+    expect(result).toEqual({
+      status: 'failed',
+      error: {
+        kind: 'embedder',
+        reason: 'init',
+        detail: 'embedder dim unknown for model text-embedding-3-small',
+        staleCount: null,
+      },
+    })
+    expect(runRetrievalMock).not.toHaveBeenCalled()
+  })
+
+  it('runs the pass on a resolvable local config', async () => {
+    seedOpenStory()
+
+    const { result } = await runRetrievalPhase()
+
+    expect(result).toEqual({ status: 'completed' })
+    expect(runRetrievalMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('retrieval phase — blocking failure mapping', () => {
+  it('maps an init failure with a stale-row magnitude field by field', async () => {
+    seedOpenStory()
+    runRetrievalMock.mockResolvedValue({
+      ok: false,
+      failure: { reason: 'init', detail: 'no embedder integration', staleCount: 7 },
+    })
+
+    const { result } = await runRetrievalPhase()
+
+    expect(result).toEqual({
+      status: 'failed',
+      error: {
+        kind: 'embedder',
+        reason: 'init',
+        detail: 'no embedder integration',
+        staleCount: 7,
+      },
+    })
+  })
+
+  // Second arm so no field can be hardcoded: reason, detail and staleCount all
+  // differ from the case above.
+  it('maps a call failure whose magnitude is unknown', async () => {
+    seedOpenStory()
+    runRetrievalMock.mockResolvedValue({
+      ok: false,
+      failure: { reason: 'call', detail: 'query embed served dim 512', staleCount: null },
+    })
+
+    const { result } = await runRetrievalPhase()
+
+    expect(result).toEqual({
+      status: 'failed',
+      error: {
+        kind: 'embedder',
+        reason: 'call',
+        detail: 'query embed served dim 512',
+        staleCount: null,
+      },
+    })
+  })
+
+  it('stashes nothing on the intermediates when the pass fails', async () => {
+    seedOpenStory()
+    runRetrievalMock.mockResolvedValue({
+      ok: false,
+      failure: { reason: 'call', detail: 'boom', staleCount: null },
+    })
+
+    const { intermediates, events } = await runRetrievalPhase()
+
+    expect(intermediates).toEqual({})
+    // Failure returns, never emits: a `recoverable_error` event here would let
+    // the orchestrator keep the turn running past a blocking embed failure.
+    expect(events).toEqual([])
+  })
+})
+
+describe('retrieval phase — success', () => {
+  it('stashes the outcome for the narrative phase and bumps the injected awareness row', async () => {
+    seedOpenStory()
+
+    const { result, events, intermediates } = await runRetrievalPhase()
+
+    expect(result).toEqual({ status: 'completed' })
+    expect(intermediates[RETRIEVAL_INTERMEDIATE_KEY]).toBe(OK_OUTCOME)
+    expect(events).toEqual([bumpEvent('haw_1')])
+  })
+
+  it('bumps every injected awareness row, one delta each', async () => {
+    seedOpenStory()
+    runRetrievalMock.mockResolvedValue(
+      okOutcome({
+        injectedAwareness: [
+          { id: 'haw_1', retrievalCount: 0 },
+          { id: 'haw_2', retrievalCount: 3 },
+          { id: 'haw_3', retrievalCount: 0 },
+        ],
+      }),
+    )
+
+    const { events } = await runRetrievalPhase()
+
+    // haw_2's prior is 3, not 0: the handler no longer reads the row, so a phase
+    // that dropped the count would bump it from the wrong base.
+    expect(events).toEqual([bumpEvent('haw_1'), bumpEvent('haw_2', 3), bumpEvent('haw_3')])
+  })
+
+  // outcome.timings measures the pass and is computed before the bumps, so the
+  // dispatch cost was invisible to the one log AC7 added for per-turn cost. The
+  // orchestrator suspends this generator while it applies each delta, so the
+  // span covers the handler reads and transactions, not just the yields.
+  it('reports the bump dispatch span apart from the pass timing', async () => {
+    seedOpenStory()
+    runRetrievalMock.mockResolvedValue(
+      okOutcome({
+        injectedAwareness: [
+          { id: 'haw_1', retrievalCount: 0 },
+          { id: 'haw_2', retrievalCount: 3 },
+          { id: 'haw_3', retrievalCount: 0 },
+        ],
+      }),
+    )
+
+    const { log } = await runRetrievalPhase()
+
+    expect(log.debug).toHaveBeenCalledWith('retrieval.bump_dispatch', {
+      count: 3,
+      ms: expect.any(Number) as unknown as number,
+    })
+  })
+
+  // Not a degenerate shape: runRetrieval admits a common-knowledge happening
+  // with no in-scene awareness row, so a turn can select happenings and still
+  // report no ids to bump.
+  it('emits nothing when the pass injected no awareness rows', async () => {
+    seedOpenStory()
+    runRetrievalMock.mockResolvedValue(okOutcome({ injectedAwareness: [] }))
+
+    const { result, events, log } = await runRetrievalPhase()
+
+    expect(result).toEqual({ status: 'completed' })
+    expect(events).toEqual([])
+    // No bumps, no span — an empty measurement is noise in the log.
+    expect(log.debug).not.toHaveBeenCalledWith(
+      'retrieval.bump_dispatch',
+      expect.anything() as unknown as Record<string, unknown>,
+    )
+  })
+
+  it('hands the pass the full dep surface, not just the query embedder', async () => {
+    seedOpenStory()
+
+    await runRetrievalPhase()
+
+    const deps = runRetrievalMock.mock.calls.at(-1)?.[0] as Record<string, unknown>
+    // Key-set equality, not spot checks: the embed trio arrives as one spread,
+    // so dropping it leaves queryAll/runInTransaction in place and every
+    // params-shaped assertion in this file still green.
+    expect(Object.keys(deps).sort()).toEqual([
+      'abortSignal',
+      'embedRows',
+      'embedTexts',
+      'loadStaleRows',
+      'onRowsSynced',
+      'queryAll',
+      'runInTransaction',
+    ])
+    for (const key of ['embedRows', 'embedTexts', 'loadStaleRows', 'queryAll', 'runInTransaction'])
+      expect(typeof deps[key]).toBe('function')
+  })
+})
+
+describe('retrieval phase — abort', () => {
+  it('aborts before the pass when the turn was cancelled during the lazy import', async () => {
+    seedOpenStory()
+
+    const { result } = await runRetrievalPhase(abortedSignal())
+
+    expect(result).toEqual({ status: 'aborted' })
+    expect(runRetrievalMock).not.toHaveBeenCalled()
+  })
+
+  // An expiry aborts the pass the same way a cancel does, so reading the bounded
+  // signal after it would report every stalled provider as a user cancel: draft
+  // restored, no error, no Switch embedder, retrying into the same dead endpoint.
+  it('reports a timed-out embed as a blocking failure, not as a cancel', async () => {
+    seedOpenStory()
+    vi.useFakeTimers()
+    runRetrievalMock.mockImplementation(async (deps: { abortSignal?: AbortSignal }) => {
+      vi.advanceTimersByTime(300_000)
+      if (deps.abortSignal?.aborted !== true) throw new Error('expected the bounded signal to fire')
+      return { ok: false, failure: { reason: 'call', detail: 'aborted', staleCount: null } }
+    })
+
+    const { result } = await runRetrievalPhase()
+    vi.useRealTimers()
+
+    expect(result).toMatchObject({
+      status: 'failed',
+      error: { kind: 'embedder', reason: 'call', detail: 'embed timed out after 300000ms' },
+    })
+  })
+
+  it('aborts after a pass the cancel landed mid-way through, stashing nothing', async () => {
+    seedOpenStory()
+    const controller = new AbortController()
+    runRetrievalMock.mockImplementation(async () => {
+      controller.abort()
+      return OK_OUTCOME
+    })
+
+    const { result, events, intermediates } = await runRetrievalPhase(controller.signal)
+
+    // Distinct from the case above: the pass DID run, so only the poll after it
+    // can catch this.
+    expect(runRetrievalMock).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ status: 'aborted' })
+    expect(intermediates).toEqual({})
+    // The outcome reported haw_1 as injected; the bumps sit downstream of the
+    // poll so a cancelled turn leaves no counter for reverse-replay to walk back.
+    expect(events).toEqual([])
+  })
+
+  it('reports a cancelled turn as aborted even when the pass also failed', async () => {
+    seedOpenStory()
+    const controller = new AbortController()
+    runRetrievalMock.mockImplementation(async () => {
+      controller.abort()
+      return { ok: false, failure: { reason: 'call', detail: 'boom', staleCount: null } }
+    })
+
+    const { result, log } = await runRetrievalPhase(controller.signal)
+
+    // Same precedence as narrativePhase: a cancel outranks whatever the work it
+    // cancelled reported, so a stopped turn raises no failure banner.
+    expect(result).toEqual({ status: 'aborted' })
+    expect(log.warn).not.toHaveBeenCalled()
+  })
+
+  it('completes the same pass when nothing cancels it', async () => {
+    seedOpenStory()
+
+    const { result, intermediates } = await runRetrievalPhase()
+
+    expect(result).toEqual({ status: 'completed' })
+    expect(intermediates[RETRIEVAL_INTERMEDIATE_KEY]).toBe(OK_OUTCOME)
+    expect(runRetrievalMock).toHaveBeenCalledWith(
+      expect.objectContaining({ onRowsSynced: expect.any(Function) }),
+      expect.anything(),
+    )
+  })
+})
+
+describe('retrieval phase — diagnostics', () => {
+  it('warns with the failure magnitude when the pass fails', async () => {
+    seedOpenStory()
+    runRetrievalMock.mockResolvedValue({
+      ok: false,
+      failure: { reason: 'call', detail: 'embedder session died', staleCount: 4 },
+    })
+
+    const { log } = await runRetrievalPhase()
+
+    expect(log.warn).toHaveBeenCalledWith('retrieval.embed_failed', {
+      reason: 'call',
+      staleCount: 4,
+    })
+  })
+
+  it('trips on rows the blocking sync stage left stale', async () => {
+    seedOpenStory()
+    const counts = { entities: 0, lore: 3, happenings: 0, threads: 0, chapters: 0 }
+    runRetrievalMock.mockResolvedValue(okOutcome({ staleCounts: counts }))
+
+    const { result, log } = await runRetrievalPhase()
+
+    expect(log.warn).toHaveBeenCalledWith('retrieval.stale_after_sync', counts)
+    // A tripwire, not a gate: the turn still goes through.
+    expect(result).toEqual({ status: 'completed' })
+  })
+
+  it('stays quiet when every count is zero', async () => {
+    seedOpenStory()
+
+    const { log } = await runRetrievalPhase()
+
+    expect(log.warn).not.toHaveBeenCalled()
+  })
+
+  // A budget below its type's overhead drops every candidate as too large and
+  // seats nothing, which no prompt and no error surface ever shows. Canon wants
+  // it reported (retrieval.md → Budget-fill termination).
+  it('warns when a type ranked candidates and seated none of them', async () => {
+    seedOpenStory()
+    runRetrievalMock.mockResolvedValue(
+      okOutcome({
+        bundleOverrides: {
+          happenings: {
+            selected: [],
+            traces: [],
+            funnel: {
+              poolSize: 12,
+              preFilteredSize: 12,
+              selectedCount: 0,
+              tokensUsed: 0,
+              typeBudget: 3,
+            },
+          },
+        },
+      }),
+    )
+
+    const { result, log } = await runRetrievalPhase()
+
+    expect(log.warn).toHaveBeenCalledWith('retrieval.type_seated_nothing', {
+      type: 'happenings',
+      poolSize: 12,
+      typeBudget: 3,
+    })
+    // A signal, not a gate.
+    expect(result).toEqual({ status: 'completed' })
+  })
+
+  // The empty-pool case is a cold start, not a misconfiguration.
+  it('stays quiet when a type had no candidates to seat', async () => {
+    seedOpenStory()
+
+    const { log } = await runRetrievalPhase()
+
+    expect(log.warn).not.toHaveBeenCalledWith(
+      'retrieval.type_seated_nothing',
+      expect.anything() as unknown as Record<string, unknown>,
+    )
+  })
+
+  // AC7: the per-turn cost has to be observable against the PoC baseline, which
+  // is a per-KNN-query figure — so the breakdown reaches the log, not just a total.
+  it('logs the pass timing the run reported, breakdown included', async () => {
+    seedOpenStory()
+    const timings = { totalMs: 91, syncMs: 40, embedMs: 30, knnMs: 15, rankMs: 5 }
+    runRetrievalMock.mockResolvedValue(okOutcome({ timings }))
+
+    const { log } = await runRetrievalPhase()
+
+    expect(log.debug).toHaveBeenCalledWith('retrieval.timing', timings)
+  })
+
+  it('logs no timing for a pass that failed before it produced one', async () => {
+    seedOpenStory()
+    runRetrievalMock.mockResolvedValue({
+      ok: false,
+      failure: { reason: 'call', detail: 'embedder session died', staleCount: 4 },
+    })
+
+    const { log } = await runRetrievalPhase()
+
+    expect(log.debug).not.toHaveBeenCalledWith('retrieval.timing', expect.anything())
+  })
+})
+
+describe('retrieval phase — RetrievalParams assembly', () => {
+  it('carries the branch, the resolved model and its read dim', async () => {
+    seedOpenStory({ entries: [entry(1, 'user_action', 'I draw the blade.', meta())] })
+
+    await runRetrievalPhase()
+
+    expect(lastParams()).toMatchObject({
+      branchId: 'b1',
+      modelId: 'Xenova/all-MiniLM-L6-v2',
+      dim: 384,
+    })
+  })
+
+  // Second model so neither field can be a constant that happens to match the
+  // default story: both the id and the dim move together with the setting.
+  it('follows the story to another catalog model and its dim family', async () => {
+    seedOpenStory({ settings: { embedding_model_id: 'onnx-community/embeddinggemma-300m-ONNX' } })
+
+    await runRetrievalPhase()
+
+    expect(lastParams()).toMatchObject({
+      modelId: 'onnx-community/embeddinggemma-300m-ONNX',
+      dim: 768,
+    })
+  })
+
+  // The sync scope is no longer passed alongside the branch — runRetrieval
+  // derives it from this one field, so the pair cannot disagree. Pinning the
+  // field is all that is left to get wrong here.
+  it('names the branch being read exactly once', async () => {
+    seedOpenStory()
+
+    await runRetrievalPhase()
+
+    expect(lastParams().branchId).toBe('b1')
+    expect(runRetrievalMock.mock.calls.at(-1)?.[0]).not.toHaveProperty('branchIds')
+  })
+
+  it("takes the budgets from the story's settings, not the code defaults", async () => {
+    seedOpenStory({
+      settings: {
+        retrievalBudgets: { entities: 11, lore: 22, happenings: 33, threads: 44, chapters: 55 },
+      },
+    })
+
+    await runRetrievalPhase()
+
+    expect(lastParams().budgets).toEqual({
+      entities: 11,
+      lore: 22,
+      happenings: 33,
+      threads: 44,
+      chapters: 55,
+    })
+  })
+
+  it('takes the scene and location off the tail entry, narrowing characters by kind', async () => {
+    seedOpenStory({
+      entities: [
+        entity('char_hero', 'character', 'Kael'),
+        entity('item_blade', 'item', 'Blade'),
+        entity('loc_keep', 'location', 'The Keep'),
+      ],
+      entries: [
+        entry(
+          1,
+          'user_action',
+          'I draw the blade.',
+          meta({
+            sceneEntities: ['char_hero', 'item_blade'],
+            currentLocationId: 'loc_keep',
+          }),
+        ),
+      ],
+    })
+
+    await runRetrievalPhase()
+
+    const params = lastParams()
+    // Positive control on both sides of the kind filter: the item is in the
+    // scene set and out of the character set, so a filter that passed
+    // everything (or nothing) fails here.
+    expect(params.sceneEntityIds).toEqual(['char_hero', 'item_blade'])
+    expect(params.sceneCharacterIds).toEqual(['char_hero'])
+    expect(params.currentLocationId).toBe('loc_keep')
+  })
+
+  it('falls back to an empty scene when the branch has no entries at all', async () => {
+    seedOpenStory()
+
+    await runRetrievalPhase()
+
+    expect(lastParams()).toMatchObject({
+      sceneEntityIds: [],
+      sceneCharacterIds: [],
+      currentLocationId: null,
+    })
+  })
+
+  it("takes Q1 from the turn's own user action", async () => {
+    seedOpenStory({
+      entries: [
+        entry(1, 'opening', 'The keep stands.', meta()),
+        entry(2, 'user_action', 'I draw the blade.', meta()),
+      ],
+    })
+
+    await runRetrievalPhase()
+
+    expect(lastParams().query.userAction).toBe('I draw the blade.')
+  })
+
+  it('leaves Q1 empty rather than reaching back when the tail is not a user action', async () => {
+    seedOpenStory({
+      entries: [
+        entry(1, 'user_action', 'I draw the blade.', meta()),
+        entry(2, 'ai_reply', 'Steel sings.', meta()),
+      ],
+    })
+
+    await runRetrievalPhase()
+
+    expect(lastParams().query.userAction).toBe('')
+  })
+
+  it('takes Q3 from the last ai_reply', async () => {
+    seedOpenStory({
+      entries: [
+        entry(1, 'opening', 'The keep stands.', meta()),
+        entry(2, 'user_action', 'I look around.', meta()),
+        entry(3, 'ai_reply', 'The hall is cold.', meta()),
+        entry(4, 'user_action', 'I draw the blade.', meta()),
+      ],
+    })
+
+    await runRetrievalPhase()
+
+    expect(lastParams().query.lastNarrativeContent).toBe('The hall is cold.')
+  })
+
+  // Cold start (retrieval.md → Cold start): turn 1 has no ai_reply, and the
+  // opening entry the wizard always commits is what Q3 extracts from. Selecting
+  // ai_reply alone passes '' and silently drops Q3 on the first turn of every
+  // story.
+  it('takes Q3 from the opening entry on turn 1', async () => {
+    seedOpenStory({
+      entries: [
+        entry(1, 'opening', 'The keep stands against the ash.', meta()),
+        entry(2, 'user_action', 'I draw the blade.', meta()),
+      ],
+    })
+
+    await runRetrievalPhase()
+
+    expect(lastParams().query.lastNarrativeContent).toBe('The keep stands against the ash.')
+  })
+
+  it('leaves Q3 empty when the branch carries no narrative entry', async () => {
+    seedOpenStory({ entries: [entry(1, 'user_action', 'I draw the blade.', meta())] })
+
+    await runRetrievalPhase()
+
+    expect(lastParams().query.lastNarrativeContent).toBe('')
+  })
+
+  it("enriches Q2 with the last narrative entry's piggyback summary", async () => {
+    seedOpenStory({
+      entries: [
+        entry(1, 'ai_reply', 'Steel sings.', meta({ summary: 'Kael drew on the guard.' })),
+        entry(2, 'user_action', 'I press the attack.', meta()),
+      ],
+    })
+
+    await runRetrievalPhase()
+
+    expect(lastParams().query.piggybackSummary).toBe('Kael drew on the guard.')
+  })
+
+  it('leaves the Q2 summary line absent when the block never parsed', async () => {
+    seedOpenStory({
+      entries: [
+        entry(1, 'ai_reply', 'Steel sings.', meta()),
+        entry(2, 'user_action', 'I press the attack.', meta()),
+      ],
+    })
+
+    await runRetrievalPhase()
+
+    expect(lastParams().query.piggybackSummary).toBeNull()
+  })
+
+  it('leaves the Q2 era line absent — nothing writes branch_era_flips yet', async () => {
+    seedOpenStory()
+
+    await runRetrievalPhase()
+
+    expect(lastParams().query.eraName).toBeNull()
+  })
+
+  it('scans the composed prompt buffer for Layer-A suppression, not the whole branch', async () => {
+    seedOpenStory({
+      settings: { partialChapterBuffer: 2, protectedBuffer: 0 },
+      entries: [
+        entry(1, 'opening', 'ancient-prose', meta()),
+        entry(2, 'ai_reply', 'older-prose', meta()),
+        entry(3, 'ai_reply', 'recent-prose', meta()),
+        entry(4, 'user_action', 'newest-prose', meta()),
+      ],
+    })
+
+    await runRetrievalPhase()
+
+    const { recentProse } = lastParams()
+    expect(recentProse).toContain('recent-prose')
+    expect(recentProse).toContain('newest-prose')
+    // Positive control on the window: prose that slid out of the buffer must
+    // not suppress a staged namesake forever.
+    expect(recentProse).not.toContain('older-prose')
+    expect(recentProse).not.toContain('ancient-prose')
+  })
+})

--- a/lib/pipeline/definitions/per-turn-retrieval.ts
+++ b/lib/pipeline/definitions/per-turn-retrieval.ts
@@ -83,11 +83,21 @@ export async function* retrievalPhase(
         abortSignal: bounded.signal,
         queryAll: queryRows,
         runInTransaction: ctx.runInTransaction,
-        onRowsSynced: () =>
-          refreshEmbeddingStatus(open.storyId, {
-            db: ctx.db,
-            runInTransaction: ctx.runInTransaction,
-          }),
+        // Reporting, not a gate: the sync it follows has already committed, so a
+        // failed recount must not fail a turn that can still complete. The next
+        // pass recounts from the flags rather than from anything stashed here.
+        onRowsSynced: async () => {
+          try {
+            await refreshEmbeddingStatus(open.storyId, {
+              db: ctx.db,
+              runInTransaction: ctx.runInTransaction,
+            })
+          } catch (error) {
+            ctx.log.warn('retrieval.status_refresh_failed', {
+              detail: error instanceof Error ? error.message : String(error),
+            })
+          }
+        },
         ...composeRetrievalEmbedDeps(resolution.config),
       },
       {

--- a/lib/pipeline/definitions/per-turn-retrieval.ts
+++ b/lib/pipeline/definitions/per-turn-retrieval.ts
@@ -1,0 +1,191 @@
+import { boundedSignal } from '@/lib/abort'
+import { inheritedEntryMetadata, queryRows, type StoryEntry } from '@/lib/db'
+import { embedderReadDim } from '@/lib/embedder'
+import { composePromptBuffer, runRetrieval } from '@/lib/retrieval'
+
+import { loadPerTurnWorkingSet } from './working-set'
+import type { PhaseContext, PhaseEmittedEvent, PhaseResult } from '../types'
+
+export const RETRIEVAL_PHASE_NAME = 'retrieval'
+
+/** Where this phase parks its outcome; consumers re-narrow to `RetrievalSuccess`. */
+export const RETRIEVAL_INTERMEDIATE_KEY = 'retrieval'
+
+const NARRATIVE_KINDS = new Set<StoryEntry['kind']>(['ai_reply', 'opening'])
+
+// Matches the periodic classifier's call budget: both bound one blocking
+// provider call, and a turn already tolerates a narrative stream of this order.
+const EMBED_TIMEOUT_MS = 300_000
+
+export async function* retrievalPhase(
+  ctx: PhaseContext,
+): AsyncGenerator<PhaseEmittedEvent, PhaseResult> {
+  const { branchId } = ctx
+  const working = loadPerTurnWorkingSet(ctx, RETRIEVAL_PHASE_NAME)
+  if (!working.ok) return working.result
+  const { open, entries, entities } = working.set
+
+  // Lazy: lib/actions' barrel reaches submitTurn, which imports lib/pipeline.
+  // A module-eval import would close that require cycle and warn under Metro.
+  const { composeRetrievalEmbedDeps, refreshEmbeddingStatus, resolveStorySwapConfig } =
+    await import('@/lib/actions')
+  if (ctx.abortSignal.aborted) return { status: 'aborted' }
+
+  const resolution = resolveStorySwapConfig(open.storyId, {
+    modelId: open.settings.embedding_model_id,
+    backend: open.settings.embeddingBackend,
+    providerId: open.settings.embedding_provider_id,
+  })
+  if (!resolution.ok)
+    return {
+      status: 'failed',
+      error: {
+        kind: 'embedder',
+        reason: 'init',
+        detail: `embedder not configured: ${resolution.reason}`,
+        staleCount: null,
+      },
+    }
+  const dim = embedderReadDim(resolution.config)
+  // Only an unprobed provider lands here. Guessing would KNN the wrong vec0 dim
+  // family, which vec0 rejects with an opaque error rather than an empty result.
+  if (dim === null)
+    return {
+      status: 'failed',
+      error: {
+        kind: 'embedder',
+        reason: 'init',
+        detail: `embedder dim unknown for model ${resolution.config.modelId}`,
+        staleCount: null,
+      },
+    }
+
+  const tail = entries.at(-1)
+  const scene = inheritedEntryMetadata(tail?.metadata)
+  const characterIds = new Set(entities.filter((e) => e.kind === 'character').map((e) => e.id))
+  // retrieval.md → POV-awareness scope queries `sceneEntities ∩ characters`;
+  // sceneEntities itself is kind-mixed (data-model.md → Entry metadata shape).
+  const sceneCharacterIds = scene.sceneEntities.filter((id) => characterIds.has(id))
+
+  const lastNarrative = entries.findLast((e) => NARRATIVE_KINDS.has(e.kind))
+
+  // A provider that accepts the connection and stalls would otherwise park the
+  // turn forever holding the hard gate, with the pill still offering a Cancel
+  // that reaches nothing.
+  const bounded = boundedSignal(ctx.abortSignal, EMBED_TIMEOUT_MS)
+  // finally, because runRetrieval rethrows anything outside the vector-invariant
+  // family: without it every non-embedder fault leaks an armed timer and an
+  // abort listener on the run signal.
+  let outcome
+  try {
+    outcome = await runRetrieval(
+      {
+        abortSignal: bounded.signal,
+        queryAll: queryRows,
+        runInTransaction: ctx.runInTransaction,
+        onRowsSynced: () =>
+          refreshEmbeddingStatus(open.storyId, {
+            db: ctx.db,
+            runInTransaction: ctx.runInTransaction,
+          }),
+        ...composeRetrievalEmbedDeps(resolution.config),
+      },
+      {
+        branchId,
+        modelId: resolution.config.modelId,
+        dim,
+        budgets: open.settings.retrievalBudgets,
+        query: {
+          // Q1 is THIS turn's action, which submitTurn commits immediately before
+          // the run; anything else at the tail means the turn has none, and an
+          // older action would embed as if it were current.
+          userAction: tail?.kind === 'user_action' ? tail.content : '',
+          // branch_era_flips has no writer wired, so no era can be named yet.
+          eraName: null,
+          piggybackSummary: lastNarrative?.metadata?.summary ?? null,
+          lastNarrativeContent: lastNarrative?.content ?? '',
+        },
+        sceneCharacterIds,
+        sceneEntityIds: scene.sceneEntities,
+        currentLocationId: scene.currentLocationId,
+        // Layer A scans the recent un-classified buffer prose (edge-cases.md →
+        // Layer A — retrieval-time same-name suppression); the prompt buffer only
+        // approximates that set, over-suppressing while classifierCadence stays
+        // under partialChapterBuffer and under-suppressing past it (cadence.md →
+        // User-tunable knobs).
+        recentProse: composePromptBuffer(entries, open.settings)
+          .map((e) => e.content)
+          .join('\n'),
+      },
+    )
+  } finally {
+    bounded.dispose()
+  }
+
+  // The OUTER signal, not the bounded one: an expiry aborts the pass the same
+  // way a cancel does, but it is a provider fault. Reading the bounded signal
+  // here would report every timeout as a phantom user-cancel — draft restored,
+  // no error, no Switch embedder, retrying into the same dead provider.
+  if (ctx.abortSignal.aborted) return { status: 'aborted' }
+
+  if (!outcome.ok) {
+    const failure = bounded.expired()
+      ? { ...outcome.failure, detail: `embed timed out after ${EMBED_TIMEOUT_MS}ms` }
+      : outcome.failure
+    ctx.log.warn('retrieval.embed_failed', {
+      reason: failure.reason,
+      staleCount: failure.staleCount,
+    })
+    return { status: 'failed', error: { kind: 'embedder', ...failure } }
+  }
+
+  // AC7 wants the per-turn cost observable against the PoC baseline (~43 ms per
+  // KNN query at 10k rows), so the KNN span is reported apart from the total.
+  ctx.log.debug('retrieval.timing', outcome.timings)
+
+  // staleCounts is a tripwire, not a report (lib/retrieval → RetrievalOutcome):
+  // the sync stage is blocking and clears every flag it embeds, so a non-zero
+  // count means its scope or its ops missed rows.
+  if (Object.values(outcome.staleCounts).some((count) => count > 0))
+    ctx.log.warn('retrieval.stale_after_sync', outcome.staleCounts)
+
+  // retrieval.md → Budget-fill termination wants a budget below its type's
+  // overhead surfaced, not absorbed. Until the Story Settings warning exists,
+  // this is the only signal that a type is seating nothing: candidates were
+  // ranked and every one of them was dropped, which no prompt ever shows.
+  for (const [type, bundle] of Object.entries(outcome.bundles)) {
+    if (bundle.funnel.poolSize > 0 && bundle.funnel.selectedCount === 0)
+      ctx.log.warn('retrieval.type_seated_nothing', {
+        type,
+        poolSize: bundle.funnel.poolSize,
+        typeBudget: bundle.funnel.typeBudget,
+      })
+  }
+
+  ctx.intermediates[RETRIEVAL_INTERMEDIATE_KEY] = outcome
+
+  // Downstream of the abort poll on purpose: bumping a cancelled turn's counters
+  // leaves reverse-replay work for a turn that produced no prose.
+  const bumpStartedAt = performance.now()
+  for (const { id, retrievalCount } of outcome.injectedAwareness) {
+    yield {
+      type: 'delta_emitted',
+      action: {
+        kind: 'bumpAwarenessRetrieval',
+        source: 'ai_classifier',
+        payload: { branchId, id, priorCount: retrievalCount },
+      },
+    }
+  }
+  // Reported apart from outcome.timings, which measures the pass and returns
+  // before any of this. One bump per aware in-scene character per seated
+  // happening, each awaited by the orchestrator and each a handler read plus a
+  // transaction — so this span is the turn's cost for the counters, and it is
+  // spent before the narrative phase streams a word.
+  if (outcome.injectedAwareness.length > 0)
+    ctx.log.debug('retrieval.bump_dispatch', {
+      count: outcome.injectedAwareness.length,
+      ms: Math.round(performance.now() - bumpStartedAt),
+    })
+  return { status: 'completed' }
+}

--- a/lib/pipeline/definitions/per-turn.test.ts
+++ b/lib/pipeline/definitions/per-turn.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { APP_SETTINGS_DEFAULTS, STORY_SETTINGS_DEFAULTS, type StorySettings } from '@/lib/db'
 import { logger, makeLogger, type Logger } from '@/lib/diagnostics'
+import type { TemplateId } from '@/lib/prompts'
+import type { Candidate, RetrievalSuccess } from '@/lib/retrieval'
 import {
   appSettingsStore,
   currentStoryStore,
@@ -11,10 +13,12 @@ import {
 } from '@/lib/stores'
 
 import { ensurePerTurnPipelineRegistered, PER_TURN_KIND } from './per-turn'
+import { RETRIEVAL_INTERMEDIATE_KEY } from './per-turn-retrieval'
 import { getPipeline } from '../authoring/registry'
 
-const { streamTextMock } = vi.hoisted(() => ({
+const { streamTextMock, renderTemplateMock } = vi.hoisted(() => ({
   streamTextMock: vi.fn(),
+  renderTemplateMock: vi.fn(),
 }))
 
 vi.mock('@/lib/ai', async (importOriginal) => {
@@ -22,6 +26,21 @@ vi.mock('@/lib/ai', async (importOriginal) => {
   return {
     ...actual,
     streamText: streamTextMock,
+  }
+})
+
+// Records the context each phase hands over, then renders for real — the
+// generation context is the only place a retrieval bundle is observable until
+// the bundled pack renders one.
+vi.mock('@/lib/prompts', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  const render = actual.renderTemplate as (id: TemplateId, ctx: Record<string, unknown>) => string
+  return {
+    ...actual,
+    renderTemplate: (templateId: TemplateId, context: Record<string, unknown>) => {
+      renderTemplateMock(templateId, context)
+      return render(templateId, context)
+    },
   }
 })
 
@@ -66,7 +85,7 @@ function failingStreamCall() {
 
 async function runNarrativePhase(abortSignal = new AbortController().signal) {
   ensurePerTurnPipelineRegistered()
-  const phase = getPipeline(PER_TURN_KIND).phases[1]
+  const phase = getPipeline(PER_TURN_KIND).phases[2]
   if (!phase || !('run' in phase)) throw new Error('expected a single-run narrative phase node')
   const gen = phase.run({
     actionId: 'act_1',
@@ -74,6 +93,7 @@ async function runNarrativePhase(abortSignal = new AbortController().signal) {
     intermediates: {},
     log: makeLogger('act_1'),
     db: {} as never,
+    runInTransaction: async () => undefined,
     storyId: 's1',
     branchId: 'b1',
   })
@@ -85,15 +105,17 @@ async function runNarrativePhase(abortSignal = new AbortController().signal) {
 beforeEach(() => {
   vi.restoreAllMocks()
   streamTextMock.mockReset().mockReturnValue(failingStreamCall())
+  renderTemplateMock.mockReset()
   resetAllStores()
 })
 
 describe('per-turn pipeline declaration', () => {
-  it('registers phase 0 user-action-translation then narrative then piggyback-fallback-classifier, aligned to canonical V1', () => {
+  it('registers phase 0 user-action-translation then retrieval then narrative then piggyback-fallback-classifier, aligned to canonical V1', () => {
     ensurePerTurnPipelineRegistered()
     const p = getPipeline(PER_TURN_KIND)
     expect(p.phases.map((n) => n.name)).toEqual([
       'user-action-translation',
+      'retrieval',
       'narrative',
       'piggyback-fallback-classifier',
     ])
@@ -113,6 +135,7 @@ describe('per-turn pipeline declaration', () => {
       intermediates: {},
       log: makeLogger('act_1'),
       db: {} as never,
+      runInTransaction: async () => undefined,
       storyId: 's1',
       branchId: 'b1',
     }
@@ -309,7 +332,7 @@ describe('per-turn pipeline declaration', () => {
 
     const intermediates: Record<string, unknown> = {}
     ensurePerTurnPipelineRegistered()
-    const phase = getPipeline(PER_TURN_KIND).phases[1]
+    const phase = getPipeline(PER_TURN_KIND).phases[2]
     if (!phase || !('run' in phase)) throw new Error('expected narrative phase')
 
     const gen = phase.run({
@@ -317,6 +340,7 @@ describe('per-turn pipeline declaration', () => {
       abortSignal: new AbortController().signal,
       intermediates,
       log: makeLogger('act_1'),
+      runInTransaction: async () => undefined,
       db: {
         select: () => ({
           from: () => ({
@@ -423,7 +447,7 @@ describe('per-turn pipeline declaration', () => {
 
     const intermediates: Record<string, unknown> = {}
     ensurePerTurnPipelineRegistered()
-    const phase = getPipeline(PER_TURN_KIND).phases[1]
+    const phase = getPipeline(PER_TURN_KIND).phases[2]
     if (!phase || !('run' in phase)) throw new Error('expected narrative phase')
 
     const gen = phase.run({
@@ -431,6 +455,7 @@ describe('per-turn pipeline declaration', () => {
       abortSignal: new AbortController().signal,
       intermediates,
       log: makeLogger('act_1'),
+      runInTransaction: async () => undefined,
       db: {
         select: () => ({ from: () => ({ where: () => Promise.resolve([{ next: 1 }]) }) }),
       } as never,
@@ -508,7 +533,7 @@ describe('per-turn pipeline declaration', () => {
 
     const intermediates: Record<string, unknown> = {}
     ensurePerTurnPipelineRegistered()
-    const phase = getPipeline(PER_TURN_KIND).phases[1]
+    const phase = getPipeline(PER_TURN_KIND).phases[2]
     if (!phase || !('run' in phase)) throw new Error('expected narrative phase')
 
     const gen = phase.run({
@@ -516,6 +541,7 @@ describe('per-turn pipeline declaration', () => {
       abortSignal: new AbortController().signal,
       intermediates,
       log: logger,
+      runInTransaction: async () => undefined,
       db: {
         select: () => ({ from: () => ({ where: () => Promise.resolve([{ next: 1 }]) }) }),
       } as never,
@@ -585,7 +611,7 @@ describe('per-turn pipeline declaration', () => {
     })
 
     ensurePerTurnPipelineRegistered()
-    const phase = getPipeline(PER_TURN_KIND).phases[1]
+    const phase = getPipeline(PER_TURN_KIND).phases[2]
     if (!phase || !('run' in phase)) throw new Error('expected narrative phase')
 
     const intermediates: Record<string, unknown> = {}
@@ -594,6 +620,7 @@ describe('per-turn pipeline declaration', () => {
       abortSignal: new AbortController().signal,
       intermediates,
       log: makeLogger('act_1'),
+      runInTransaction: async () => undefined,
       db: {
         select: () => ({
           from: () => ({
@@ -668,7 +695,7 @@ describe('per-turn pipeline declaration', () => {
     })
 
     ensurePerTurnPipelineRegistered()
-    const narrativeNode = getPipeline(PER_TURN_KIND).phases[1]
+    const narrativeNode = getPipeline(PER_TURN_KIND).phases[2]
     if (!narrativeNode || !('run' in narrativeNode)) throw new Error('expected narrative phase')
 
     const intermediates: Record<string, unknown> = {}
@@ -677,6 +704,7 @@ describe('per-turn pipeline declaration', () => {
       abortSignal: new AbortController().signal,
       intermediates,
       log: makeLogger('act_1'),
+      runInTransaction: async () => undefined,
       db: {
         select: () => ({
           from: () => ({
@@ -696,7 +724,7 @@ describe('per-turn pipeline declaration', () => {
     expect(intermediates.piggybackOutcome).toEqual({ attempted: true, succeeded: false })
 
     // Verify fallback classifier phase fires when outcome is { attempted: true, succeeded: false }
-    const fallbackNode = getPipeline(PER_TURN_KIND).phases[2]
+    const fallbackNode = getPipeline(PER_TURN_KIND).phases[3]
     if (!fallbackNode || !('run' in fallbackNode)) throw new Error('expected fallback phase')
 
     // Branch has no entries so fallback phase returns completed cleanly without throws
@@ -706,6 +734,7 @@ describe('per-turn pipeline declaration', () => {
       intermediates,
       log: makeLogger('act_1'),
       db: {} as never,
+      runInTransaction: async () => undefined,
       storyId: 's1',
       branchId: 'b1',
     })
@@ -727,10 +756,81 @@ const SUGGESTION_CATEGORIES = [
   },
 ]
 
+const RETRIEVED_ENTITY_ID = 'char_00000000-0000-4000-8000-0000000000e9'
+const RETRIEVED_LOCATION_ID = 'loc_00000000-0000-4000-8000-0000000000ea'
+
+function entityCandidate(id: string, displayName: string, renderedText: string): Candidate {
+  return {
+    kind: 'entity',
+    id,
+    displayName,
+    renderedText,
+    sims: [0, 0, 0],
+    vector: new Float32Array([1, 0, 0]),
+    chaptersOld: 0,
+    pinSignal: 0,
+    keywordHits: [],
+    embeddingStale: false,
+  }
+}
+
+function retrievalIntermediate(
+  over: { entities?: Candidate[]; selectedLocationIds?: string[] } = {},
+): RetrievalSuccess {
+  const selected: Candidate[] = over.entities ?? [
+    entityCandidate(RETRIEVED_ENTITY_ID, 'Corvin', 'Corvin (currently elsewhere): a smuggler.'),
+  ]
+  const emptyBundle = {
+    selected: [],
+    traces: [],
+    funnel: {
+      poolSize: 0,
+      preFilteredSize: 0,
+      selectedCount: 0,
+      tokensUsed: 0,
+      typeBudget: 0,
+    },
+  }
+  const spec = { text: '', source: 'user_action' as const }
+  return {
+    ok: true,
+    floor: {
+      sceneEntities: [],
+      currentLocation: null,
+      activeThreads: [
+        {
+          id: 'thr_00000000-0000-4000-8000-0000000000f9',
+          status: 'active',
+          injectionMode: 'auto',
+          title: 'Find the heir',
+          description: null,
+        },
+      ],
+      alwaysEntities: [],
+      alwaysLore: [],
+      alwaysThreads: [],
+      seatedIds: new Set<string>(),
+    },
+    bundles: {
+      entities: { ...emptyBundle, selected },
+      lore: emptyBundle,
+      happenings: emptyBundle,
+      threads: emptyBundle,
+      chapters: emptyBundle,
+    },
+    queries: { q1: spec, q2: spec, q3: spec, presence: [false, false, false], embedTexts: [] },
+    staleCounts: { entities: 0, lore: 0, happenings: 0, threads: 0, chapters: 0 },
+    injectedAwareness: [],
+    selectedLocationIds: over.selectedLocationIds ?? [],
+    timings: { totalMs: 0, syncMs: 0, embedMs: 0, knnMs: 0, rankMs: 0 },
+  }
+}
+
 async function runNarrativeWith(opts: {
   narrative: string
   settings?: Partial<StorySettings>
   log?: Logger
+  intermediates?: Record<string, unknown>
 }) {
   currentStoryStore.set({
     storyId: 's1',
@@ -777,14 +877,15 @@ async function runNarrativeWith(opts: {
   })
 
   ensurePerTurnPipelineRegistered()
-  const phase = getPipeline(PER_TURN_KIND).phases[1]
+  const phase = getPipeline(PER_TURN_KIND).phases[2]
   if (!phase || !('run' in phase)) throw new Error('expected narrative phase')
-  const intermediates: Record<string, unknown> = {}
+  const intermediates: Record<string, unknown> = { ...opts.intermediates }
   const gen = phase.run({
     actionId: 'act_1',
     abortSignal: new AbortController().signal,
     intermediates,
     log: opts.log ?? makeLogger('act_1'),
+    runInTransaction: async () => undefined,
     db: {
       select: () => ({ from: () => ({ where: () => Promise.resolve([{ next: 1 }]) }) }),
     } as never,
@@ -809,8 +910,78 @@ async function runNarrativeWith(opts: {
     metadata,
     intermediates,
     prompt: streamTextMock.mock.calls.at(-1)?.[1]?.prompt as string,
+    context: renderTemplateMock.mock.calls.at(-1)?.[1] as Record<string, unknown>,
   }
 }
+
+describe('narrative fold — retrieval handoff', () => {
+  const namesOf = (bucket: unknown) =>
+    (bucket as { displayName: string }[]).map((r) => r.displayName)
+
+  it('passes the stashed retrieval outcome into the generation context', async () => {
+    const { context } = await runNarrativeWith({
+      narrative: 'prose',
+      intermediates: { [RETRIEVAL_INTERMEDIATE_KEY]: retrievalIntermediate() },
+    })
+    expect(namesOf(context.retrievedEntities)).toEqual(['Corvin'])
+    expect((context.structuralActiveThreads as { title: string }[]).map((t) => t.title)).toEqual([
+      'Find the heir',
+    ])
+  })
+
+  // The negative control for the case above: same fold, no intermediate.
+  it('renders empty buckets when the retrieval phase stashed nothing', async () => {
+    const { context } = await runNarrativeWith({ narrative: 'prose' })
+    expect(context.retrievedEntities).toEqual([])
+    expect(context.structuralActiveThreads).toEqual([])
+  })
+
+  // The whole round trip for a scene that MOVES: the ranked place has to reach
+  // the prompt as a nameable ID, and what the model names has to land on the
+  // entry. Omitting <current_location> means "inherit" (lib/piggyback/apply.ts),
+  // so a prompt that offers no place freezes the location forever.
+  it('lets the model move the scene to a ranked location', async () => {
+    const { prompt, metadata } = await runNarrativeWith({
+      narrative:
+        'They cross to the stalls.\n<state><current_location>l1</current_location></state>',
+      intermediates: {
+        [RETRIEVAL_INTERMEDIATE_KEY]: retrievalIntermediate({
+          entities: [
+            entityCandidate(
+              RETRIEVED_LOCATION_ID,
+              'The Market',
+              'The Market (currently elsewhere): stalls under sailcloth.',
+            ),
+          ],
+          selectedLocationIds: [RETRIEVED_LOCATION_ID],
+        }),
+      },
+    })
+    expect(prompt).toContain('for <current_location> when the scene is at that place: l1.')
+    expect(metadata.currentLocationId).toBe(RETRIEVED_LOCATION_ID)
+  })
+
+  // Negative control for the case above: the same fold with a ranked CHARACTER
+  // offers no place, so the instruction stays out of the prompt entirely.
+  it('offers no <current_location> target when the ranked entity is not a place', async () => {
+    const { prompt } = await runNarrativeWith({
+      narrative: 'prose',
+      intermediates: { [RETRIEVAL_INTERMEDIATE_KEY]: retrievalIntermediate() },
+    })
+    expect(prompt).toContain('Corvin (currently elsewhere): a smuggler.')
+    expect(prompt).not.toContain('for <current_location> when the scene is at that place')
+  })
+
+  // ctx.intermediates is Record<string, unknown>: a non-outcome value must not
+  // reach the builder as if it were one.
+  it('ignores a value parked under the retrieval key that is not an ok outcome', async () => {
+    const { context } = await runNarrativeWith({
+      narrative: 'prose',
+      intermediates: { [RETRIEVAL_INTERMEDIATE_KEY]: { ok: false, failure: { reason: 'call' } } },
+    })
+    expect(context.retrievedEntities).toEqual([])
+  })
+})
 
 describe('narrative fold — suggestions', () => {
   it('persists parsed chips with source piggyback on the created entry', async () => {

--- a/lib/pipeline/definitions/per-turn.ts
+++ b/lib/pipeline/definitions/per-turn.ts
@@ -12,7 +12,8 @@ import {
   substitutePiggybackIds,
 } from '@/lib/piggyback'
 import { renderTemplate, TEMPLATE_IDS } from '@/lib/prompts'
-import { appSettingsStore, currentStoryStore, entitiesStore, entriesStore } from '@/lib/stores'
+import type { RetrievalSuccess } from '@/lib/retrieval'
+import { appSettingsStore, currentStoryStore } from '@/lib/stores'
 
 import { buildGenerationContext } from './generation-context'
 import {
@@ -21,35 +22,45 @@ import {
   piggybackFallbackClassifierPhase,
   resolvePiggybackFires,
 } from './per-turn-piggyback'
+import {
+  RETRIEVAL_INTERMEDIATE_KEY,
+  RETRIEVAL_PHASE_NAME,
+  retrievalPhase,
+} from './per-turn-retrieval'
+import { loadPerTurnWorkingSet } from './working-set'
 import { definePipeline } from '../authoring/define'
 import { getPipeline } from '../authoring/registry'
-import type { PhaseContext, PhaseEmittedEvent, PhaseResult } from '../types'
+import type { PhaseContext, PhaseEmittedEvent, PhaseNode, PhaseResult } from '../types'
 
 export const PER_TURN_KIND = 'per-turn'
 
+// The status pill's phase mapping is exhaustive over this union and the phase
+// list below is typed by it, so a phase added to the turn cannot reach the
+// user unlabelled (generation-status-pill.md → Copy mapping).
+export type PerTurnPhaseName =
+  | 'user-action-translation'
+  | typeof RETRIEVAL_PHASE_NAME
+  | 'narrative'
+  | typeof PIGGYBACK_FALLBACK_PHASE_NAME
+
+// `ctx.intermediates` is Record<string, unknown>, so presence is the discriminant:
+// only ok outcomes are ever stashed, and the phase fails the run before this one
+// otherwise — absence degrades the prompt to empty buckets rather than throwing.
+// The `ok` check is defensive: a future stash of the failure variant must not
+// reach the builder as a bundle.
+function readRetrievalOutcome(
+  intermediates: Record<string, unknown>,
+): RetrievalSuccess | undefined {
+  const stashed = intermediates[RETRIEVAL_INTERMEDIATE_KEY]
+  if (typeof stashed !== 'object' || stashed === null || !('ok' in stashed)) return undefined
+  return stashed.ok === true ? (stashed as RetrievalSuccess) : undefined
+}
+
 async function* narrativePhase(ctx: PhaseContext): AsyncGenerator<PhaseEmittedEvent, PhaseResult> {
-  const { branchId, storyId } = ctx
-  const open = currentStoryStore.getCurrentStory()
-  if (!open || open.branchId !== branchId || open.storyId !== storyId)
-    return {
-      status: 'failed',
-      error: { kind: 'orchestrator', detail: 'per-turn: no open story for branch' },
-    }
-
-  // Defense-in-depth against store desync: currentStoryStore is guarded above,
-  // but the entry buffer + worldTime tail read from entriesStore — a future
-  // multi-branch/background path hydrating it elsewhere would otherwise feed a
-  // silent degenerate prompt.
-  if (entriesStore.getLoadedBranch() !== branchId)
-    return {
-      status: 'failed',
-      error: { kind: 'orchestrator', detail: 'per-turn: entries store loaded for another branch' },
-    }
-
-  const entries = [...entriesStore.getEntries().values()]
-    .filter((e) => e.branchId === branchId)
-    .sort((a, b) => a.position - b.position)
-  const entities = [...entitiesStore.getEntities().values()].filter((e) => e.branchId === branchId)
+  const { branchId } = ctx
+  const working = loadPerTurnWorkingSet(ctx, PER_TURN_KIND)
+  if (!working.ok) return working.result
+  const { open, entries, entities } = working.set
 
   const cfg = appSettingsStore.getAppSettings()
 
@@ -95,6 +106,7 @@ async function* narrativePhase(ctx: PhaseContext): AsyncGenerator<PhaseEmittedEv
     idMap,
     piggybackFires: piggybackShouldFire,
     suggestionsFire: suggestionsShouldFire,
+    retrieval: readRetrievalOutcome(ctx.intermediates),
   })
   const prompt = renderTemplate(TEMPLATE_IDS.perTurnNarrative, context)
 
@@ -314,17 +326,19 @@ export function ensurePerTurnPipelineRegistered(): void {
   try {
     getPipeline(PER_TURN_KIND)
   } catch {
+    const phases: readonly (PhaseNode & { name: PerTurnPhaseName })[] = [
+      { name: 'user-action-translation', run: userActionTranslationPhase },
+      { name: RETRIEVAL_PHASE_NAME, run: retrievalPhase },
+      { name: 'narrative', run: narrativePhase, resolves: [{ target: 'narrative' }] },
+      {
+        name: PIGGYBACK_FALLBACK_PHASE_NAME,
+        run: piggybackFallbackClassifierPhase,
+        resolves: PIGGYBACK_FALLBACK_RESOLVES,
+      },
+    ]
     definePipeline({
       kind: PER_TURN_KIND,
-      phases: [
-        { name: 'user-action-translation', run: userActionTranslationPhase },
-        { name: 'narrative', run: narrativePhase, resolves: [{ target: 'narrative' }] },
-        {
-          name: PIGGYBACK_FALLBACK_PHASE_NAME,
-          run: piggybackFallbackClassifierPhase,
-          resolves: PIGGYBACK_FALLBACK_RESOLVES,
-        },
-      ],
+      phases,
       affordance: 'pill-and-banner',
       gateBehavior: 'hard-gate',
       concurrencyPolicy: { blockedBy: ['per-turn', 'chapter-close'] },

--- a/lib/pipeline/definitions/periodic-classifier.test.ts
+++ b/lib/pipeline/definitions/periodic-classifier.test.ts
@@ -139,6 +139,7 @@ async function ctxWith(opts: {
       abortSignal: new AbortController().signal,
       intermediates: {},
       log: makeLogger('a1'),
+      runInTransaction: async () => undefined,
       db: observed as PhaseContext['db'],
       storyId: 's1',
       branchId: 'b1',

--- a/lib/pipeline/definitions/periodic-classifier.ts
+++ b/lib/pipeline/definitions/periodic-classifier.ts
@@ -1,5 +1,6 @@
 import { and, asc, eq, gt, sql } from 'drizzle-orm'
 
+import { boundedSignal } from '@/lib/abort'
 import { generateStructured } from '@/lib/ai'
 import {
   buildClassifierActions,
@@ -74,36 +75,6 @@ async function readWindowEntries(
 // failure the existing backoff can act on. A profile `timeout` shorter than
 // this still wins — the SDK aborts first; a longer one is deliberately capped.
 const CALL_TIMEOUT_MS = 300_000
-
-// AbortSignal.timeout / .any are statics Hermes has historically lacked, so
-// this composes the same behavior from AbortController + setTimeout, matching
-// lib/embedder/download/model-card.ts.
-function boundedSignal(outer: AbortSignal | undefined, ms: number) {
-  const controller = new AbortController()
-  let expired = false
-  const timer = setTimeout(() => {
-    expired = true
-    controller.abort()
-  }, ms)
-  // Clears the timer, not just relays: left armed it can still fire while the
-  // aborted call winds down, and `expired` is what tells a cancel from a
-  // timeout — a late fire would burn a retry on a clean cancellation.
-  const relay = () => {
-    clearTimeout(timer)
-    controller.abort()
-  }
-  if (outer?.aborted) relay()
-  else outer?.addEventListener('abort', relay)
-  return {
-    signal: controller.signal,
-    /** Stays readable after dispose: the flag is captured, not derived. */
-    expired: () => expired,
-    dispose: () => {
-      clearTimeout(timer)
-      outer?.removeEventListener('abort', relay)
-    },
-  }
-}
 
 async function readStatus(ctx: PhaseContext): Promise<ClassifierStatus> {
   const [row] = await ctx.db

--- a/lib/pipeline/definitions/suggestion-refresh.test.ts
+++ b/lib/pipeline/definitions/suggestion-refresh.test.ts
@@ -129,6 +129,7 @@ function phaseCtx(inputs: unknown, abortSignal = new AbortController().signal): 
     inputs,
     log: makeLogger('act_1'),
     db: {} as never,
+    runInTransaction: async () => undefined,
     storyId: 's1',
     branchId: 'b1',
   }

--- a/lib/pipeline/definitions/suggestion-refresh.ts
+++ b/lib/pipeline/definitions/suggestion-refresh.ts
@@ -95,8 +95,8 @@ async function* suggestionEmissionPhase(
     .sort((a, b) => a.position - b.position)
   // Same anchor the strip renders from, so the run writes where the reader is
   // looking. Only AI-authored entries qualify, and everything after the anchor
-  // is a user_action or a system row — neither carries chips, and the builder
-  // drops system rows — so the whole entry list is already the prompt window.
+  // is a user_action or a system row — neither carries chips. The whole branch
+  // goes to the builder regardless; composing the prompt window is its job.
   const target = findSuggestionAnchor(entries)
   if (!target) {
     ctx.log.warn('classifier.suggestions_refresh_no_anchor', { branchId: ctx.branchId })

--- a/lib/pipeline/definitions/working-set.test.ts
+++ b/lib/pipeline/definitions/working-set.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  STORY_SETTINGS_DEFAULTS,
+  storyDefinitionSchema,
+  type Entity,
+  type StoryEntry,
+} from '@/lib/db'
+import { currentStoryStore, entitiesStore, entriesStore } from '@/lib/stores'
+
+import { loadPerTurnWorkingSet } from './working-set'
+
+const DEFINITION = storyDefinitionSchema.parse({
+  mode: 'creative',
+  leadEntityId: null,
+  narration: 'third',
+  genre: { label: 'Fantasy', promptBody: '' },
+  tone: { label: 'Wry', promptBody: '' },
+  setting: '',
+  calendarSystemId: 'gregorian',
+  worldTimeOrigin: { year: 0 },
+})
+
+function entry(id: string, position: number, branchId = 'b1'): StoryEntry {
+  return {
+    id,
+    branchId,
+    position,
+    kind: 'ai_reply',
+    content: id,
+    chapterId: null,
+    metadata: { sceneEntities: [], currentLocationId: null, worldTime: 0 },
+    createdAt: 1,
+  }
+}
+
+function entity(id: string, branchId = 'b1'): Entity {
+  return {
+    id,
+    branchId,
+    kind: 'character',
+    name: id,
+    description: null,
+    tags: [],
+    status: 'active',
+    retiredReason: null,
+    nameCollisionFlag: 0,
+    injectionMode: 'auto',
+    state: null,
+    embeddingStale: 0,
+    createdAt: 1,
+    updatedAt: 1,
+  }
+}
+
+const RUN = { storyId: 's1', branchId: 'b1' }
+
+function openStory(over: { storyId?: string; branchId?: string } = {}): void {
+  currentStoryStore.set({
+    storyId: over.storyId ?? 's1',
+    branchId: over.branchId ?? 'b1',
+    definition: DEFINITION,
+    settings: STORY_SETTINGS_DEFAULTS,
+  })
+}
+
+describe('loadPerTurnWorkingSet', () => {
+  beforeEach(() => {
+    currentStoryStore.__reset()
+    entriesStore.__reset()
+    entitiesStore.__reset()
+  })
+
+  it.each([
+    { case: 'no story is open', open: null },
+    { case: 'the open story is another branch', open: { branchId: 'b2' } },
+    { case: 'the open story is another story', open: { storyId: 's2' } },
+  ])('refuses the run when $case', ({ open }) => {
+    if (open) openStory(open)
+    entriesStore.hydrate('b1', [])
+
+    expect(loadPerTurnWorkingSet(RUN, 'phase')).toEqual({
+      ok: false,
+      result: {
+        status: 'failed',
+        error: { kind: 'orchestrator', detail: 'phase: no open story for branch' },
+      },
+    })
+  })
+
+  it('refuses the run when the entries store holds another branch', () => {
+    openStory()
+    entriesStore.hydrate('b2', [])
+
+    expect(loadPerTurnWorkingSet(RUN, 'phase')).toEqual({
+      ok: false,
+      result: {
+        status: 'failed',
+        error: { kind: 'orchestrator', detail: 'phase: entries store loaded for another branch' },
+      },
+    })
+  })
+
+  // Positive control for the four refusals: the same call succeeds once every
+  // identity agrees, so those assertions are about the guards, not the setup.
+  it('loads the set when the open story and the entries store both match', () => {
+    openStory()
+    entriesStore.hydrate('b1', [entry('e1', 1)])
+    entitiesStore.hydrate('b1', [entity('char_1')])
+
+    const load = loadPerTurnWorkingSet(RUN, 'phase')
+    expect(load.ok).toBe(true)
+    if (!load.ok) return
+    expect(load.set.open.storyId).toBe('s1')
+    expect(load.set.entries.map((e) => e.id)).toEqual(['e1'])
+    expect(load.set.entities.map((e) => e.id)).toEqual(['char_1'])
+  })
+
+  it('returns entries ascending by position, not in map order', () => {
+    openStory()
+    entriesStore.hydrate('b1', [entry('e3', 3), entry('e1', 1), entry('e2', 2)])
+
+    const load = loadPerTurnWorkingSet(RUN, 'phase')
+    expect(load.ok && load.set.entries.map((e) => e.id)).toEqual(['e1', 'e2', 'e3'])
+  })
+
+  // The branch guard above already refuses a store hydrated elsewhere, so these
+  // filters only catch a row tagged for another branch inside the held one.
+  // They stay because the prompt they feed describes a single branch's story.
+  it('drops rows tagged for another branch inside the held one', () => {
+    openStory()
+    entriesStore.hydrate('b1', [entry('e1', 1), entry('foreign', 2, 'b2')])
+    entitiesStore.hydrate('b1', [entity('char_1'), entity('char_foreign', 'b2')])
+
+    const load = loadPerTurnWorkingSet(RUN, 'phase')
+    expect(load.ok && load.set.entries.map((e) => e.id)).toEqual(['e1'])
+    expect(load.ok && load.set.entities.map((e) => e.id)).toEqual(['char_1'])
+  })
+})

--- a/lib/pipeline/definitions/working-set.ts
+++ b/lib/pipeline/definitions/working-set.ts
@@ -1,0 +1,58 @@
+import type { Entity, StoryEntry } from '@/lib/db'
+import { currentStoryStore, entitiesStore, entriesStore, type OpenStory } from '@/lib/stores'
+
+import type { PhaseContext, PhaseResult } from '../types'
+
+export type PerTurnWorkingSet = {
+  open: OpenStory
+  /** The branch's entries, ascending by position. */
+  entries: StoryEntry[]
+  entities: Entity[]
+}
+
+export type WorkingSetLoad =
+  | { ok: true; set: PerTurnWorkingSet }
+  | { ok: false; result: Extract<PhaseResult, { status: 'failed' }> }
+
+/**
+ * The working set every per-turn phase reads, behind the two guards none of them
+ * may skip. Both are defense-in-depth against store desync: the stores are
+ * global and branch-scoped, and a phase that read them for the wrong branch
+ * would filter every row away and go on to build a silently degenerate prompt
+ * rather than fail. `label` prefixes the failure detail with the phase's name.
+ */
+export function loadPerTurnWorkingSet(
+  ctx: Pick<PhaseContext, 'storyId' | 'branchId'>,
+  label: string,
+): WorkingSetLoad {
+  const { branchId, storyId } = ctx
+
+  const open = currentStoryStore.getCurrentStory()
+  if (!open || open.branchId !== branchId || open.storyId !== storyId)
+    return {
+      ok: false,
+      result: {
+        status: 'failed',
+        error: { kind: 'orchestrator', detail: `${label}: no open story for branch` },
+      },
+    }
+
+  if (entriesStore.getLoadedBranch() !== branchId)
+    return {
+      ok: false,
+      result: {
+        status: 'failed',
+        error: {
+          kind: 'orchestrator',
+          detail: `${label}: entries store loaded for another branch`,
+        },
+      },
+    }
+
+  const entries = [...entriesStore.getEntries().values()]
+    .filter((e) => e.branchId === branchId)
+    .sort((a, b) => a.position - b.position)
+  const entities = [...entitiesStore.getEntities().values()].filter((e) => e.branchId === branchId)
+
+  return { ok: true, set: { open, entries, entities } }
+}

--- a/lib/pipeline/index.ts
+++ b/lib/pipeline/index.ts
@@ -1,6 +1,10 @@
 export { toPipelineError } from './call-error'
 export { definePhase, definePipeline } from './authoring/define'
-export { ensurePerTurnPipelineRegistered, PER_TURN_KIND } from './definitions/per-turn'
+export {
+  ensurePerTurnPipelineRegistered,
+  PER_TURN_KIND,
+  type PerTurnPhaseName,
+} from './definitions/per-turn'
 export {
   fallbackClassifierSchema,
   fallbackClassifierWithSuggestionsSchema,

--- a/lib/pipeline/runtime/orchestrator.ts
+++ b/lib/pipeline/runtime/orchestrator.ts
@@ -179,6 +179,7 @@ function phaseContextOf(run: RunState, ctx: RunCtx): PhaseContext {
     intermediates: run.intermediates,
     log: makeLogger(run.actionId),
     db: ctx.db,
+    runInTransaction: ctx.runInTransaction,
     storyId: run.storyId,
     branchId: run.branchId,
   }

--- a/lib/pipeline/types.ts
+++ b/lib/pipeline/types.ts
@@ -2,6 +2,7 @@ import type { PipelineAction } from '@/lib/actions/types'
 import type { ResolveFailureKind, ResolveTarget } from '@/lib/ai'
 import type { DbCtx, StorySettings } from '@/lib/db'
 import type { Logger } from '@/lib/diagnostics'
+import type { EmbedderErrorKind } from '@/lib/embedder'
 import type { AppSettingsSnapshot, RunState } from '@/lib/stores'
 
 export type PipelineError =
@@ -22,6 +23,11 @@ export type PipelineError =
       phaseName: string
       detail?: string
     }
+  // The blocking pre-retrieval sync stage and the query embed beside it
+  // (model-management.md → Embed failure is blocking). Distinct from 'provider',
+  // whose retry story is the LLM's. `staleCount` is null when there is no
+  // magnitude to report — see RetrievalFailure in lib/retrieval.
+  | { kind: 'embedder'; reason: EmbedderErrorKind; detail: string; staleCount: number | null }
 
 export type PhaseResult =
   | { status: 'completed' }
@@ -71,6 +77,10 @@ export type PhaseContext = {
   // The run's db handle, so a phase can resolve tail positions (MAX(position)+1)
   // against committed rows rather than a possibly-gappy in-memory store.
   db: DbCtx['db']
+  // The run's transaction runner. Only the retrieval phase writes outside the
+  // delta log (its vec0 sync), and it takes the run's handle rather than the
+  // module global so a test's db and its writes cannot diverge.
+  runInTransaction: DbCtx['runInTransaction']
   // Run identity, so a per-turn phase can read the open story / branch stores
   // without the generationStore self-lookup the interim narrative phase used.
   storyId: string | null

--- a/lib/prompts/bundled/__snapshots__/memory-blocks.test.ts.snap
+++ b/lib/prompts/bundled/__snapshots__/memory-blocks.test.ts.snap
@@ -1,0 +1,44 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`memory-blocks macro — row content > matches the recorded snapshot with every block populated 1`] = `
+"# Elsewhere in the world
+
+[char_9] Old Sesk: A ferryman long dead.
+
+[char_2] Mira (currently elsewhere): A courier.
+
+# Relevant lore
+
+The Concord
+Signed at the river.
+
+Veilstone
+A shard of the old moon.
+
+# What has happened
+
+The bridge fell
+At dawn.
+Saw it happen
+
+# Active threads
+
+The siege
+Three weeks in.
+
+# Background threads
+
+The debt (pending)
+Unpaid.
+
+The ledger (failed)
+Still missing.
+
+# Earlier chapters
+
+The Long Road
+She left the capital.
+Departure.
+
+"
+`;

--- a/lib/prompts/bundled/__snapshots__/per-turn.test.ts.snap
+++ b/lib/prompts/bundled/__snapshots__/per-turn.test.ts.snap
@@ -32,3 +32,58 @@ After your narrative prose, append exactly one <state> block (never inside the p
 
 Omit any inner tag you have nothing to report for. Use only the IDs shown to you above, without brackets — never invent one. Only reference items and locations that already have an ID; if something is genuinely new, describe it in prose only and leave it out of the structured block. \`to\` or \`from\` may be omitted on a transfer when there's no specific known other party (e.g. found loose, spent on someone off-scene)."
 `;
+
+exports[`bundled per-turn template — empty-guard contract > matches the recorded snapshot with a retrieval pass behind it 1`] = `
+"# In scene
+
+## Aria [char_1]
+A wary scout.
+
+
+# Current location
+
+[loc_1] The Keep: A weathered hilltop fortress.
+
+# Elsewhere in the world
+
+[char_2] Mira (currently elsewhere): A courier.
+
+# Relevant lore
+
+Veilstone
+A shard of the old moon.
+
+# Active threads
+
+The siege
+Three weeks in.
+
+If any off-scene character above enters the scene, include their ID (without brackets) in the trailing <scene_entities> block.
+
+Use one of these place IDs (without brackets) for <current_location> when the scene is at that place: loc_1. Leave it out if the scene moves somewhere not listed above.
+
+# Story so far
+
+The gate groaned open.
+
+Aria stepped through.
+
+Write the next beat of the story as prose. Do not break character or address the reader.
+After your narrative prose, append exactly one <state> block (never inside the prose itself). Entities above are listed with an ID in brackets, e.g. "[c1] Kael" — reference that ID below WITHOUT the brackets:
+
+<state>
+  <scene_entities>comma-separated IDs of every character/item present in this scene</scene_entities>
+  <current_location>the ID of the current scene's location, if any</current_location>
+  <world_time_delta>seconds elapsed since the previous entry (0 for a flashback or memory; never negative)</world_time_delta>
+  <visual_changes>
+    <entity id="ID" type="physique | face | hair | eyes | attire | distinguishing">the FULL new value for that category — this replaces whatever was there before, not a partial edit</entity>
+  </visual_changes>
+  <transfers>
+    <item id="item ID" to="ID" from="ID" slot="equipped_items | inventory" />
+    <stackable key="lowercase name, e.g. gold" amount="quantity moved" to="ID" from="ID" />
+  </transfers>
+  <summary>one sentence summarizing what happened in this reply</summary>
+</state>
+
+Omit any inner tag you have nothing to report for. Use only the IDs shown to you above, without brackets — never invent one. Only reference items and locations that already have an ID; if something is genuinely new, describe it in prose only and leave it out of the structured block. \`to\` or \`from\` may be omitted on a transfer when there's no specific known other party (e.g. found loose, spent on someone off-scene)."
+`;

--- a/lib/prompts/bundled/index.ts
+++ b/lib/prompts/bundled/index.ts
@@ -1,5 +1,6 @@
 import { MACRO_IDS, TEMPLATE_IDS } from '../ids'
 import type { Pack } from '../types'
+import { MEMORY_BLOCKS } from './memory-blocks'
 import { OUTPUT_FORMAT_NARRATIVE } from './output-format'
 import { PER_TURN_NARRATIVE } from './per-turn'
 import { PERIODIC_CLASSIFIER } from './periodic-classifier'
@@ -30,6 +31,7 @@ export const bundledPack: Pack = {
     [TEMPLATE_IDS.wizardDescription]: { group: 'wizard', source: WIZARD_DESCRIPTION },
   },
   macros: {
+    [MACRO_IDS.memoryBlocks]: { group: 'staticContent', source: MEMORY_BLOCKS },
     [MACRO_IDS.outputFormatNarrative]: { group: 'staticContent', source: OUTPUT_FORMAT_NARRATIVE },
     [MACRO_IDS.stateEmission]: { group: 'staticContent', source: STATE_EMISSION },
     [MACRO_IDS.suggestionEmission]: { group: 'staticContent', source: SUGGESTION_EMISSION },

--- a/lib/prompts/bundled/memory-blocks.test.ts
+++ b/lib/prompts/bundled/memory-blocks.test.ts
@@ -1,0 +1,360 @@
+import { describe, expect, it } from 'vitest'
+
+import { countTokens, ENTITY_FRAMING, RANKER_DEFAULTS, type RetrievalType } from '@/lib/retrieval'
+
+import { createEngine } from '../engine'
+import { MACRO_IDS } from '../ids'
+import type { Pack } from '../types'
+import { MEMORY_BLOCKS } from './memory-blocks'
+
+function renderMacro(context: Record<string, unknown>): string {
+  const pack: Pack = {
+    templates: {
+      t: { group: 'generationContext', source: `{% include '${MACRO_IDS.memoryBlocks}' %}` },
+    },
+    macros: { [MACRO_IDS.memoryBlocks]: { group: 'staticContent', source: MEMORY_BLOCKS } },
+  }
+  return createEngine(pack).renderFileSync('t', context) as string
+}
+
+// Every bucket the macro reads, all empty. Spread-and-override so each test
+// populates exactly one and the rest stay provably absent.
+const EMPTY = {
+  structuralPinnedEntities: [],
+  structuralPinnedLore: [],
+  structuralPinnedThreads: [],
+  structuralActiveThreads: [],
+  retrievedEntities: [],
+  retrievedLore: [],
+  retrievedHappenings: [],
+  retrievedThreads: [],
+  retrievedChapters: [],
+  piggybackFires: true,
+}
+
+const ranked = (id: string, displayName: string, renderedText: string) => ({
+  id,
+  displayName,
+  renderedText,
+})
+
+const floorEntity = {
+  id: 'char_9',
+  kind: 'character',
+  status: 'retired',
+  name: 'Old Sesk',
+  description: 'A ferryman long dead.',
+}
+const floorLore = { id: 'lore_9', title: 'The Concord', body: 'Signed at the river.' }
+const floorThread = { id: 'thr_9', status: 'pending', title: 'The debt', description: 'Unpaid.' }
+
+describe('memory-blocks macro — empty-guard contract', () => {
+  it('renders nothing at all when every bucket is empty', () => {
+    expect(renderMacro(EMPTY).trim()).toBe('')
+    // Positive control: the same helper does produce a block when one bucket
+    // is populated, so the assertion above is not passing on a dead render.
+    expect(
+      renderMacro({ ...EMPTY, retrievedLore: [ranked('lore_1', 'Veilstone', 'x')] }),
+    ).toContain('# Relevant lore')
+  })
+
+  const blocks: [header: string, key: string, row: unknown][] = [
+    ['# Elsewhere in the world', 'structuralPinnedEntities', floorEntity],
+    ['# Elsewhere in the world', 'retrievedEntities', ranked('char_1', 'Mira', 'Mira: a courier.')],
+    ['# Relevant lore', 'structuralPinnedLore', floorLore],
+    ['# Relevant lore', 'retrievedLore', ranked('lore_1', 'Veilstone', 'Veilstone\nA shard.')],
+    [
+      '# What has happened',
+      'retrievedHappenings',
+      ranked('hap_1', 'The bridge fell', 'The bridge fell\nAt dawn.'),
+    ],
+    ['# Active threads', 'structuralActiveThreads', { ...floorThread, status: 'active' }],
+    ['# Background threads', 'structuralPinnedThreads', floorThread],
+    ['# Background threads', 'retrievedThreads', ranked('thr_1', 'The debt', 'The debt\nUnpaid.')],
+    [
+      '# Earlier chapters',
+      'retrievedChapters',
+      ranked('chap_1', 'The Long Road', 'She left the capital.\nDeparture.'),
+    ],
+  ]
+
+  it.each(blocks)('emits %s only when %s is populated', (header, key, row) => {
+    expect(renderMacro({ ...EMPTY, [key]: [row] })).toContain(header)
+    expect(renderMacro(EMPTY)).not.toContain(header)
+  })
+})
+
+describe('memory-blocks macro — row content', () => {
+  it('renders the ranked entity text the ranker measured, with its sub-pool framing', () => {
+    const out = renderMacro({
+      ...EMPTY,
+      retrievedEntities: [ranked('char_2', 'Mira', 'Mira (available to introduce): A courier.')],
+    })
+    expect(out).toContain('[char_2] Mira (available to introduce): A courier.')
+  })
+
+  it('brackets entity ids only when piggybackFires, and never on the other types', () => {
+    const context = {
+      ...EMPTY,
+      structuralPinnedEntities: [floorEntity],
+      retrievedEntities: [ranked('char_2', 'Mira', 'Mira: A courier.')],
+      retrievedLore: [ranked('lore_1', 'Veilstone', 'Veilstone\nA shard.')],
+      retrievedHappenings: [ranked('hap_1', 'Fall', 'Fall\nAt dawn.')],
+      retrievedThreads: [ranked('thr_1', 'Debt', 'Debt\nUnpaid.')],
+      retrievedChapters: [ranked('chap_1', 'Road', 'She left.\nDeparture.')],
+    }
+    const firing = renderMacro(context)
+    expect(firing).toContain('[char_2] Mira')
+    expect(firing).toContain('[char_9] Old Sesk')
+    for (const id of ['lore_1', 'hap_1', 'thr_1', 'chap_1']) expect(firing).not.toContain(id)
+
+    const quiet = renderMacro({ ...context, piggybackFires: false })
+    expect(quiet).not.toContain('[char_2]')
+    expect(quiet).not.toContain('[char_9]')
+    // Positive control: the rows themselves still render, only the ids drop.
+    expect(quiet).toContain('Mira: A courier.')
+    expect(quiet).toContain('Old Sesk')
+  })
+
+  it('carries no emission instructions — those belong to the including template', () => {
+    const out = renderMacro({
+      ...EMPTY,
+      structuralPinnedEntities: [floorEntity],
+      retrievedEntities: [ranked('char_2', 'Mira', 'Mira: A courier.')],
+    })
+    expect(out).not.toContain('<scene_entities>')
+    expect(out).not.toContain('<current_location>')
+    // Positive control: the rows the instructions would have referred to render.
+    expect(out).toContain('[char_2] Mira: A courier.')
+  })
+
+  it('renders happening awareness sources verbatim, newlines and all', () => {
+    const out = renderMacro({
+      ...EMPTY,
+      retrievedHappenings: [
+        ranked(
+          'hap_1',
+          'The bridge fell',
+          'The bridge fell\nAt dawn.\nSaw it happen\nHeard a rumor',
+        ),
+      ],
+    })
+    expect(out).toContain('The bridge fell\nAt dawn.\nSaw it happen\nHeard a rumor')
+  })
+
+  it('puts pinned and ranked lore under one header, pinned first', () => {
+    const out = renderMacro({
+      ...EMPTY,
+      structuralPinnedLore: [floorLore],
+      retrievedLore: [ranked('lore_1', 'Veilstone', 'Veilstone\nA shard.')],
+    })
+    expect(out.split('# Relevant lore')).toHaveLength(2)
+    expect(out.indexOf('The Concord')).toBeLessThan(out.indexOf('Veilstone'))
+    expect(out).toContain('Signed at the river.')
+  })
+
+  // Whole render, not substrings: the two row families differ in shape but not
+  // in framing, so they share one header the way lore's and threads' do — and a
+  // second header would still leave every substring assertion green.
+  it('puts pinned and ranked entities under one header, pinned first', () => {
+    const out = renderMacro({
+      ...EMPTY,
+      structuralPinnedEntities: [floorEntity],
+      retrievedEntities: [ranked('char_2', 'Mira', 'Mira (currently elsewhere): A courier.')],
+    })
+    expect(out).toBe(
+      '# Elsewhere in the world\n\n[char_9] Old Sesk: A ferryman long dead.\n\n[char_2] Mira (currently elsewhere): A courier.\n\n',
+    )
+  })
+
+  // A pinned row bypasses the ranker, so nothing pre-renders its sub-pool
+  // framing the way run.ts does for a candidate. Without it a pinned staged
+  // character reads as an existing off-scene figure rather than one the model
+  // may introduce.
+  it.each([
+    ['active', ENTITY_FRAMING.active],
+    ['staged', ENTITY_FRAMING.staged],
+  ])('frames a pinned %s entity the same way the ranker frames a candidate', (status, framing) => {
+    const out = renderMacro({
+      ...EMPTY,
+      structuralPinnedEntities: [{ ...floorEntity, status }],
+    })
+    expect(out).toContain(`[char_9] Old Sesk (${framing}): A ferryman long dead.`)
+  })
+
+  it('leaves a pinned retired entity unframed', () => {
+    const out = renderMacro({ ...EMPTY, structuralPinnedEntities: [floorEntity] })
+    expect(out).toContain('[char_9] Old Sesk: A ferryman long dead.')
+    expect(out).not.toContain('(')
+  })
+
+  it('puts pinned and ranked non-active threads under one header, pinned first', () => {
+    const out = renderMacro({
+      ...EMPTY,
+      structuralPinnedThreads: [floorThread],
+      retrievedThreads: [ranked('thr_1', 'The ledger', 'The ledger (failed)\nStill missing.')],
+    })
+    expect(out.split('# Background threads')).toHaveLength(2)
+    expect(out.indexOf('The debt')).toBeLessThan(out.indexOf('The ledger'))
+    expect(out).toContain('Still missing.')
+  })
+
+  // data-model.md → threads: "failed is distinct because lumping them together
+  // loses useful information". A header that says only "not active" lumps them,
+  // and a paid debt rendered like an open one has the model write the character
+  // still dodging it.
+  it.each(['pending', 'resolved', 'failed'])(
+    'marks a pinned %s thread with its status',
+    (status) => {
+      const out = renderMacro({ ...EMPTY, structuralPinnedThreads: [{ ...floorThread, status }] })
+      expect(out).toContain(`The debt (${status})`)
+    },
+  )
+
+  it('renders a chapter from its renderedText alone — the title rides inside it', () => {
+    const out = renderMacro({
+      ...EMPTY,
+      retrievedChapters: [
+        ranked('chap_1', 'The Long Road', 'The Long Road\nShe left the capital.\nDeparture.'),
+      ],
+    })
+    expect(out).toContain('The Long Road\nShe left the capital.\nDeparture.')
+    // The measured cost is countTokens(renderedText); a title on a `##` line
+    // outside it is length the type budget never charged for.
+    expect(out).not.toContain('##')
+  })
+
+  // per-turn.ts guards the identical case for structuralLocation. Every
+  // structural row is a raw column projection, so every nullable column needs
+  // the same guard or its separator ships without its value. Asserted as whole
+  // renders, not substrings: an unguarded newline separator is invisible to
+  // toContain, since the block's own trailer supplies an identical one.
+  const activeThread = { ...floorThread, status: 'active' }
+  const nullColumn: [key: string, populated: object, nulled: object, whole: string][] = [
+    [
+      'structuralPinnedEntities',
+      floorEntity,
+      { ...floorEntity, description: null },
+      '# Elsewhere in the world\n\n[char_9] Old Sesk\n\n',
+    ],
+    [
+      'structuralPinnedLore',
+      floorLore,
+      { ...floorLore, body: null },
+      '# Relevant lore\n\nThe Concord\n\n',
+    ],
+    [
+      'structuralPinnedThreads',
+      floorThread,
+      { ...floorThread, description: null },
+      '# Background threads\n\nThe debt (pending)\n\n',
+    ],
+    [
+      'structuralActiveThreads',
+      activeThread,
+      { ...activeThread, description: null },
+      '# Active threads\n\nThe debt\n\n',
+    ],
+  ]
+
+  it.each(nullColumn)(
+    'drops the separator when a %s row has a null column',
+    (key, populated, nulled, whole) => {
+      expect(renderMacro({ ...EMPTY, [key]: [nulled] })).toBe(whole)
+      // Positive control: the same row with the column filled does emit the
+      // separator, so the assertion above is not passing on a dead render.
+      expect(renderMacro({ ...EMPTY, [key]: [populated] })).not.toBe(whole)
+    },
+  )
+
+  it('matches the recorded snapshot with every block populated', () => {
+    expect(
+      renderMacro({
+        ...EMPTY,
+        structuralPinnedEntities: [floorEntity],
+        structuralPinnedLore: [floorLore],
+        structuralPinnedThreads: [floorThread],
+        structuralActiveThreads: [
+          { id: 'thr_8', status: 'active', title: 'The siege', description: 'Three weeks in.' },
+        ],
+        retrievedEntities: [ranked('char_2', 'Mira', 'Mira (currently elsewhere): A courier.')],
+        retrievedLore: [ranked('lore_1', 'Veilstone', 'Veilstone\nA shard of the old moon.')],
+        retrievedHappenings: [
+          ranked('hap_1', 'The bridge fell', 'The bridge fell\nAt dawn.\nSaw it happen'),
+        ],
+        retrievedThreads: [ranked('thr_1', 'The ledger', 'The ledger (failed)\nStill missing.')],
+        retrievedChapters: [
+          ranked('chap_1', 'The Long Road', 'The Long Road\nShe left the capital.\nDeparture.'),
+        ],
+      }),
+    ).toMatchSnapshot()
+  })
+
+  it('keeps active threads out of the non-active block', () => {
+    const out = renderMacro({
+      ...EMPTY,
+      structuralActiveThreads: [{ ...floorThread, status: 'active', title: 'The siege' }],
+    })
+    expect(out).toContain('# Active threads')
+    expect(out).toContain('The siege')
+    expect(out).not.toContain('# Background threads')
+  })
+})
+
+// retrieval.md → Token estimation: the ranker charges
+// countTokens(renderedText) + typeOverhead[type] for every row it seats, so
+// typeOverhead has to be this macro's own wrapping cost. Measured by rendering
+// exactly one row of the block with no content of its own and counting what is
+// left; a macro edit that changes the wrapper fails here until the constant
+// follows. What the one-row basis buys, and where it stops being conservative,
+// is recorded there too.
+const CONSTANT_PATH = 'lib/retrieval/constants.ts → RANKER_DEFAULTS.typeOverhead'
+
+const OVERHEAD_BUCKET: Record<RetrievalType, string> = {
+  entities: 'retrievedEntities',
+  lore: 'retrievedLore',
+  happenings: 'retrievedHappenings',
+  threads: 'retrievedThreads',
+  chapters: 'retrievedChapters',
+}
+
+// piggybackFires true is the costlier of the two shapes — it brackets an id
+// beside every entity row — and the ranker has no per-turn flag to branch on.
+// `c1` is the substituted-placeholder shape an id actually has at prompt time.
+// Entity placeholders are a single letter plus a counter (lib/ids/prefixes.ts →
+// PLACEHOLDER_PREFIX_BY_KIND) and every one up to three digits costs the same 4
+// tokens, so only a branch seating a four-digit id under-charges, by one.
+const PROBE_ROW = { id: 'c1', displayName: '', renderedText: '' }
+
+describe('per-type overhead constants', () => {
+  const types = Object.keys(OVERHEAD_BUCKET) as RetrievalType[]
+
+  it.each(types)('typeOverhead.%s is what the macro wrapper actually costs', (type) => {
+    const measured = countTokens(renderMacro({ ...EMPTY, [OVERHEAD_BUCKET[type]]: [PROBE_ROW] }))
+    // Guards the equality below against a macro that renders nothing: a
+    // zero-cost wrapper would let a zeroed constant pass silently.
+    expect(measured).toBeGreaterThan(0)
+    // Whoever trips this is editing a Liquid template and has no reason to know
+    // the constant exists, so the message has to name it and the new value.
+    expect(
+      RANKER_DEFAULTS.typeOverhead[type],
+      `The ${type} block's wrapper now costs ${measured} tokens. Set ${CONSTANT_PATH}.${type} to ${measured}.`,
+    ).toBe(measured)
+  })
+
+  // The overhead above is measured with displayName: '', so a block that starts
+  // rendering the title costs nothing on the probe row and everything in
+  // production — ~20 seated rows carrying an uncharged title overrun their
+  // partition, and the snapshot diff reads as an intentional "show lore titles".
+  // renderedText is the only field the ranker charges for; nothing else may vary
+  // the output length.
+  it.each(types)('%s rows render nothing whose length the ranker did not charge', (type) => {
+    const withRow = (displayName: string) =>
+      renderMacro({
+        ...EMPTY,
+        [OVERHEAD_BUCKET[type]]: [{ id: 'c1', displayName, renderedText: 'The body.' }],
+      })
+
+    expect(withRow('x'.repeat(200))).toBe(withRow('x'))
+  })
+})

--- a/lib/prompts/bundled/memory-blocks.ts
+++ b/lib/prompts/bundled/memory-blocks.ts
@@ -1,0 +1,57 @@
+export const MEMORY_BLOCKS = `{%- comment -%}
+Two row families, never one loop: ranked rows carry the exact renderedText the
+ranker measured the type budget against; structural-floor rows are raw column
+projections that bypass the ranker entirely. Wrapping a ranked row costs
+RANKER_DEFAULTS.typeOverhead once per ROW, which is why the <scene_entities>
+and <current_location> instructions live in the including template instead.
+Only the entity block brackets an id: <state> references entities and nothing
+else, so an id anywhere below invites a reference no parser resolves.
+{%- endcomment -%}
+{% if structuralPinnedEntities.size > 0 or retrievedEntities.size > 0 -%}
+# Elsewhere in the world
+{% for e in structuralPinnedEntities %}
+{% if piggybackFires %}[{{ e.id }}] {% endif %}{{ e.name }}{% if e.status == 'active' %} (currently elsewhere){% elsif e.status == 'staged' %} (available to introduce){% endif %}{% if e.description != blank %}: {{ e.description }}{% endif %}
+{% endfor %}
+{%- for e in retrievedEntities %}
+{% if piggybackFires %}[{{ e.id }}] {% endif %}{{ e.renderedText }}
+{% endfor %}
+{% endif -%}
+{% if structuralPinnedLore.size > 0 or retrievedLore.size > 0 -%}
+# Relevant lore
+{% for l in structuralPinnedLore %}
+{{ l.title }}{% if l.body != blank %}
+{{ l.body }}{% endif %}
+{% endfor %}
+{%- for l in retrievedLore %}
+{{ l.renderedText }}
+{% endfor %}
+{% endif -%}
+{% if retrievedHappenings.size > 0 -%}
+# What has happened
+{% for h in retrievedHappenings %}
+{{ h.renderedText }}
+{% endfor %}
+{% endif -%}
+{% if structuralActiveThreads.size > 0 -%}
+# Active threads
+{% for t in structuralActiveThreads %}
+{{ t.title }}{% if t.description != blank %}
+{{ t.description }}{% endif %}
+{% endfor %}
+{% endif -%}
+{% if structuralPinnedThreads.size > 0 or retrievedThreads.size > 0 -%}
+# Background threads
+{% for t in structuralPinnedThreads %}
+{{ t.title }} ({{ t.status }}){% if t.description != blank %}
+{{ t.description }}{% endif %}
+{% endfor %}
+{%- for t in retrievedThreads %}
+{{ t.renderedText }}
+{% endfor %}
+{% endif -%}
+{% if retrievedChapters.size > 0 -%}
+# Earlier chapters
+{% for c in retrievedChapters %}
+{{ c.renderedText }}
+{% endfor %}
+{% endif -%}`

--- a/lib/prompts/bundled/per-turn.test.ts
+++ b/lib/prompts/bundled/per-turn.test.ts
@@ -25,6 +25,21 @@ const m2Context = {
   entries: [{ content: 'The gate groaned open.' }, { content: 'Aria stepped through.' }],
   userSettings: { partialChapterBuffer: 10 },
   piggybackFires: true,
+  // Empty, not absent. buildGenerationContext emits every retrieval bucket on
+  // every call, so a fixture that omits them tests `nil.size > 0` — a
+  // comparison that is false for the wrong reason and lets a broken guard pass.
+  structuralLocation: null,
+  locationIds: [],
+  structuralSceneEntities: [],
+  structuralActiveThreads: [],
+  structuralPinnedEntities: [],
+  structuralPinnedLore: [],
+  structuralPinnedThreads: [],
+  retrievedEntities: [],
+  retrievedLore: [],
+  retrievedHappenings: [],
+  retrievedThreads: [],
+  retrievedChapters: [],
 }
 
 describe('bundled per-turn template — empty-guard contract', () => {
@@ -47,8 +62,97 @@ describe('bundled per-turn template — empty-guard contract', () => {
     expect(out).toMatchSnapshot()
   })
 
-  it('renders the staged-entities block with promotion instructions when a staged entity exists', () => {
-    const contextWithStaged = {
+  // The retrieval-fed shape: where the memory blocks sit relative to the scene,
+  // the location, and the ID instructions they are the referent for.
+  it('matches the recorded snapshot with a retrieval pass behind it', () => {
+    expect(
+      renderTemplate(TEMPLATE_IDS.perTurnNarrative, {
+        ...m2Context,
+        structuralLocation: {
+          id: 'loc_1',
+          kind: 'location',
+          status: 'active',
+          name: 'The Keep',
+          description: 'A weathered hilltop fortress.',
+        },
+        locationIds: ['loc_1'],
+        structuralActiveThreads: [
+          { id: 'thr_1', status: 'active', title: 'The siege', description: 'Three weeks in.' },
+        ],
+        retrievedEntities: [
+          {
+            id: 'char_2',
+            displayName: 'Mira',
+            renderedText: 'Mira (currently elsewhere): A courier.',
+          },
+        ],
+        retrievedLore: [
+          {
+            id: 'lore_1',
+            displayName: 'Veilstone',
+            renderedText: 'Veilstone\nA shard of the old moon.',
+          },
+        ],
+      }),
+    ).toMatchSnapshot()
+  })
+
+  // The ID instructions say "any off-scene character above" and "somewhere not
+  // listed above" — words that point at the memory blocks. Move the include
+  // below them and the prompt asks the model to look at something it has not
+  // been shown yet; scene-entity promotion and location selection degrade with
+  // no parse error, and the snapshot diff is a pure hunk move.
+  it('renders the memory blocks before the instructions that refer back to them', () => {
+    const withMemory = renderTemplate(TEMPLATE_IDS.perTurnNarrative, {
+      ...m2Context,
+      locationIds: ['loc_1'],
+      retrievedEntities: [
+        { id: 'char_2', displayName: 'Mira', renderedText: 'Mira (currently elsewhere).' },
+      ],
+    })
+
+    const blocks = withMemory.indexOf('# Elsewhere in the world')
+    expect(blocks).toBeGreaterThan(-1)
+    expect(blocks).toBeLessThan(withMemory.indexOf('off-scene character above'))
+    expect(blocks).toBeLessThan(withMemory.indexOf('not listed above'))
+  })
+
+  // The builder hands over an already-composed window (cadence.md → Composition
+  // rule), which partialChapterBuffer alone cannot reproduce: a template that
+  // re-trims by it sends the model less prose than the caller composed.
+  it('renders every entry it is handed, ignoring partialChapterBuffer', () => {
+    const rendered = renderTemplate(TEMPLATE_IDS.perTurnNarrative, {
+      ...m2Context,
+      userSettings: { partialChapterBuffer: 1 },
+      entries: [{ content: 'alpha-line' }, { content: 'beta-line' }, { content: 'gamma-line' }],
+    })
+    expect(rendered).toContain('alpha-line')
+    expect(rendered).toContain('beta-line')
+    expect(rendered).toContain('gamma-line')
+  })
+
+  it('renders a ranked off-scene entity with promotion instructions', () => {
+    const rendered = renderTemplate(TEMPLATE_IDS.perTurnNarrative, {
+      ...m2Context,
+      retrievedEntities: [
+        {
+          id: 'char_2',
+          displayName: 'Lord Eldrin',
+          renderedText: 'Lord Eldrin (available to introduce): An exiled noble.',
+        },
+      ],
+    })
+    expect(rendered).toContain('# Elsewhere in the world')
+    expect(rendered).toContain('[char_2] Lord Eldrin (available to introduce): An exiled noble.')
+    expect(rendered).toContain(
+      'include their ID (without brackets) in the trailing <scene_entities> block',
+    )
+  })
+
+  // The ranker owns off-scene entity spend now; a template that re-dumps the
+  // roster would send rows nothing measured against the entity budget.
+  it('does not dump the branch roster when nothing was retrieved', () => {
+    const rendered = renderTemplate(TEMPLATE_IDS.perTurnNarrative, {
       ...m2Context,
       entities: [
         ...m2Context.entities,
@@ -61,18 +165,33 @@ describe('bundled per-turn template — empty-guard contract', () => {
           injectionMode: 'auto',
         },
       ],
-    }
-    const rendered = renderTemplate(TEMPLATE_IDS.perTurnNarrative, contextWithStaged)
-    expect(rendered).toContain('# Staged characters (introduce when narratively appropriate)')
-    expect(rendered).toContain('- [char_2] Lord Eldrin: An exiled noble.')
-    expect(rendered).toContain(
-      'include their ID (without brackets) in the trailing <scene_entities> block',
-    )
+    })
+    expect(rendered).not.toContain('# Elsewhere in the world')
+    expect(rendered).not.toContain('Lord Eldrin')
+    // The instruction has no referent without the block, so it must go too.
+    expect(rendered).not.toContain('enters the scene, include their ID')
+    // Positive control against a wholly empty render.
+    expect(rendered).toContain('## Aria [char_1]')
   })
 
-  it('omits the staged-entities block when there are no staged entities', () => {
-    const rendered = renderTemplate(TEMPLATE_IDS.perTurnNarrative, m2Context)
-    expect(rendered).not.toContain('# Staged characters')
+  it('renders the pinned-entity block from the structural floor, not from the roster', () => {
+    const rendered = renderTemplate(TEMPLATE_IDS.perTurnNarrative, {
+      ...m2Context,
+      structuralPinnedEntities: [
+        {
+          id: 'char_3',
+          kind: 'character',
+          status: 'retired',
+          name: 'Old Sesk',
+          description: 'A ferryman long dead.',
+        },
+      ],
+    })
+    expect(rendered).toContain('# Elsewhere in the world')
+    expect(rendered).toContain('[char_3] Old Sesk: A ferryman long dead.')
+    // The bracketed id is meaningless without the instruction that explains it,
+    // and the pinned half of the guard is the only thing keeping it here.
+    expect(rendered).toContain('enters the scene, include their ID')
   })
 
   it('renders the calendar vocabulary section when calendarVocabulary is provided', () => {
@@ -95,8 +214,174 @@ describe('bundled per-turn template — empty-guard contract', () => {
     expect(rendered).not.toContain('# Calendar')
   })
 
-  it('renders active locations with bracketed IDs regardless of scene membership', () => {
-    const contextWithLocation = {
+  it('renders the current location from the structural floor, with its ID', () => {
+    const rendered = renderTemplate(TEMPLATE_IDS.perTurnNarrative, {
+      ...m2Context,
+      structuralLocation: {
+        id: 'loc_1',
+        kind: 'location',
+        status: 'active',
+        name: 'The Keep',
+        description: 'A weathered hilltop fortress.',
+      },
+      locationIds: ['loc_1'],
+    })
+    expect(rendered).toContain('# Current location')
+    expect(rendered).toContain('[loc_1] The Keep: A weathered hilltop fortress.')
+    expect(rendered).toContain('for <current_location> when the scene is at that place: loc_1.')
+  })
+
+  it('drops the colon on a current location with no description', () => {
+    const rendered = renderTemplate(TEMPLATE_IDS.perTurnNarrative, {
+      ...m2Context,
+      structuralLocation: { id: 'loc_2', kind: 'location', status: 'active', name: 'Old Mill' },
+    })
+    expect(rendered).toContain('[loc_2] Old Mill')
+    expect(rendered).not.toContain('[loc_2] Old Mill:')
+  })
+
+  // structuralLocation is null when the scene names a location that is staged,
+  // retired, or gone — guarding on it rather than on currentLocationId is what
+  // keeps a dangling header out (templateContextMap → structuralLocation).
+  it('omits the location block and its ID instruction when the floor seats none', () => {
+    const rendered = renderTemplate(TEMPLATE_IDS.perTurnNarrative, {
+      ...m2Context,
+      currentLocationId: 'loc_1',
+      structuralLocation: null,
+    })
+    expect(rendered).not.toContain('# Current location')
+    expect(rendered).not.toContain('<current_location> when the scene is at that place')
+    expect(rendered).toContain('## Aria [char_1]')
+  })
+
+  // The regression this pins: a ranked location renders with a bracketed ID, so
+  // the scene moving there has to be expressible. locationIds is what tells the
+  // template which of those IDs are places.
+  it('offers a ranked location as a <current_location> target', () => {
+    const rendered = renderTemplate(TEMPLATE_IDS.perTurnNarrative, {
+      ...m2Context,
+      structuralLocation: {
+        id: 'loc_1',
+        kind: 'location',
+        status: 'active',
+        name: 'The Keep',
+        description: 'A weathered hilltop fortress.',
+      },
+      retrievedEntities: [
+        {
+          id: 'loc_9',
+          displayName: 'The Market',
+          renderedText: 'The Market (currently elsewhere): Stalls under sailcloth.',
+        },
+      ],
+      locationIds: ['loc_1', 'loc_9'],
+    })
+    expect(rendered).toContain('[loc_9] The Market (currently elsewhere): Stalls under sailcloth.')
+    expect(rendered).toContain(
+      'for <current_location> when the scene is at that place: loc_1, loc_9.',
+    )
+  })
+
+  // RetrievedRow is { id, displayName, renderedText } — no EntityKind — so an
+  // instruction naming "the IDs above" would point <current_location> at an ID
+  // set that can be entirely characters, and nothing downstream kind-checks what
+  // comes back (lib/piggyback/apply.ts writes it through unvalidated).
+  it('drops the <current_location> instruction when no ranked entity is a place', () => {
+    const rendered = renderTemplate(TEMPLATE_IDS.perTurnNarrative, {
+      ...m2Context,
+      structuralLocation: null,
+      retrievedEntities: [
+        {
+          id: 'char_9',
+          displayName: 'Mira',
+          renderedText: 'Mira (currently elsewhere): A courier.',
+        },
+      ],
+      locationIds: [],
+    })
+    expect(rendered).not.toContain('# Current location')
+    expect(rendered).not.toContain('for <current_location> when the scene is at that place')
+    // Positive control: the ranked row and its own instruction still render, so
+    // the exclusion above is not passing on an empty block.
+    expect(rendered).toContain('[char_9] Mira (currently elsewhere): A courier.')
+    expect(rendered).toContain('enters the scene, include their ID')
+  })
+
+  // The classifier can name one entity as both in-scene and the location; the
+  // scene loop reads `entities` while the location block reads the floor, so
+  // without the de-dupe the same row renders under both headers.
+  it('renders an in-scene entity that is also the current location only once', () => {
+    const rendered = renderTemplate(TEMPLATE_IDS.perTurnNarrative, {
+      ...m2Context,
+      sceneEntities: ['char_1', 'loc_1'],
+      entities: [
+        ...m2Context.entities,
+        {
+          id: 'loc_1',
+          kind: 'location',
+          name: 'The Keep',
+          description: 'A weathered hilltop fortress.',
+          status: 'active',
+          injectionMode: 'auto',
+        },
+      ],
+      structuralLocation: {
+        id: 'loc_1',
+        kind: 'location',
+        status: 'active',
+        name: 'The Keep',
+        description: 'A weathered hilltop fortress.',
+      },
+    })
+    expect(rendered.split('The Keep')).toHaveLength(2)
+    expect(rendered).not.toContain('## The Keep')
+    // Positive control: the other in-scene row is untouched by the de-dupe.
+    expect(rendered).toContain('## Aria [char_1]')
+  })
+
+  it('keeps the # In scene block out entirely when the location is its only member', () => {
+    const rendered = renderTemplate(TEMPLATE_IDS.perTurnNarrative, {
+      ...m2Context,
+      sceneEntities: ['loc_1'],
+      entities: [
+        {
+          id: 'loc_1',
+          kind: 'location',
+          name: 'The Keep',
+          description: 'A weathered hilltop fortress.',
+          status: 'active',
+          injectionMode: 'auto',
+        },
+      ],
+      structuralLocation: {
+        id: 'loc_1',
+        kind: 'location',
+        status: 'active',
+        name: 'The Keep',
+        description: 'A weathered hilltop fortress.',
+      },
+    })
+    expect(rendered).not.toContain('# In scene')
+    // Positive control: the row itself still reaches the prompt, via the floor.
+    expect(rendered).toContain('[loc_1] The Keep: A weathered hilltop fortress.')
+  })
+
+  // A second row after the null-description one pins the blank line the guard
+  // removes; the block's own trailer would otherwise supply an identical one.
+  it('drops the description line on an in-scene entity that has none', () => {
+    const rendered = renderTemplate(TEMPLATE_IDS.perTurnNarrative, {
+      ...m2Context,
+      sceneEntities: ['char_1', 'char_2'],
+      entities: [
+        { ...m2Context.entities[0], description: null },
+        { ...m2Context.entities[0], id: 'char_2', name: 'Bex', description: 'A quiet smith.' },
+      ],
+    })
+    expect(rendered).toContain('## Aria [char_1]\n\n## Bex [char_2]\nA quiet smith.')
+  })
+
+  it('does not dump every active location — locations rank like any other entity', () => {
+    const rendered = renderTemplate(TEMPLATE_IDS.perTurnNarrative, {
       ...m2Context,
       entities: [
         ...m2Context.entities,
@@ -108,25 +393,10 @@ describe('bundled per-turn template — empty-guard contract', () => {
           status: 'active',
           injectionMode: 'auto',
         },
-        {
-          id: 'loc_2',
-          kind: 'location',
-          name: 'Old Mill',
-          status: 'active',
-          injectionMode: 'auto',
-        },
       ],
-    }
-    const rendered = renderTemplate(TEMPLATE_IDS.perTurnNarrative, contextWithLocation)
-    expect(rendered).toContain('# Known locations')
-    expect(rendered).toContain('- [loc_1] The Keep: A weathered hilltop fortress.')
-    expect(rendered).toContain('- [loc_2] Old Mill')
-    expect(rendered).not.toContain('- [loc_2] Old Mill:')
-  })
-
-  it('omits the known-locations block when there are no active locations', () => {
-    const rendered = renderTemplate(TEMPLATE_IDS.perTurnNarrative, m2Context)
-    expect(rendered).not.toContain('# Known locations')
+    })
+    expect(rendered).not.toContain('The Keep')
+    expect(rendered).toContain('## Aria [char_1]')
   })
 })
 
@@ -134,25 +404,21 @@ describe('bundled per-turn template — piggybackFires gating', () => {
   const contextWithEverything = {
     ...m2Context,
     piggybackFires: false,
-    entities: [
-      ...m2Context.entities,
+    retrievedEntities: [
       {
         id: 'char_2',
-        kind: 'character',
-        name: 'Lord Eldrin',
-        description: 'An exiled noble.',
-        status: 'staged',
-        injectionMode: 'auto',
-      },
-      {
-        id: 'loc_1',
-        kind: 'location',
-        name: 'The Keep',
-        description: 'A weathered hilltop fortress.',
-        status: 'active',
-        injectionMode: 'auto',
+        displayName: 'Lord Eldrin',
+        renderedText: 'Lord Eldrin (available to introduce): An exiled noble.',
       },
     ],
+    structuralLocation: {
+      id: 'loc_1',
+      kind: 'location',
+      status: 'active',
+      name: 'The Keep',
+      description: 'A weathered hilltop fortress.',
+    },
+    locationIds: ['loc_1'],
     calendarVocabulary: {
       baseUnitName: 'second',
       secondsPerBaseUnit: 1,
@@ -160,20 +426,20 @@ describe('bundled per-turn template — piggybackFires gating', () => {
     },
   }
 
-  it('keeps the staged/locations/calendar info sections but drops ID brackets, ID-usage instructions, and the state-emission macro when the fallback classifier will fire anyway', () => {
+  it('keeps the memory/location/calendar info sections but drops ID brackets, ID-usage instructions, and the state-emission macro when the fallback classifier will fire anyway', () => {
     const rendered = renderTemplate(TEMPLATE_IDS.perTurnNarrative, contextWithEverything)
     expect(rendered).toContain('## Aria')
     expect(rendered).not.toContain('## Aria [char_1]')
-    expect(rendered).toContain('# Staged characters')
-    expect(rendered).toContain('- Lord Eldrin: An exiled noble.')
+    expect(rendered).toContain('# Elsewhere in the world')
+    expect(rendered).toContain('Lord Eldrin (available to introduce): An exiled noble.')
     expect(rendered).not.toContain('[char_2]')
     expect(rendered).not.toContain(
       'include their ID (without brackets) in the trailing <scene_entities> block',
     )
-    expect(rendered).toContain('# Known locations')
-    expect(rendered).toContain('- The Keep: A weathered hilltop fortress.')
+    expect(rendered).toContain('# Current location')
+    expect(rendered).toContain('The Keep: A weathered hilltop fortress.')
     expect(rendered).not.toContain('[loc_1]')
-    expect(rendered).not.toContain('Use one of these IDs (without brackets) for <current_location>')
+    expect(rendered).not.toContain('for <current_location> when the scene is at that place')
     expect(rendered).toContain('# Calendar')
     expect(rendered).not.toContain('<world_time_delta>')
     expect(rendered).not.toContain('<state>')
@@ -185,8 +451,8 @@ describe('bundled per-turn template — piggybackFires gating', () => {
       piggybackFires: true,
     })
     expect(rendered).toContain('## Aria [char_1]')
-    expect(rendered).toContain('# Staged characters')
-    expect(rendered).toContain('# Known locations')
+    expect(rendered).toContain('[char_2] Lord Eldrin')
+    expect(rendered).toContain('[loc_1] The Keep')
     expect(rendered).toContain('# Calendar')
     expect(rendered).toContain('<state>')
   })

--- a/lib/prompts/bundled/per-turn.ts
+++ b/lib/prompts/bundled/per-turn.ts
@@ -1,7 +1,10 @@
 // `entities` use the drizzle row shape (camelCase: id/kind/name/description/
 // status/injectionMode). `sceneEntities` is the id array from entry metadata.
 // The scene loop is intentionally injectionMode-agnostic — that IS the
-// structural-floor invariant (active + in-scene always inject).
+// structural-floor invariant (active + in-scene always inject). It reads
+// `entities` rather than `structuralSceneEntities` so the invariant survives a
+// context built with no retrieval outcome — no retrieval phase ran ahead of the
+// render — where every floor bundle arrives empty.
 export const PER_TURN_NARRATIVE = `{% if definition.setting != blank -%}
 # Setting
 {{ definition.setting }}
@@ -17,43 +20,48 @@ export const PER_TURN_NARRATIVE = `{% if definition.setting != blank -%}
 {{ definition.tone.promptBody }}
 
 {% endif -%}
+{%- comment -%}
+The second half of the condition de-dupes the row the classifier named as both
+in-scene and the location; it is nil-safe, since a null structuralLocation
+makes the comparison "e.id != nil", which is true.
+{%- endcomment -%}
 {%- assign hasScene = false -%}
 {%- for e in entities | active -%}
-{%- if sceneEntities contains e.id -%}{%- assign hasScene = true -%}{%- endif -%}
+{%- if sceneEntities contains e.id and e.id != structuralLocation.id -%}{%- assign hasScene = true -%}{%- endif -%}
 {%- endfor -%}
 {% if hasScene -%}
 # In scene
 {% for e in entities | active -%}
-{%- if sceneEntities contains e.id %}
-## {{ e.name }}{% if piggybackFires %} [{{ e.id }}]{% endif %}
-{{ e.description }}
+{%- if sceneEntities contains e.id and e.id != structuralLocation.id %}
+## {{ e.name }}{% if piggybackFires %} [{{ e.id }}]{% endif %}{% if e.description != blank %}
+{{ e.description }}{% endif %}
 {% endif -%}
 {%- endfor %}
 
 {% endif -%}
-{%- assign stagedList = entities | staged -%}
-{% if stagedList.size > 0 -%}
-# Staged characters (introduce when narratively appropriate)
-{% for e in stagedList %}
-- {% if piggybackFires %}[{{ e.id }}] {% endif %}{{ e.name }}: {{ e.description }}
-{%- endfor %}
+{% if structuralLocation -%}
+# Current location
+
+{% if piggybackFires %}[{{ structuralLocation.id }}] {% endif %}{{ structuralLocation.name }}{% if structuralLocation.description != blank %}: {{ structuralLocation.description }}{% endif %}
+
+{% endif -%}
+{% include 'macro_memory_blocks' -%}
 {% if piggybackFires -%}
+{% if structuralPinnedEntities.size > 0 or retrievedEntities.size > 0 -%}
+If any off-scene character above enters the scene, include their ID (without brackets) in the trailing <scene_entities> block.
 
-If you introduce any staged character, include their ID (without brackets) in the trailing <scene_entities> block.
 {% endif -%}
+{%- comment -%}
+The ids are enumerated rather than referred to as "the IDs above": the memory
+blocks are kind-blind (RetrievedRow has no EntityKind), so pointing
+<current_location> at them would offer a set that can be all characters, and
+nothing downstream kind-checks what comes back. locationIds is the kind-filtered
+union the builder assembles for exactly this line.
+{%- endcomment -%}
+{% if locationIds.size > 0 -%}
+Use one of these place IDs (without brackets) for <current_location> when the scene is at that place: {{ locationIds | join: ', ' }}. Leave it out if the scene moves somewhere not listed above.
 
 {% endif -%}
-{%- assign locationList = entities | active | by_kind: 'location' -%}
-{% if locationList.size > 0 -%}
-# Known locations
-{% for e in locationList %}
-- {% if piggybackFires %}[{{ e.id }}] {% endif %}{{ e.name }}{% if e.description != blank %}: {{ e.description }}{% endif %}
-{%- endfor %}
-{% if piggybackFires -%}
-
-Use one of these IDs (without brackets) for <current_location> if the scene is at one of them; leave it out if the scene moves somewhere not listed here.
-{% endif -%}
-
 {% endif -%}
 {% if calendarVocabulary -%}
 # Calendar
@@ -61,8 +69,7 @@ This story tracks time in {{ calendarVocabulary.baseUnitName }}s ({{ calendarVoc
 
 {% endif -%}
 # Story so far
-{%- assign recentEntries = entries | recent: userSettings.partialChapterBuffer %}
-{% for entry in recentEntries %}
+{% for entry in entries %}
 {{ entry.content }}
 {% endfor %}
 {% include 'macro_output_format_narrative' %}

--- a/lib/prompts/bundled/structural-floor.test.ts
+++ b/lib/prompts/bundled/structural-floor.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { createEngine } from '../engine'
 import { MACRO_IDS } from '../ids'
 import type { Pack } from '../types'
+import { MEMORY_BLOCKS } from './memory-blocks'
 import { PER_TURN_NARRATIVE } from './per-turn'
 import { STATE_EMISSION } from './state-emission'
 import { SUGGESTION_EMISSION_JSON } from './suggestion-emission-json'
@@ -27,6 +28,19 @@ const context = {
   entities: [sceneEntity],
   sceneEntities: ['char_1'],
   entries: [{ content: 'The gate groaned open.' }],
+  // Empty, not absent — buildGenerationContext emits every bucket on every
+  // call, and `nil.size > 0` is false for a reason the guard does not own.
+  structuralLocation: null,
+  structuralSceneEntities: [],
+  structuralActiveThreads: [],
+  structuralPinnedEntities: [],
+  structuralPinnedLore: [],
+  structuralPinnedThreads: [],
+  retrievedEntities: [],
+  retrievedLore: [],
+  retrievedHappenings: [],
+  retrievedThreads: [],
+  retrievedChapters: [],
 }
 
 // Permanent negative fixture: a deliberately injectionMode-respecting scene
@@ -42,10 +56,13 @@ const BROKEN_PER_TURN = `# Characters in scene
 {% endif -%}
 {%- endfor %}`
 
-function render(source: string): string {
+function render(source: string, extra: Record<string, unknown> = {}): string {
   const pack: Pack = {
     templates: { t: { group: 'generationContext', source } },
     macros: {
+      // Real source, not a stub: the negative case below turns on this macro
+      // being the ONLY route a staged entity has into the prompt.
+      [MACRO_IDS.memoryBlocks]: { group: 'staticContent', source: MEMORY_BLOCKS },
       [MACRO_IDS.outputFormatNarrative]: { group: 'staticContent', source: 'FMT' },
       [MACRO_IDS.stateEmission]: { group: 'staticContent', source: STATE_EMISSION },
       // suggestion-refresh includes this unconditionally (its whole purpose is
@@ -57,7 +74,7 @@ function render(source: string): string {
       },
     },
   }
-  return createEngine(pack).renderFileSync('t', context) as string
+  return createEngine(pack).renderFileSync('t', { ...context, ...extra }) as string
 }
 
 // The invariant check, factored so both fixtures run the identical assertion.
@@ -78,5 +95,41 @@ describe('structural-floor invariant — active + in-scene always inject', () =>
 
   it('permanent negative fixture: an injectionMode-respecting variant DROPS it', () => {
     expect(injectsSceneEntity(BROKEN_PER_TURN)).toBe(false)
+  })
+})
+
+// The floor's counterpart: what is NOT structural has to earn its seat, and the
+// ranker's bundle is a staged entity's only route into the prompt.
+describe('non-structural rows reach the prompt only by winning budget', () => {
+  const stagedEntity = {
+    id: 'char_2',
+    kind: 'character',
+    name: 'Mira',
+    description: 'A courier who owes the guild.',
+    status: 'staged',
+    injectionMode: 'auto',
+  }
+
+  it('does not dump a staged entity that only the branch roster knows about', () => {
+    const out = render(PER_TURN_NARRATIVE, { entities: [sceneEntity, stagedEntity] })
+    expect(out).not.toContain('Mira')
+    // Positive control: an empty render would satisfy the line above just as
+    // well, so pin something the same render must still carry.
+    expect(out).toContain('## Aria')
+  })
+
+  it('renders a staged entity that WON budget, with its sub-pool framing', () => {
+    const out = render(PER_TURN_NARRATIVE, {
+      entities: [sceneEntity, stagedEntity],
+      retrievedEntities: [
+        {
+          id: 'char_2',
+          displayName: 'Mira',
+          renderedText: 'Mira (available to introduce): A courier who owes the guild.',
+        },
+      ],
+    })
+    expect(out).toContain('# Elsewhere in the world')
+    expect(out).toContain('Mira (available to introduce): A courier who owes the guild.')
   })
 })

--- a/lib/prompts/bundled/suggestion-refresh.ts
+++ b/lib/prompts/bundled/suggestion-refresh.ts
@@ -31,8 +31,7 @@ export const SUGGESTION_REFRESH = `{% if definition.setting != blank -%}
 
 {% endif -%}
 # Story so far
-{%- assign recentEntries = entries | recent: userSettings.partialChapterBuffer %}
-{% for entry in recentEntries %}
+{% for entry in entries %}
 {{ entry.content }}
 {% endfor %}
 {%- comment -%}

--- a/lib/prompts/ids.ts
+++ b/lib/prompts/ids.ts
@@ -15,6 +15,7 @@ export const TEMPLATE_IDS = {
 } as const
 
 export const MACRO_IDS = {
+  memoryBlocks: 'macro_memory_blocks',
   outputFormatNarrative: 'macro_output_format_narrative',
   stateEmission: 'macro_state_emission',
   suggestionEmission: 'macro_suggestion_emission',

--- a/lib/prompts/templateContextMap.test.ts
+++ b/lib/prompts/templateContextMap.test.ts
@@ -1,7 +1,38 @@
 import { describe, expect, it } from 'vitest'
 
 import { TEMPLATE_IDS } from './ids'
-import { TEMPLATE_GROUPS, validateRegistry } from './templateContextMap'
+import {
+  DISPLAY_GROUPS,
+  TEMPLATE_GROUPS,
+  VARIABLES,
+  validateRegistry,
+  type VariableDef,
+} from './templateContextMap'
+
+const ALL_VARIABLES = Object.values(VARIABLES).flat()
+
+// validateRegistry only walks display groups toward variables, leaving both
+// reverse directions unchecked: a defined variable in no group, and a
+// `category` naming no group. DISPLAY_GROUPS and `category` are two
+// hand-maintained copies of one grouping with nothing tying them together.
+const ungroupedNames = (defs: readonly VariableDef[]) => {
+  const grouped = new Set(Object.values(DISPLAY_GROUPS).flat())
+  return defs.filter((v) => !grouped.has(v.name)).map((v) => v.name)
+}
+
+const strayCategories = (defs: readonly VariableDef[]) => {
+  const groups = new Set(Object.keys(DISPLAY_GROUPS))
+  return defs.filter((v) => !groups.has(v.category)).map((v) => `${v.name} -> ${v.category}`)
+}
+
+// Positive control for both checks above: one variable that is wrong in both
+// directions at once, so neither assertion can pass by finding nothing to look at.
+const GHOST: VariableDef = {
+  name: 'ghostVariable',
+  type: 'string',
+  category: 'Bogus Group That Does Not Exist',
+  description: 'Defined nowhere, grouped nowhere.',
+}
 
 describe('templateContextMap', () => {
   it('maps every shipped template id to a group', () => {
@@ -17,6 +48,16 @@ describe('templateContextMap', () => {
   it('reports an unmapped template id', () => {
     const issues = validateRegistry([...Object.values(TEMPLATE_IDS), 'tmpl_ghost'])
     expect(issues).toContainEqual({ kind: 'unmapped-template', id: 'tmpl_ghost' })
+  })
+
+  it('surfaces every defined variable in some display group', () => {
+    expect(ungroupedNames(ALL_VARIABLES)).toEqual([])
+    expect(ungroupedNames([GHOST])).toEqual(['ghostVariable'])
+  })
+
+  it('gives every variable a category that names a display group', () => {
+    expect(strayCategories(ALL_VARIABLES)).toEqual([])
+    expect(strayCategories([GHOST])).toEqual(['ghostVariable -> Bogus Group That Does Not Exist'])
   })
 
   it('reports a dangling display variable', () => {

--- a/lib/prompts/templateContextMap.ts
+++ b/lib/prompts/templateContextMap.ts
@@ -5,12 +5,13 @@ import type { ContextGroup } from './types'
 export type VariableDef = {
   name: string
   type: string
+  /** Must name a DISPLAY_GROUPS key; untyped, so a test carries the tie. */
   category: string
   description: string
   required?: boolean
 }
 
-// Pinned M2 variable names per group. buildGenerationContext must emit these
+// Pinned variable names per group. buildGenerationContext must emit these
 // exact names — parity-tested in lib/pipeline/definitions/generation-context.test.ts.
 // Entity fields follow the drizzle row shape (camelCase).
 export const VARIABLES: Record<ContextGroup, VariableDef[]> = {
@@ -20,7 +21,7 @@ export const VARIABLES: Record<ContextGroup, VariableDef[]> = {
       type: 'Entry[]',
       category: 'Story',
       description:
-        'Caller-scoped entry window (per-turn: the open partial chapter); system entries excluded. Window with `recent`.',
+        'Prompt buffer, already composed to the two-mode window plus protectedBuffer spillover; system entries excluded. Render it whole.',
       required: true,
     },
     {
@@ -35,6 +36,13 @@ export const VARIABLES: Record<ContextGroup, VariableDef[]> = {
       type: 'string[]',
       category: 'Entities',
       description: 'Entity ids present in the current scene.',
+      required: true,
+    },
+    {
+      name: 'currentLocationId',
+      type: 'string | null',
+      category: 'Entities',
+      description: 'Entity id of the current scene location; null when the scene has none.',
       required: true,
     },
     {
@@ -56,8 +64,105 @@ export const VARIABLES: Record<ContextGroup, VariableDef[]> = {
       name: 'userSettings',
       type: 'object',
       category: 'Story Config',
-      description: 'Operational knobs exposed to templates (partialChapterBuffer).',
+      description:
+        'Buffer knobs the composed `entries` window was built from (fullChapterInBuffer, partialChapterBuffer, protectedBuffer) — informational, not a re-windowing instruction.',
       required: false,
+    },
+    {
+      name: 'retrievedEntities',
+      type: 'RetrievedRow[]',
+      category: 'Retrieval',
+      description:
+        'Off-scene entities the ranker seated this turn, as { id, displayName, renderedText }. Empty when nothing scored or no retrieval ran.',
+      required: true,
+    },
+    {
+      name: 'retrievedLore',
+      type: 'RetrievedRow[]',
+      category: 'Retrieval',
+      description:
+        'Lore rows the ranker seated this turn; same row shape as retrievedEntities. Empty when nothing scored or no retrieval ran.',
+      required: true,
+    },
+    {
+      name: 'retrievedHappenings',
+      type: 'RetrievedRow[]',
+      category: 'Retrieval',
+      description:
+        'Happenings the ranker seated this turn; renderedText carries the awareness sources verbatim. Empty when nothing scored or no retrieval ran.',
+      required: true,
+    },
+    {
+      name: 'retrievedThreads',
+      type: 'RetrievedRow[]',
+      category: 'Retrieval',
+      description:
+        'Non-active threads the ranker seated this turn; active ones are structural (structuralActiveThreads). Empty when nothing scored or no retrieval ran.',
+      required: true,
+    },
+    {
+      name: 'retrievedChapters',
+      type: 'RetrievedRow[]',
+      category: 'Retrieval',
+      description:
+        'Closed-chapter summaries the ranker seated this turn. Empty when nothing scored or no retrieval ran.',
+      required: true,
+    },
+    {
+      name: 'structuralSceneEntities',
+      type: 'FloorEntity[]',
+      category: 'Retrieval',
+      description:
+        'Active in-scene entities as { id, kind, status, name, description }, EXCLUDING the one that is the current location — that row is routed to structuralLocation instead. Injected unconditionally; injection mode is deliberately ignored. Empty when the scene names none, or no retrieval ran.',
+      required: true,
+    },
+    {
+      name: 'structuralLocation',
+      type: 'FloorEntity | null',
+      category: 'Retrieval',
+      description:
+        'The ACTIVE entity for currentLocationId, same row shape as structuralSceneEntities. Null both when the scene names no location and when it names one that is staged, retired, or absent from the branch — so guard the location block on this variable, never on currentLocationId. Null when no retrieval ran.',
+      required: true,
+    },
+    {
+      name: 'locationIds',
+      type: 'string[]',
+      category: 'Retrieval',
+      description:
+        'Every id above that belongs to a place — the legal <current_location> set. Union of the floor scene rows, structuralLocation, the pinned entities and the ranked entities, kind-filtered and de-duplicated, in the order those blocks render. Use this rather than "the IDs above": ranked entity rows arrive as RetrievedRow with no kind, so the bracketed IDs in the memory blocks can be entirely characters. Empty when the prompt shows no place, or no retrieval ran.',
+      required: true,
+    },
+    {
+      name: 'structuralActiveThreads',
+      type: 'FloorThread[]',
+      category: 'Retrieval',
+      description:
+        'Threads at status `active`, seated by the structural floor rather than ranked, as { id, status, title, description }. Empty when the branch has none, or no retrieval ran.',
+      required: true,
+    },
+    {
+      name: 'structuralPinnedEntities',
+      type: 'FloorEntity[]',
+      category: 'Retrieval',
+      description:
+        'Entities the user pinned with injection mode `always`, minus any already seated elsewhere in the floor. Empty when nothing is pinned, or no retrieval ran.',
+      required: true,
+    },
+    {
+      name: 'structuralPinnedLore',
+      type: 'FloorLore[]',
+      category: 'Retrieval',
+      description:
+        'Lore pinned with injection mode `always`, as { id, title, body } — `title` and `body`, not `name` and `description`. Empty when nothing is pinned, or no retrieval ran.',
+      required: true,
+    },
+    {
+      name: 'structuralPinnedThreads',
+      type: 'FloorThread[]',
+      category: 'Retrieval',
+      description:
+        'Threads pinned with injection mode `always`, beyond the active ones. Empty when nothing is pinned, or no retrieval ran.',
+      required: true,
     },
     {
       name: 'intermediates',
@@ -187,8 +292,23 @@ export const TEMPLATE_GROUPS: Record<string, ContextGroup> & Record<TemplateId, 
 // UI-level grouping name -> variable names it surfaces. A name that matches
 // no defined variable is "dangling" and reported by validateRegistry.
 export const DISPLAY_GROUPS: Record<string, string[]> = {
-  Story: ['entries'],
-  Entities: ['entities', 'sceneEntities', 'leadName', 'leadEntityId'],
+  Story: ['entries', 'turns'],
+  Entities: ['entities', 'sceneEntities', 'currentLocationId', 'leadName', 'leadEntityId'],
+  Plot: ['happenings'],
+  Retrieval: [
+    'retrievedEntities',
+    'retrievedLore',
+    'retrievedHappenings',
+    'retrievedThreads',
+    'retrievedChapters',
+    'structuralSceneEntities',
+    'structuralLocation',
+    'locationIds',
+    'structuralActiveThreads',
+    'structuralPinnedEntities',
+    'structuralPinnedLore',
+    'structuralPinnedThreads',
+  ],
   'Story Config': [
     'definition',
     'calendarVocabulary',

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -41,8 +41,10 @@
     "generationStatusPill": {
       "phase": {
         "reasoning": "reasoning…",
+        "recallingMemory": "recalling memory…",
         "generatingNarrative": "generating narrative…",
         "classifying": "classifying…",
+        "updatingMemory": "updating memory…",
         "closingChapter": "closing chapter…",
         "refreshingSuggestions": "refreshing suggestions…"
       },

--- a/locales/en/reader.json
+++ b/locales/en/reader.json
@@ -64,9 +64,12 @@
     "assignProfile": "Assign profile",
     "fixProfile": "Fix profile",
     "fixDefault": "Fix default",
+    "switchEmbedder": "Switch embedder",
     "failureMessage": "Generation failed. Retry to try again.",
+    "blockedDetail": "blocked by another operation ({{reason}})",
     "failure": {
       "llmCall": "LLM call failed.",
+      "embed": "The embedder failed, so memory retrieval couldn't run.",
       "noProfileAssigned": "The narrative agent has no profile assigned.",
       "profileMissing": "The narrative agent's assigned profile is missing.",
       "providerMissing": "The narrative model's provider is missing."
@@ -77,6 +80,7 @@
     "redo": "Redo",
     "nothingToUndo": "Nothing to undo.",
     "nothingToRedo": "Nothing to redo.",
-    "blockedWhileGenerating": "Unavailable while generating."
+    "blockedWhileGenerating": "Unavailable while generating.",
+    "blockedWhileSwapping": "Unavailable while the embedder switch finishes."
   }
 }

--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -52,6 +52,10 @@ const BUILD_OUTPUTS = [
       'constants',
       'types',
       'assets',
+      // Bundled, not read at runtime: lib/i18n imports the JSON directly, so a
+      // copy-only edit changes the bundle while touching no source directory
+      // above — the one input class that could go stale reading as fresh.
+      'locales',
       ...ROOT_BUILD_INPUTS,
     ],
     rebuild: 'pnpm build:web',


### PR DESCRIPTION
Upper half of **Slice 3.4 — Retrieval**, stacked on #422.

> **Base is `slice/m3.4-retrieval-base`, not `main`.** Review #422 first — the diff here is only the 79 files that sit above the retrieval substrate. Merge #422, then this.

Together the two PRs reproduce `slice/m3.4-retrieval` byte-for-byte: 60 + 79 = 139 files, zero overlap, and this branch's tree is identical to the original branch's tree.

## What's here

- **`lib/pipeline/**`** — the per-turn retrieval phase and its working set, the pre-retrieval sync barrier, the awareness bump dispatch span
- **`lib/prompts/**`** — the memory-blocks macro, retrieval bundles and the composed buffer in the generation context, staged and location rows now ranking
- **`lib/actions/**`** — delta-logged `retrieval_count` bump on injected awareness, atomic turn/embedder admission, the embedder-swap wiring
- **`lib/abort.ts`** — `boundedSignal`, lifted to a shared module
- **Reader surfaces** — the retrieval-labelled generation status pill, the embedder sync-failure surface with its `Switch embedder` route (C8), the open-region token-progress strip
- **`e2e/**`** — retrieval populating vec0 and injecting a bundle, blocking-embed failure and recovery, plus the existing specs reconciled with blocking retrieval

## Why the split

The original branch was 139 files, past CodeRabbit's 100-file review cap. The split follows the module layering rather than the commit history, so each PR is the *final* state of one layer instead of "the feature" plus "25 commits of fixes to it".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added retrieval-powered memory context for narrative generation, including relevant entities, lore, happenings, threads, and chapters.
  - Added chapter progress tracking for open-region content.
  - Added memory recall and update statuses with localized labels.
  - Added embedder failure details and a recovery path through Memory Settings.

- **Bug Fixes**
  - Improved generation-status display so errors remain visible during background activity.
  - Prevented conflicting actions while memory updates or embedding swaps are in progress.
  - Improved retry and undo behavior after retrieval or embedding failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->