### PR TITLE
Classifier: a bad field no longer costs the whole world update

### DIFF
--- a/src/lib/components/story/ActionInput.svelte
+++ b/src/lib/components/story/ActionInput.svelte
@@ -642,6 +642,17 @@
             messageId: narrationEntry.id,
             result: event.result,
           })
+          // A world update that failed used to be indistinguishable from a turn that
+          // changed nothing: same empty result, no error, no toast. Say it happened —
+          // the alternative is the player noticing a missing location three turns later.
+          if (event.result._error) {
+            console.error('[ActionInput] World update failed:', event.result._error)
+            ui.showToast(
+              'The world update failed for this response. Some or all changes were not ' +
+                'applied — you can regenerate the response to try again.',
+              'warning',
+            )
+          }
           await story.applyClassificationResult(event.result, narrationEntry.id)
           await story.updateEntryTimeEnd(narrationEntry.id)
 

--- a/src/lib/services/ai/generation/ClassifierService.ts
+++ b/src/lib/services/ai/generation/ClassifierService.ts
@@ -31,8 +31,13 @@ import {
   clampNumber,
   type ClassificationResult,
 } from '../sdk/schemas/classifier'
-import { buildExtendedClassificationSchema } from '../sdk/schemas/runtime-variables'
+import {
+  buildExtendedClassificationSchema,
+  salvageClassification,
+} from '../sdk/schemas/runtime-variables'
 import type { RuntimeVariable, RuntimeEntityType } from '$lib/services/packs/types'
+import { NoObjectGeneratedError } from 'ai'
+import { jsonrepair } from 'jsonrepair'
 
 const log = createLogger('Classifier')
 
@@ -180,25 +185,77 @@ export class ClassifierService extends BaseAIService {
       return result
     } catch (error) {
       log('classify failed', error)
-      // Return empty result on failure
-      return {
-        entryUpdates: {
-          characterUpdates: [],
-          locationUpdates: [],
-          itemUpdates: [],
-          storyBeatUpdates: [],
-          newCharacters: [],
-          newLocations: [],
-          newItems: [],
-          newStoryBeats: [],
-        },
-        scene: {
-          currentLocationName: null,
-          presentCharacterNames: [],
-          timeProgression: 'none',
-        },
-      }
+      return this.recover(error, runtimeVars, runtimeVarsByType)
     }
+  }
+
+  /**
+   * Turn a failed classification into whatever of it is still usable.
+   *
+   * The response is one object holding eight arrays and the scene, and validation is
+   * all-or-nothing: a single malformed entity used to cost the whole turn's world update
+   * — every character, location, item, beat and the time progression with it — silently.
+   * When the SDK rejected the object it kept the text that produced it, so the elements
+   * that were fine are still there to be read back.
+   */
+  private recover(
+    error: unknown,
+    runtimeVars: RuntimeVariable[],
+    runtimeVarsByType: Record<string, RuntimeVariable[]>,
+  ): ClassificationResult {
+    const empty: ClassificationResult = {
+      entryUpdates: {
+        characterUpdates: [],
+        locationUpdates: [],
+        itemUpdates: [],
+        storyBeatUpdates: [],
+        newCharacters: [],
+        newLocations: [],
+        newItems: [],
+        newStoryBeats: [],
+      },
+      scene: {
+        currentLocationName: null,
+        presentCharacterNames: [],
+        timeProgression: 'none',
+      },
+      _error: error instanceof Error ? error.message : String(error),
+    }
+
+    // Only a schema/parse rejection carries the model's text. A transport failure, an
+    // abort or a 401 has nothing to salvage from.
+    if (!NoObjectGeneratedError.isInstance(error) || !error.text) return empty
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(jsonrepair(error.text))
+    } catch (parseError) {
+      log('classify salvage: response is not recoverable JSON', parseError)
+      return empty
+    }
+
+    const salvaged = salvageClassification(parsed, runtimeVarsByType)
+    if (!salvaged) return empty
+
+    if (runtimeVars.length > 0) {
+      this.clampRuntimeVarNumbers(salvaged, runtimeVarsByType)
+      salvaged._runtimeVarDefs = runtimeVars
+    }
+    salvaged._error = empty._error
+
+    log('classify salvaged a partial result', {
+      characterUpdates: salvaged.entryUpdates.characterUpdates.length,
+      newCharacters: salvaged.entryUpdates.newCharacters.length,
+      locationUpdates: salvaged.entryUpdates.locationUpdates.length,
+      newLocations: salvaged.entryUpdates.newLocations.length,
+      itemUpdates: salvaged.entryUpdates.itemUpdates.length,
+      newItems: salvaged.entryUpdates.newItems.length,
+      storyBeatUpdates: salvaged.entryUpdates.storyBeatUpdates.length,
+      newStoryBeats: salvaged.entryUpdates.newStoryBeats.length,
+      timeProgression: salvaged.scene.timeProgression,
+    })
+
+    return salvaged
   }
 
   /**
@@ -255,9 +312,11 @@ export class ClassifierService extends BaseAIService {
           parts.push('text')
         }
 
-        // Required vs optional
+        // Nothing here is required by the schema (see buildEntityVarsShape); a variable
+        // with no default is merely the one worth naming, since there is no sensible
+        // value to fall back on when the model leaves it out.
         parts.push(
-          v.defaultValue !== undefined && v.defaultValue !== null ? 'optional' : 'required',
+          v.defaultValue !== undefined && v.defaultValue !== null ? 'optional' : 'set if known',
         )
 
         // Default value

--- a/src/lib/services/ai/generation/ClassifierService.ts
+++ b/src/lib/services/ai/generation/ClassifierService.ts
@@ -226,6 +226,10 @@ export class ClassifierService extends BaseAIService {
     // abort or a 401 has nothing to salvage from.
     if (!NoObjectGeneratedError.isInstance(error) || !error.text) return empty
 
+    // Repaired again here rather than trusting the text to be clean: `createJsonExtractMiddleware`
+    // already extracts and repairs on the way through, but it swallows its own failure and hands
+    // the original text on, so the one case that reaches this line is the one it could not fix.
+    // A repair that succeeds where it failed costs a parse; the alternative is losing the turn.
     let parsed: unknown
     try {
       parsed = JSON.parse(jsonrepair(error.text))

--- a/src/lib/services/ai/sdk/schemas/classifier.ts
+++ b/src/lib/services/ai/sdk/schemas/classifier.ts
@@ -226,4 +226,15 @@ export type Scene = z.infer<typeof sceneSchema>
 export type ClassificationResult = z.infer<typeof classificationResultSchema> & {
   /** Internal metadata: runtime variable definitions for use by applyClassificationResult. Not LLM output. */
   _runtimeVarDefs?: RuntimeVariable[]
+  /**
+   * Internal metadata: why this result is thinner than the model's output, if it is.
+   * Not LLM output.
+   *
+   * An empty classification and a failed one are the same object, and the difference
+   * matters to the user — "nothing happened this turn" and "the world update was thrown
+   * away" look identical in the world panel. Set by ClassifierService when the response
+   * failed validation, so the UI can say so instead of leaving the player to notice a
+   * missing location three turns later.
+   */
+  _error?: string
 }

--- a/src/lib/services/ai/sdk/schemas/runtime-variables.test.ts
+++ b/src/lib/services/ai/sdk/schemas/runtime-variables.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+import * as z from 'zod'
+import type { RuntimeVariable } from '$lib/services/packs/types'
+import { buildExtendedClassificationSchema, salvageClassification } from './runtime-variables'
+
+function variable(overrides: Partial<RuntimeVariable> & Pick<RuntimeVariable, 'variableName'>) {
+  return {
+    id: overrides.variableName,
+    packId: 'pack',
+    entityType: 'character',
+    displayName: overrides.variableName,
+    variableType: 'number',
+    color: '#fff',
+    pinned: false,
+    sortOrder: 0,
+    createdAt: 0,
+    ...overrides,
+  } as RuntimeVariable
+}
+
+/** A well-formed response, matching what the classifier is asked to produce. */
+function response() {
+  return {
+    entryUpdates: {
+      characterUpdates: [{ name: 'Accompanying Knight', changes: { health: 80 } }],
+      newCharacters: [{ name: 'Man at The Drunken Dragon', status: 'active', health: 100 }],
+      newLocations: [{ name: 'Blackwood', visited: true, current: true }],
+      newItems: [{ name: 'Letter from Peter', quantity: 1, location: 'inventory' }],
+      newStoryBeats: [{ title: 'Restore the forge', type: 'quest', status: 'active' }],
+    },
+    scene: {
+      currentLocationName: 'Blackwood',
+      presentCharacterNames: ['Kaelen Voss'],
+      timeProgression: 'minutes',
+    },
+  }
+}
+
+describe('buildExtendedClassificationSchema', () => {
+  const health = variable({ variableName: 'health', entityType: 'character', maxValue: 100 })
+  const danger = variable({ variableName: 'danger_level', entityType: 'location', maxValue: 10 })
+
+  it('accepts inline runtime variables on updates and new entities', () => {
+    const schema = buildExtendedClassificationSchema({ character: [health] }) as z.ZodType
+    const parsed = schema.parse(response()) as ReturnType<typeof response>
+
+    expect(parsed.entryUpdates.characterUpdates[0].changes).toEqual({ health: 80 })
+    expect(parsed.entryUpdates.newCharacters[0]).toMatchObject({ health: 100 })
+  })
+
+  // A variable with no defaultValue used to be a required field on every new entity of
+  // its type, so one the model left out threw away the whole turn's world update.
+  it('does not require a variable the model omitted on a new entity', () => {
+    const schema = buildExtendedClassificationSchema({
+      character: [health],
+      location: [danger],
+    }) as z.ZodType
+
+    const result = schema.safeParse(response())
+
+    expect(result.success).toBe(true)
+    const parsed = result.data as ReturnType<typeof response>
+    expect(parsed.entryUpdates.newLocations[0].name).toBe('Blackwood')
+    expect(parsed.entryUpdates.newCharacters[0]).toMatchObject({ health: 100 })
+  })
+
+  it('still rejects a wrongly typed variable, so salvage can drop that element alone', () => {
+    const schema = buildExtendedClassificationSchema({ character: [health] }) as z.ZodType
+    const bad = response()
+    ;(bad.entryUpdates.newCharacters[0] as Record<string, unknown>).health = 'full'
+
+    expect(schema.safeParse(bad).success).toBe(false)
+  })
+})
+
+describe('salvageClassification', () => {
+  const health = variable({ variableName: 'health', entityType: 'character', maxValue: 100 })
+
+  it('keeps the elements that validate and drops only the ones that do not', () => {
+    const raw = response()
+    // Invalid: `type` is not one of the story beat types.
+    raw.entryUpdates.newStoryBeats.push({
+      title: 'Find the Legendary Blade',
+      type: 'objective',
+      status: 'active',
+    })
+
+    const salvaged = salvageClassification(raw, { character: [health] })
+
+    expect(salvaged).not.toBeNull()
+    expect(salvaged!.entryUpdates.newLocations).toHaveLength(1)
+    expect(salvaged!.entryUpdates.newItems).toHaveLength(1)
+    expect(salvaged!.entryUpdates.newCharacters).toHaveLength(1)
+    expect(salvaged!.entryUpdates.newStoryBeats.map((b) => b.title)).toEqual(['Restore the forge'])
+    expect(salvaged!.scene.timeProgression).toBe('minutes')
+    expect(salvaged!.scene.currentLocationName).toBe('Blackwood')
+  })
+
+  it('fills the arrays the model omitted entirely', () => {
+    const salvaged = salvageClassification(response(), {})
+
+    expect(salvaged!.entryUpdates.locationUpdates).toEqual([])
+    expect(salvaged!.entryUpdates.itemUpdates).toEqual([])
+    expect(salvaged!.entryUpdates.storyBeatUpdates).toEqual([])
+  })
+
+  // A bad timeProgression must not cost the current location: the scene's three fields
+  // are independent claims, like the arrays around them.
+  it('salvages the scene field by field', () => {
+    const raw = response()
+    ;(raw.scene as Record<string, unknown>).timeProgression = 'a while'
+
+    const salvaged = salvageClassification(raw, {})
+
+    expect(salvaged!.scene.currentLocationName).toBe('Blackwood')
+    expect(salvaged!.scene.presentCharacterNames).toEqual(['Kaelen Voss'])
+    expect(salvaged!.scene.timeProgression).toBe('none')
+  })
+
+  // An empty result and a failed one are the same object, so the caller has to be able
+  // to tell "salvaged nothing" from "salvaged an empty turn".
+  it('returns null when there is nothing to salvage', () => {
+    expect(salvageClassification(null, {})).toBeNull()
+    expect(salvageClassification('not an object', {})).toBeNull()
+    expect(salvageClassification({ entryUpdates: {}, scene: {} }, {})).toBeNull()
+  })
+})

--- a/src/lib/services/ai/sdk/schemas/runtime-variables.test.ts
+++ b/src/lib/services/ai/sdk/schemas/runtime-variables.test.ts
@@ -117,11 +117,86 @@ describe('salvageClassification', () => {
     expect(salvaged!.scene.timeProgression).toBe('none')
   })
 
+  // `timeProgression` carries .default('none'), so an omitted one parses successfully with
+  // undefined as its input. Reading the input back instead of the parse result put undefined
+  // in the field and left the emptiness check below unable to see an empty scene.
+  it("defaults an omitted timeProgression to 'none' when the scene fails for another reason", () => {
+    const raw = response()
+    const scene = raw.scene as Record<string, unknown>
+    scene.currentLocationName = 42
+    delete scene.timeProgression
+
+    const salvaged = salvageClassification(raw, {})
+
+    expect(salvaged!.scene.timeProgression).toBe('none')
+    expect(salvaged!.scene.currentLocationName).toBeNull()
+  })
+
+  it('reports nothing to salvage for an empty turn whose scene also failed to parse', () => {
+    const raw = {
+      entryUpdates: {},
+      // Invalid, so the scene takes the field-by-field path with nothing in it to keep.
+      scene: { currentLocationName: 42, presentCharacterNames: 'Kaelen' },
+    }
+
+    expect(salvageClassification(raw, {})).toBeNull()
+  })
+
   // An empty result and a failed one are the same object, so the caller has to be able
   // to tell "salvaged nothing" from "salvaged an empty turn".
   it('returns null when there is nothing to salvage', () => {
     expect(salvageClassification(null, {})).toBeNull()
     expect(salvageClassification('not an object', {})).toBeNull()
     expect(salvageClassification({ entryUpdates: {}, scene: {} }, {})).toBeNull()
+  })
+})
+
+// A runtime variable value is the one part of an element that is recoverable by design —
+// that is the whole reason they are optional — so a bad one must cost the value, not the
+// entity carrying it.
+describe('salvageClassification — a bad variable value', () => {
+  const health = variable({ variableName: 'health', entityType: 'character', maxValue: 100 })
+  const morale = variable({ variableName: 'morale', entityType: 'character', maxValue: 10 })
+
+  it('keeps the new entity and its other variables, dropping only the bad value', () => {
+    const raw = response()
+    raw.entryUpdates.newCharacters = [
+      { name: 'Man at The Drunken Dragon', status: 'active', health: 'full', morale: 7 } as never,
+    ]
+
+    const salvaged = salvageClassification(raw, { character: [health, morale] })
+
+    const [character] = salvaged!.entryUpdates.newCharacters as unknown as Record<string, unknown>[]
+    expect(character.name).toBe('Man at The Drunken Dragon')
+    expect(character.status).toBe('active')
+    expect(character.morale).toBe(7)
+    expect(character).not.toHaveProperty('health')
+  })
+
+  it('keeps an update whose native changes survive the bad value', () => {
+    const raw = response()
+    raw.entryUpdates.characterUpdates = [
+      { name: 'Accompanying Knight', changes: { status: 'inactive', health: 'full' } } as never,
+    ]
+
+    const salvaged = salvageClassification(raw, { character: [health] })
+
+    const [update] = salvaged!.entryUpdates.characterUpdates
+    expect(update.name).toBe('Accompanying Knight')
+    expect(update.changes.status).toBe('inactive')
+    expect(update.changes).not.toHaveProperty('health')
+  })
+
+  // Applying it would write no column but still copy the entity onto the current branch,
+  // since the COW runs before the update rather than after it.
+  it('drops an update left holding nothing but the name it addresses', () => {
+    const raw = response()
+    raw.entryUpdates.characterUpdates = [
+      { name: 'Accompanying Knight', changes: { health: 'full' } } as never,
+    ]
+
+    const salvaged = salvageClassification(raw, { character: [health] })
+
+    expect(salvaged!.entryUpdates.characterUpdates).toEqual([])
   })
 })

--- a/src/lib/services/ai/sdk/schemas/runtime-variables.test.ts
+++ b/src/lib/services/ai/sdk/schemas/runtime-variables.test.ts
@@ -64,6 +64,30 @@ describe('buildExtendedClassificationSchema', () => {
     expect(parsed.entryUpdates.newCharacters[0]).toMatchObject({ health: 100 })
   })
 
+  // Nothing stops a pack from calling a variable `status`, and `.extend()` lets the last
+  // shape win — so without a guard the variable would decide what the entity's own field
+  // means, and its value would be written into the native column.
+  it('lets the native field win over a variable that shares its name', () => {
+    const status = variable({
+      variableName: 'status',
+      entityType: 'character',
+      variableType: 'text',
+    })
+    const schema = buildExtendedClassificationSchema({ character: [status] }) as z.ZodType
+
+    // 'wounded' is a valid value for the pack's text variable, but not for the native enum.
+    const raw = response()
+    raw.entryUpdates.newCharacters = [
+      { name: 'Man at The Drunken Dragon', status: 'wounded' } as never,
+    ]
+    expect(schema.safeParse(raw).success).toBe(false)
+
+    raw.entryUpdates.characterUpdates = [
+      { name: 'Accompanying Knight', changes: { status: 'wounded' } } as never,
+    ]
+    expect(schema.safeParse(raw).success).toBe(false)
+  })
+
   it('still rejects a wrongly typed variable, so salvage can drop that element alone', () => {
     const schema = buildExtendedClassificationSchema({ character: [health] }) as z.ZodType
     const bad = response()
@@ -176,14 +200,18 @@ describe('salvageClassification — a bad variable value', () => {
   it('keeps an update whose native changes survive the bad value', () => {
     const raw = response()
     raw.entryUpdates.characterUpdates = [
-      { name: 'Accompanying Knight', changes: { status: 'inactive', health: 'full' } } as never,
+      {
+        name: 'Accompanying Knight',
+        changes: { status: 'inactive', health: 'full', morale: 7 },
+      } as never,
     ]
 
-    const salvaged = salvageClassification(raw, { character: [health] })
+    const salvaged = salvageClassification(raw, { character: [health, morale] })
 
     const [update] = salvaged!.entryUpdates.characterUpdates
     expect(update.name).toBe('Accompanying Knight')
     expect(update.changes.status).toBe('inactive')
+    expect((update.changes as Record<string, unknown>).morale).toBe(7)
     expect(update.changes).not.toHaveProperty('health')
   })
 

--- a/src/lib/services/ai/sdk/schemas/runtime-variables.ts
+++ b/src/lib/services/ai/sdk/schemas/runtime-variables.ts
@@ -177,6 +177,33 @@ interface ElementSchemas {
 }
 
 /**
+ * Drop the variables whose name is already a field of the entity, or return null if that
+ * leaves nothing.
+ *
+ * Nothing stops a pack author from calling a variable `status` or `description` — the name
+ * rule is only `^[a-z_][a-z0-9_]*$` — and `.extend()` lets the last shape win, so the
+ * variable would quietly replace the native field's schema. The classifier would then be
+ * told that `status` means the pack's enum, and `applyClassificationResult` would write
+ * whatever came back into the native column: `changes.status` is applied verbatim.
+ *
+ * The native contract wins because it is the one the rest of the app is written against.
+ * The variable is not lost — it is still described in the prompt by
+ * `buildCustomVarInstructions`, and `extractInlineCustomVars` still stores a value under it —
+ * it just no longer decides what the native field means.
+ */
+function withoutNativeFields(
+  varsShape: z.ZodRawShape,
+  native: z.ZodObject<z.ZodRawShape>,
+): Record<string, z.ZodType> | null {
+  const nativeFields = new Set(Object.keys(native.shape))
+  const kept: Record<string, z.ZodType> = {}
+  for (const [name, schema] of Object.entries(varsShape)) {
+    if (!nativeFields.has(name)) kept[name] = schema as z.ZodType
+  }
+  return Object.keys(kept).length > 0 ? kept : null
+}
+
+/**
  * Build the per-array *element* schema for every `entryUpdates` field, with runtime
  * variable fields added INLINE (not nested under a `customVars` object):
  *
@@ -198,36 +225,31 @@ function buildEntryUpdateElementSchemas(
     const varsShape = vars ? buildEntityVarsShape(vars) : null
     const baseUpdate = BASE_UPDATE_SCHEMAS[entityType]
     const baseNew = BASE_NEW_SCHEMAS[entityType]
-
-    if (!varsShape) {
-      elements[fields.updates] = {
-        full: baseUpdate,
-        native: baseUpdate,
-        vars: null,
-        varsAt: 'changes',
-      }
-      elements[fields.new] = { full: baseNew, native: baseNew, vars: null, varsAt: 'root' }
-      continue
-    }
-
     const originalChanges = (baseUpdate.shape as Record<string, z.ZodTypeAny>).changes
-    const extendedUpdate =
-      originalChanges instanceof z.ZodObject
-        ? baseUpdate.extend({ changes: originalChanges.extend(varsShape) })
-        : baseUpdate
-    elements[fields.updates] = {
-      full: extendedUpdate,
-      native: baseUpdate,
-      // Nothing to put back if the update schema had no `changes` object to extend.
-      vars: extendedUpdate === baseUpdate ? null : (varsShape as Record<string, z.ZodType>),
-      varsAt: 'changes',
-    }
-    elements[fields.new] = {
-      full: baseNew.extend(varsShape),
-      native: baseNew,
-      vars: varsShape as Record<string, z.ZodType>,
-      varsAt: 'root',
-    }
+
+    // Each container keeps its own surviving shape: `status` is a native field on an update's
+    // `changes` but not on a new entity, so the same variable can be legal in one and not the
+    // other.
+    const newVars = varsShape ? withoutNativeFields(varsShape, baseNew) : null
+    const changesVars =
+      varsShape && originalChanges instanceof z.ZodObject
+        ? withoutNativeFields(varsShape, originalChanges)
+        : null
+
+    elements[fields.updates] = changesVars
+      ? {
+          full: baseUpdate.extend({
+            changes: (originalChanges as z.ZodObject<z.ZodRawShape>).extend(changesVars),
+          }),
+          native: baseUpdate,
+          vars: changesVars,
+          varsAt: 'changes',
+        }
+      : { full: baseUpdate, native: baseUpdate, vars: null, varsAt: 'changes' }
+
+    elements[fields.new] = newVars
+      ? { full: baseNew.extend(newVars), native: baseNew, vars: newVars, varsAt: 'root' }
+      : { full: baseNew, native: baseNew, vars: null, varsAt: 'root' }
   }
 
   return elements

--- a/src/lib/services/ai/sdk/schemas/runtime-variables.ts
+++ b/src/lib/services/ai/sdk/schemas/runtime-variables.ts
@@ -9,7 +9,8 @@
  * - Runtime vars are added as INLINE fields (not nested under `customVars`)
  * - Single-element enums use z.literal() directly (z.union crashes with <2 items)
  * - Number min/max are included in .describe() for LLM guidance; clamped post-extraction
- * - Variables with defaultValue are marked .optional() in the schema
+ * - Every variable is .optional(), on new entities as much as on updates -- see
+ *   buildEntityVarsShape for why a required one costs the whole classification
  * - The LLM sees variableName as the key, but stored values are keyed by defId
  */
 
@@ -26,6 +27,8 @@ import {
   storyBeatUpdateSchema,
   newStoryBeatSchema,
   sceneSchema,
+  type ClassificationResult,
+  type Scene,
 } from './classifier'
 
 // ============================================================================
@@ -88,16 +91,6 @@ function buildVariableBaseSchema(def: RuntimeVariable): z.ZodType {
   }
 }
 
-/**
- * Build a Zod schema for a single runtime variable definition.
- * Variables with a defaultValue are marked .optional().
- */
-export function buildVariableSchema(def: RuntimeVariable): z.ZodTypeAny {
-  const base = buildVariableBaseSchema(def)
-  const hasDefault = def.defaultValue !== undefined && def.defaultValue !== null
-  return hasDefault ? base.optional() : base
-}
-
 // ============================================================================
 // Entity Variable Shape Builder
 // ============================================================================
@@ -106,25 +99,22 @@ export function buildVariableSchema(def: RuntimeVariable): z.ZodTypeAny {
  * Build a Zod shape (Record of field schemas) for runtime variables of one entity type.
  * Returns null if no variables.
  *
- * @param variables - runtime variables
- * @param allOptional - true for update schemas (only include changed fields),
- *                      false for new entity schemas (required fields stay required)
+ * **Every variable is optional, on new entities as much as on updates.** A variable
+ * without a `defaultValue` used to be a required field on every new entity of its type,
+ * which made one forgotten field cost the whole turn: validation is all-or-nothing, so
+ * a missing `danger_level` on a new location threw away the characters, the items, the
+ * story beats and the time progression alongside it. A missing value is recoverable —
+ * `mergeRuntimeVars` fills the default at apply time, and the entity keeps whatever it
+ * already had — so there is nothing here worth failing a classification over.
  */
-export function buildEntityVarsShape(
-  variables: RuntimeVariable[],
-  allOptional: boolean,
-): z.ZodRawShape | null {
+export function buildEntityVarsShape(variables: RuntimeVariable[]): z.ZodRawShape | null {
   if (variables.length === 0) return null
 
   // Built as a mutable Record: Zod 4's ZodRawShape is Readonly and can't be
   // assembled by index assignment.
   const shape: Record<string, z.ZodType> = {}
   for (const def of variables) {
-    // For updates: all vars optional (only send what changed)
-    // For new entities: respect defaultValue-based optionality
-    shape[def.variableName] = allOptional
-      ? buildVariableBaseSchema(def).optional()
-      : buildVariableSchema(def)
+    shape[def.variableName] = buildVariableBaseSchema(def).optional()
   }
 
   return shape
@@ -161,13 +151,51 @@ const BASE_NEW_SCHEMAS: Record<RuntimeEntityType, z.ZodObject<z.ZodRawShape>> = 
   story_beat: newStoryBeatSchema as unknown as z.ZodObject<z.ZodRawShape>,
 }
 
+const ENTITY_TYPES: RuntimeEntityType[] = ['character', 'location', 'item', 'story_beat']
+
+/**
+ * Build the per-array *element* schema for every `entryUpdates` field, with runtime
+ * variable fields added INLINE (not nested under a `customVars` object):
+ *
+ * - Update schemas get var fields added directly inside their `changes` object
+ * - New entity schemas get var fields added at the top level
+ *
+ * Elements rather than arrays, because both the strict schema sent to the provider and
+ * the salvage pass below need to talk about one entity at a time — the salvage pass
+ * exists precisely to keep the elements that validate when a sibling does not.
+ */
+function buildEntryUpdateElementSchemas(
+  runtimeVarsByEntityType: Record<string, RuntimeVariable[]>,
+): Record<string, z.ZodType> {
+  const elements: Record<string, z.ZodType> = {}
+
+  for (const entityType of ENTITY_TYPES) {
+    const fields = ENTITY_TYPE_TO_SCHEMA_FIELDS[entityType]
+    const vars = runtimeVarsByEntityType[entityType]
+    const varsShape = vars ? buildEntityVarsShape(vars) : null
+    const baseUpdate = BASE_UPDATE_SCHEMAS[entityType]
+    const baseNew = BASE_NEW_SCHEMAS[entityType]
+
+    if (!varsShape) {
+      elements[fields.updates] = baseUpdate
+      elements[fields.new] = baseNew
+      continue
+    }
+
+    const originalChanges = (baseUpdate.shape as Record<string, z.ZodTypeAny>).changes
+    elements[fields.updates] =
+      originalChanges instanceof z.ZodObject
+        ? baseUpdate.extend({ changes: originalChanges.extend(varsShape) })
+        : baseUpdate
+    elements[fields.new] = baseNew.extend(varsShape)
+  }
+
+  return elements
+}
+
 /**
  * Build an extended classification schema that includes runtime variable fields
- * INLINE on entity update/new schemas (not nested under a `customVars` object).
- *
- * For each entity type with runtime variables:
- * - Update schemas get var fields added directly inside their `changes` object (all optional)
- * - New entity schemas get var fields added at the top level (with default-based optionality)
+ * INLINE on entity update/new schemas.
  *
  * If no runtime variables exist for any entity type, returns the base schema unchanged.
  */
@@ -184,43 +212,96 @@ export function buildExtendedClassificationSchema(
     return classificationResultSchema
   }
 
-  // Build extended sub-schemas for each entity type with variables
+  const elements = buildEntryUpdateElementSchemas(runtimeVarsByEntityType)
   const entryUpdatesShape: Record<string, z.ZodTypeAny> = {}
-
-  for (const entityType of ['character', 'location', 'item', 'story_beat'] as RuntimeEntityType[]) {
-    const fields = ENTITY_TYPE_TO_SCHEMA_FIELDS[entityType]
-    const vars = runtimeVarsByEntityType[entityType]
-    const updateVarsShape = vars ? buildEntityVarsShape(vars, true) : null
-    const newVarsShape = vars ? buildEntityVarsShape(vars, false) : null
-
-    if (updateVarsShape) {
-      // Extend the update schema: add var fields directly inside `changes`
-      const baseUpdate = BASE_UPDATE_SCHEMAS[entityType]
-      const originalChanges = (baseUpdate.shape as Record<string, z.ZodTypeAny>).changes
-
-      if (originalChanges && originalChanges instanceof z.ZodObject) {
-        const extendedChanges = originalChanges.extend(updateVarsShape)
-        const extendedUpdate = baseUpdate.extend({ changes: extendedChanges })
-        entryUpdatesShape[fields.updates] = z.array(extendedUpdate).default([])
-      } else {
-        entryUpdatesShape[fields.updates] = z.array(baseUpdate).default([])
-      }
-
-      // Extend the new entity schema: add var fields at top level
-      const baseNew = BASE_NEW_SCHEMAS[entityType]
-      const extendedNew = baseNew.extend(newVarsShape!)
-      entryUpdatesShape[fields.new] = z.array(extendedNew).default([])
-    } else {
-      // No variables for this entity type: use base schemas
-      entryUpdatesShape[fields.updates] = z.array(BASE_UPDATE_SCHEMAS[entityType]).default([])
-      entryUpdatesShape[fields.new] = z.array(BASE_NEW_SCHEMAS[entityType]).default([])
-    }
+  for (const [field, element] of Object.entries(elements)) {
+    entryUpdatesShape[field] = z.array(element).default([])
   }
 
   return z.object({
     entryUpdates: z.object(entryUpdatesShape),
     scene: sceneSchema,
   })
+}
+
+// ============================================================================
+// Salvage
+// ============================================================================
+
+/**
+ * Rebuild a classification result from model output that failed whole-object validation,
+ * keeping every element that validates on its own.
+ *
+ * Schema validation is all-or-nothing, and the classifier's schema is one object holding
+ * eight arrays plus the scene: one malformed story beat used to cost the characters, the
+ * locations, the items and the time progression too, silently. Nothing about those arrays
+ * makes them interdependent, so there is no reason a bad element should take its siblings
+ * with it.
+ *
+ * Returns null when the input yields nothing at all — an empty result and a failed one are
+ * the same object, and only the caller can tell them apart, so it must not be handed the
+ * empty one by mistake.
+ */
+export function salvageClassification(
+  raw: unknown,
+  runtimeVarsByEntityType: Record<string, RuntimeVariable[]>,
+): ClassificationResult | null {
+  if (typeof raw !== 'object' || raw === null) return null
+
+  const root = raw as Record<string, unknown>
+  const rawEntryUpdates =
+    typeof root.entryUpdates === 'object' && root.entryUpdates !== null
+      ? (root.entryUpdates as Record<string, unknown>)
+      : {}
+
+  const elements = buildEntryUpdateElementSchemas(runtimeVarsByEntityType)
+  const entryUpdates: Record<string, unknown[]> = {}
+  let salvagedCount = 0
+
+  for (const [field, element] of Object.entries(elements)) {
+    const value = rawEntryUpdates[field]
+    const kept = Array.isArray(value)
+      ? value.flatMap((item) => {
+          const parsed = element.safeParse(item)
+          return parsed.success ? [parsed.data] : []
+        })
+      : []
+    salvagedCount += kept.length
+    entryUpdates[field] = kept
+  }
+
+  // The scene is three independent claims, so it is salvaged field by field for the same
+  // reason. A bad `timeProgression` must not cost the current location.
+  const rawScene =
+    typeof root.scene === 'object' && root.scene !== null
+      ? (root.scene as Record<string, unknown>)
+      : {}
+  const scene = sceneSchema.safeParse(rawScene)
+  const salvagedScene: Scene = scene.success
+    ? scene.data
+    : {
+        currentLocationName:
+          typeof rawScene.currentLocationName === 'string' ? rawScene.currentLocationName : null,
+        presentCharacterNames: Array.isArray(rawScene.presentCharacterNames)
+          ? rawScene.presentCharacterNames.filter((n): n is string => typeof n === 'string')
+          : [],
+        timeProgression: sceneSchema.shape.timeProgression.safeParse(rawScene.timeProgression)
+          .success
+          ? (rawScene.timeProgression as Scene['timeProgression'])
+          : 'none',
+      }
+
+  const sceneIsEmpty =
+    !salvagedScene.currentLocationName &&
+    salvagedScene.presentCharacterNames.length === 0 &&
+    salvagedScene.timeProgression === 'none'
+
+  if (salvagedCount === 0 && sceneIsEmpty) return null
+
+  return {
+    entryUpdates: entryUpdates as unknown as ClassificationResult['entryUpdates'],
+    scene: salvagedScene,
+  }
 }
 
 /**

--- a/src/lib/services/ai/sdk/schemas/runtime-variables.ts
+++ b/src/lib/services/ai/sdk/schemas/runtime-variables.ts
@@ -103,9 +103,14 @@ function buildVariableBaseSchema(def: RuntimeVariable): z.ZodType {
  * without a `defaultValue` used to be a required field on every new entity of its type,
  * which made one forgotten field cost the whole turn: validation is all-or-nothing, so
  * a missing `danger_level` on a new location threw away the characters, the items, the
- * story beats and the time progression alongside it. A missing value is recoverable —
- * `mergeRuntimeVars` fills the default at apply time, and the entity keeps whatever it
- * already had — so there is nothing here worth failing a classification over.
+ * story beats and the time progression alongside it.
+ *
+ * What a missing value actually costs is small and local. On an update, `mergeRuntimeVars`
+ * only merges what the model sent, so the entity keeps the value it already had. On a new
+ * entity there is nothing to keep: no creation path writes `defaultValue` into
+ * `metadata.runtimeVars`, so the variable stays unset and `RuntimeVariableDisplay` shows it
+ * as "Not set" until a later turn or a manual edit fills it in. One unset variable against
+ * the entire turn's world state is not a trade worth making.
  */
 export function buildEntityVarsShape(variables: RuntimeVariable[]): z.ZodRawShape | null {
   if (variables.length === 0) return null
@@ -154,6 +159,24 @@ const BASE_NEW_SCHEMAS: Record<RuntimeEntityType, z.ZodObject<z.ZodRawShape>> = 
 const ENTITY_TYPES: RuntimeEntityType[] = ['character', 'location', 'item', 'story_beat']
 
 /**
+ * One `entryUpdates` array's element, in the three forms salvage needs to take it apart.
+ */
+interface ElementSchemas {
+  /** Native fields plus the runtime variables: what the provider is held to. */
+  full: z.ZodType
+  /**
+   * The native fields alone. Salvage falls back to this when `full` rejects an element,
+   * because a variable value the model got wrong is not a reason to lose the entity.
+   * Identical to `full` when the entity type has no variables.
+   */
+  native: z.ZodType
+  /** Per-variable schemas, so salvage can put back the ones that are individually fine. */
+  vars: Record<string, z.ZodType> | null
+  /** Variables sit at the top level on a new entity and inside `changes` on an update. */
+  varsAt: 'root' | 'changes'
+}
+
+/**
  * Build the per-array *element* schema for every `entryUpdates` field, with runtime
  * variable fields added INLINE (not nested under a `customVars` object):
  *
@@ -166,8 +189,8 @@ const ENTITY_TYPES: RuntimeEntityType[] = ['character', 'location', 'item', 'sto
  */
 function buildEntryUpdateElementSchemas(
   runtimeVarsByEntityType: Record<string, RuntimeVariable[]>,
-): Record<string, z.ZodType> {
-  const elements: Record<string, z.ZodType> = {}
+): Record<string, ElementSchemas> {
+  const elements: Record<string, ElementSchemas> = {}
 
   for (const entityType of ENTITY_TYPES) {
     const fields = ENTITY_TYPE_TO_SCHEMA_FIELDS[entityType]
@@ -177,17 +200,34 @@ function buildEntryUpdateElementSchemas(
     const baseNew = BASE_NEW_SCHEMAS[entityType]
 
     if (!varsShape) {
-      elements[fields.updates] = baseUpdate
-      elements[fields.new] = baseNew
+      elements[fields.updates] = {
+        full: baseUpdate,
+        native: baseUpdate,
+        vars: null,
+        varsAt: 'changes',
+      }
+      elements[fields.new] = { full: baseNew, native: baseNew, vars: null, varsAt: 'root' }
       continue
     }
 
     const originalChanges = (baseUpdate.shape as Record<string, z.ZodTypeAny>).changes
-    elements[fields.updates] =
+    const extendedUpdate =
       originalChanges instanceof z.ZodObject
         ? baseUpdate.extend({ changes: originalChanges.extend(varsShape) })
         : baseUpdate
-    elements[fields.new] = baseNew.extend(varsShape)
+    elements[fields.updates] = {
+      full: extendedUpdate,
+      native: baseUpdate,
+      // Nothing to put back if the update schema had no `changes` object to extend.
+      vars: extendedUpdate === baseUpdate ? null : (varsShape as Record<string, z.ZodType>),
+      varsAt: 'changes',
+    }
+    elements[fields.new] = {
+      full: baseNew.extend(varsShape),
+      native: baseNew,
+      vars: varsShape as Record<string, z.ZodType>,
+      varsAt: 'root',
+    }
   }
 
   return elements
@@ -215,7 +255,7 @@ export function buildExtendedClassificationSchema(
   const elements = buildEntryUpdateElementSchemas(runtimeVarsByEntityType)
   const entryUpdatesShape: Record<string, z.ZodTypeAny> = {}
   for (const [field, element] of Object.entries(elements)) {
-    entryUpdatesShape[field] = z.array(element).default([])
+    entryUpdatesShape[field] = z.array(element.full).default([])
   }
 
   return z.object({
@@ -227,6 +267,72 @@ export function buildExtendedClassificationSchema(
 // ============================================================================
 // Salvage
 // ============================================================================
+
+/**
+ * Salvage one element of an `entryUpdates` array, or return null if nothing of it survives.
+ *
+ * The whole element is tried first. When that fails the native fields are tried alone and
+ * each runtime variable is put back on its own merits: a variable value is the one thing in
+ * here that is recoverable by design — that is why they are all optional in the first place —
+ * so `health: "full"` must cost the value, not the character it was attached to.
+ */
+function salvageElement(item: unknown, schemas: ElementSchemas): unknown | null {
+  const full = schemas.full.safeParse(item)
+  if (full.success) return full.data
+
+  const native = schemas.native.safeParse(item)
+  if (!native.success) return null
+  const salvaged = native.data as Record<string, unknown>
+
+  if (schemas.vars && typeof item === 'object' && item !== null) {
+    const rawItem = item as Record<string, unknown>
+    const source = schemas.varsAt === 'changes' ? rawItem.changes : rawItem
+    const target = schemas.varsAt === 'changes' ? salvaged.changes : salvaged
+    if (source && typeof source === 'object' && target && typeof target === 'object') {
+      for (const [name, schema] of Object.entries(schemas.vars)) {
+        const value = schema.safeParse((source as Record<string, unknown>)[name])
+        // Every variable schema is `.optional()`, so an absent one parses as undefined.
+        if (value.success && value.data !== undefined) {
+          ;(target as Record<string, unknown>)[name] = value.data
+        }
+      }
+    }
+  }
+
+  // An update left holding nothing but the name it addresses is not worth keeping: applying
+  // it writes no column but still copies the entity onto the current branch (`cowCharacter`
+  // and friends run before the update, not after it), so a no-op would cost a COW row.
+  const changes = salvaged.changes
+  if (changes && typeof changes === 'object' && Object.keys(changes).length === 0) return null
+
+  return salvaged
+}
+
+/**
+ * Salvage the scene, field by field when it does not parse whole.
+ *
+ * Its three fields are independent claims, exactly like the arrays beside them: a
+ * `timeProgression` the model spelled wrong must not cost the current location.
+ */
+function salvageScene(rawScene: Record<string, unknown>): Scene {
+  const scene = sceneSchema.safeParse(rawScene)
+  if (scene.success) return scene.data
+
+  // Taken from the parse rather than from the raw value: the field carries `.default('none')`,
+  // so an omitted `timeProgression` parses successfully and its *result* is 'none' while the
+  // input is undefined. Reading the input back would put undefined in a field typed as the
+  // enum, and leave the caller's emptiness check unable to recognise an empty scene.
+  const time = sceneSchema.shape.timeProgression.safeParse(rawScene.timeProgression)
+
+  return {
+    currentLocationName:
+      typeof rawScene.currentLocationName === 'string' ? rawScene.currentLocationName : null,
+    presentCharacterNames: Array.isArray(rawScene.presentCharacterNames)
+      ? rawScene.presentCharacterNames.filter((n): n is string => typeof n === 'string')
+      : [],
+    timeProgression: time.success ? time.data : 'none',
+  }
+}
 
 /**
  * Rebuild a classification result from model output that failed whole-object validation,
@@ -262,34 +368,19 @@ export function salvageClassification(
     const value = rawEntryUpdates[field]
     const kept = Array.isArray(value)
       ? value.flatMap((item) => {
-          const parsed = element.safeParse(item)
-          return parsed.success ? [parsed.data] : []
+          const salvagedItem = salvageElement(item, element)
+          return salvagedItem === null ? [] : [salvagedItem]
         })
       : []
     salvagedCount += kept.length
     entryUpdates[field] = kept
   }
 
-  // The scene is three independent claims, so it is salvaged field by field for the same
-  // reason. A bad `timeProgression` must not cost the current location.
   const rawScene =
     typeof root.scene === 'object' && root.scene !== null
       ? (root.scene as Record<string, unknown>)
       : {}
-  const scene = sceneSchema.safeParse(rawScene)
-  const salvagedScene: Scene = scene.success
-    ? scene.data
-    : {
-        currentLocationName:
-          typeof rawScene.currentLocationName === 'string' ? rawScene.currentLocationName : null,
-        presentCharacterNames: Array.isArray(rawScene.presentCharacterNames)
-          ? rawScene.presentCharacterNames.filter((n): n is string => typeof n === 'string')
-          : [],
-        timeProgression: sceneSchema.shape.timeProgression.safeParse(rawScene.timeProgression)
-          .success
-          ? (rawScene.timeProgression as Scene['timeProgression'])
-          : 'none',
-      }
+  const salvagedScene = salvageScene(rawScene)
 
   const sceneIsEmpty =
     !salvagedScene.currentLocationName &&


### PR DESCRIPTION
Fixes #428.

## The failure

The classifier's response is one object holding eight arrays and the scene, and schema
validation is all-or-nothing. One element the model got wrong threw away every character,
location, item, beat and the time progression alongside it — `classify()` caught the
rejection and returned an empty result. No error, no toast, nothing in the UI. The world
panel showed a turn that changed nothing, which is exactly what a turn that changed
nothing shows.

## Why it fired routinely rather than rarely

A runtime variable with no `defaultValue` was built as a **required** field on every new
entity of its type, while every native field except the name is optional:

```
newCharacters: required = ["name", "health"]     // before
newLocations:  required = ["name", "danger_level"]
```

So a pack defining one variable on locations made "the model did not mention
`danger_level` for this new tavern" cost the entire turn's world state. The reporter's own
payload validates fine against the base schema and against `health` alone — it is one of
their *other* variables that sank it, which is why the loss looked random.

Nothing needs the value to be present: it is recoverable. `mergeRuntimeVars` fills the
default at apply time and the entity keeps whatever it already had. `buildEntityVarsShape`
now builds every variable optional, on new entities as much as on updates, and the prompt
stops calling them required to match. Required lists are back to the native contract:

```
newCharacters: required = ["name"]               // after
newLocations:  required = ["name"]
```

## The failure mode itself

Removing the common cause does not remove the shape of the failure — any enum the model
spells wrong still rejects the whole object — so:

- **`salvageClassification`** rebuilds the result from the model's own text, keeping every
  element that validates on its own and dropping only the ones that do not. The SDK keeps
  that text on `NoObjectGeneratedError`, so a rejected response is still readable. The
  scene is salvaged field by field for the same reason: a bad `timeProgression` must not
  cost the current location.
- **`ClassificationResult._error`** carries why a result is thinner than the model's
  output, and `ActionInput` toasts it. An empty classification and a failed one are the
  same object; only the classifier can tell them apart, and the player should not have to
  notice a missing location three turns later.

Salvage runs only on a schema/parse rejection — a transport failure, an abort or a 401 has
nothing to read back.

## Notes

- `ChapterBatchService` still gets a result rather than a throw, so a batch chapterization
  is not aborted by one bad chapter classification.
- `buildEntityVarsShape` loses its `allOptional` parameter (both call sites passed the same
  value once the distinction went away), and `buildVariableSchema` goes with it — it had no
  other caller. The strict and salvage paths now share one element-schema builder, so they
  cannot drift.
- Not addressed here: the issue also asks for a way to **re-run** a world update on an
  existing response (useful beyond failures — e.g. after editing a response). That is a
  feature, not part of this fix.

`check`, `lint` and the full suite (743 tests, 7 new) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery when AI-generated classifications contain incomplete or invalid data, preserving valid changes wherever possible.
  - Prevented usable scene and entity updates from being lost when only part of a response is malformed.
  - Added clearer handling for responses that cannot be recovered.

- **User Experience**
  - Added a warning toast when some world changes may not have been applied, with an option to regenerate the response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->