### PR TITLE
Updates that work: a real dialog, an Android path, and two installs that should not happen

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,17 @@ A cross-story library, separate from any single playthrough:
 - Adjustable text size (small, medium, large)
 - Word count display toggle
 
+### Updates
+
+- Optional check on startup (Settings -> Interface -> Updates), rate-limited by
+  `checkInterval`, plus a manual **Check for Updates** button
+- An available update opens a dialog with the version, release date and rendered release
+  notes — a dialog on desktop, a bottom sheet on Android
+- Desktop downloads and installs in place, with a progress bar and a restart prompt
+- **Android cannot self-update** and the dialog says so: it opens the release APK in the
+  browser and lets Android's package installer take over. See
+  [The Updater](#the-updater) for why
+
 ### Cross-Platform
 
 - Desktop (Windows, macOS, Linux)
@@ -255,6 +266,54 @@ GitHub Actions workflows in `.github/workflows/`:
 
 Both release workflows expect `TAURI_SIGNING_PRIVATE_KEY(_PASSWORD)` and the `ANDROID_KEYSTORE_*` /
 `ANDROID_KEY_*` secrets to be configured on the repository.
+
+### The Updater
+
+`src/lib/services/updater.ts` answers one question on two platforms that share no machinery
+for it. `UpdateInfo.canInstallInApp` is the flag that tells them apart, and the dialog
+(`src/lib/components/updater/UpdateDialog.svelte`) branches on it rather than on the platform.
+
+**Desktop** uses `@tauri-apps/plugin-updater`: it fetches the `latest.json` named by the
+`updater.endpoints` entry in `tauri.conf.json`, verifies its signature against the `pubkey`
+there, and installs the new build itself.
+
+**Android has no updater at all, and this is not a configuration problem.**
+`tauri-plugin-updater` declares Android support level `none`, and its `updater_os()` has
+branches for linux/macos/windows only — on Android `target_os` is `"android"`, so `check()`
+returns `UnsupportedOs` before a single request is sent. There is no install path either: an
+APK is installed by the system package installer, not by the app it replaces. The Android
+path therefore calls the GitHub Releases API directly, compares the tag against `getVersion()`
+using `src/lib/utils/version.ts`, and opens the `.apk` asset in the browser. String comparison
+is not adequate for that — `'0.10.0' > '0.9.0'` is false lexically — which is why the
+comparison is a tested module of its own.
+
+Two things must stay in step, or the platforms will offer different versions to their users:
+the `RELEASE_REPO` constant in `updater.ts` and the `updater.endpoints` URL in
+`tauri.conf.json`.
+
+**A draft release is invisible to the updater.** `release.yml` publishes with
+`releaseDraft: true`, and both paths resolve `/releases/latest`, which GitHub defines as the
+latest **published, non-pre-release** release. Until the draft is published by hand, the
+desktop endpoint 404s and the API returns the previous release — so the last step of every
+release is publishing the draft on GitHub. Nothing reaches users before that.
+
+The desktop check surfaces that state honestly rather than as a generic failure: a 404 becomes
+the `no-release` kind ("it may still be a draft"), distinct from `network` and `unsupported`.
+
+**A `.deb` install is deliberately not updated in place.** The plugin would attempt it —
+`install_deb` writes the package to a temp dir and runs `dpkg -i` through `pkexec`, falling
+back to zenity/kdialog and finally to a terminal `sudo` that a windowed app has no terminal
+for — but that chain has too many ways to end half-finished for something the user starts
+with one click, and the package manager is the thing that owns that install anyway. So the
+check reports `canInstallInApp: false` with `manualInstallReason: 'deb-package'` and the
+dialog opens the releases page instead. The install format comes from `getBundleType()`,
+which returns `null` for an unpackaged build — treated as "not a deb", so `tauri dev` still
+exercises the normal path.
+
+`.rpm` currently still installs in place, through the same privileged-helper chain.
+
+One more limit: **the Android check is unauthenticated**, so it shares GitHub's per-IP rate
+limit. A 403 is reported as a network-kind error.
 
 ### Environment Variables
 
@@ -691,6 +750,11 @@ neither workflow trigger, so they would tag and build nothing.
 
 Pushing a stable tag (`vX.Y.Z`) triggers `release.yml`; pushing a pre-release tag (`vX.Y.Z-pre.N`, via the
 `prerelease` bump type) triggers `ci.yml`. See [Continuous Integration](#continuous-integration) above.
+
+**The script does not finish the release.** `release.yml` publishes a **draft**, and a draft is
+invisible to `/releases/latest` — which is where both the desktop updater and the Android check
+look. Publishing the draft on GitHub is the step that actually ships it; until then no existing
+install will see the new version. See [The Updater](#the-updater).
 
 `scripts/version.js` holds the version arithmetic and `scripts/version.test.js` covers it
 (`vitest.config.ts` includes `scripts/**/*.test.js` for this).

--- a/README.md
+++ b/README.md
@@ -300,6 +300,22 @@ release is publishing the draft on GitHub. Nothing reaches users before that.
 The desktop check surfaces that state honestly rather than as a generic failure: a 404 becomes
 the `no-release` kind ("it may still be a draft"), distinct from `network` and `unsupported`.
 
+**The release notes users read are the GitHub release body, on both platforms.** They are not
+taken from `latest.json`, whose `notes` field is written by `tauri-action` at build time from
+the fixed `releaseBody` string in `release.yml` — which is a placeholder, not a changelog, and
+cannot be otherwise, since the notes are written after the build. `releaseNotesFor` therefore
+fetches the release from the API and uses its body, falling back to `latest.json` if the call
+fails; the update installs either way. Two consequences:
+
+- Editing a published release's text on GitHub changes what every client shows, with no
+  rebuild and no new version.
+- The notes must be written **before** the draft is published, because publishing is what
+  makes the release visible to the check. A release published with the placeholder still in
+  it will show that placeholder.
+
+The fetched notes are used only when the release tag matches the version being offered —
+notes belonging to a different release are worse than none.
+
 **A `.deb` install is deliberately not updated in place.** The plugin would attempt it —
 `install_deb` writes the package to a temp dir and runs `dpkg -i` through `pkexec`, falling
 back to zenity/kdialog and finally to a terminal `sudo` that a windowed app has no terminal

--- a/README.md
+++ b/README.md
@@ -322,9 +322,18 @@ back to zenity/kdialog and finally to a terminal `sudo` that a windowed app has 
 for — but that chain has too many ways to end half-finished for something the user starts
 with one click, and the package manager is the thing that owns that install anyway. So the
 check reports `canInstallInApp: false` with `manualInstallReason: 'deb-package'` and the
-dialog opens the releases page instead. The install format comes from `getBundleType()`,
-which returns `null` for an unpackaged build — treated as "not a deb", so `tauri dev` still
-exercises the normal path.
+dialog opens the releases page instead.
+
+**An unpackaged build never installs either, and this one is a safety guard.** On Linux the
+plugin's `extract_path` _is_ the running executable, so in `tauri dev` "Download and install"
+moves the dev binary into a `TempDir`, writes the release AppImage over it, then drops the
+`TempDir` — deleting the backup — and reports success. The developer is left with a 100 MB
+AppImage where their build was. `getBundleType()` returns `null` for a build the bundler never
+touched, which is exactly that case, so it is routed to the browser with
+`manualInstallReason: 'unpackaged'`.
+
+Note that on macOS `bundle_type()` falls back to `App` rather than `None`, so this guard does
+not fire there.
 
 `.rpm` currently still installs in place, through the same privileged-helper chain.
 

--- a/src/lib/components/layout/AppShell.svelte
+++ b/src/lib/components/layout/AppShell.svelte
@@ -17,6 +17,7 @@
   import DebugLogModal from '$lib/components/debug/DebugLogModal.svelte'
   import SyncModal from '$lib/components/sync/SyncModal.svelte'
   import STChatImportModal from '$lib/components/modals/STChatImportModal.svelte'
+  import UpdateDialog from '$lib/components/updater/UpdateDialog.svelte'
   import { swipe } from '$lib/utils/swipe'
   import { releaseOrphanScrollLock } from '$lib/utils/scrollLock'
   import { createLogger } from '$lib/log'
@@ -292,6 +293,9 @@
 
   <!-- SillyTavern Chat Import Modal -->
   <STChatImportModal />
+
+  <!-- Update Dialog (raised by the startup check and by the Settings button alike) -->
+  <UpdateDialog />
 
   <!-- Floating Debug Button (when debug mode enabled) - draggable, high z-index -->
   {#if settings.uiSettings.debugMode}

--- a/src/lib/components/settings/tabs/interface.svelte
+++ b/src/lib/components/settings/tabs/interface.svelte
@@ -15,7 +15,8 @@
   import { ScrollArea } from '$lib/components/ui/scroll-area'
   import { Separator } from '$lib/components/ui/separator'
   import { getSupportedLanguages } from '$lib/services/ai/utils/TranslationService'
-  import { updaterService } from '$lib/services/updater'
+  import { updaterService, UpdateError } from '$lib/services/updater'
+  import { updateNotifier } from '$lib/stores/updateNotifier.svelte'
   import { RefreshCw, Loader2, Languages, Plus, X, Trash2 } from '@lucide/svelte'
 
   const storyWidthIndex = $derived(
@@ -129,13 +130,18 @@
     updateMessage = null
     try {
       const info = await updaterService.checkForUpdates()
+      await settings.setLastChecked(Date.now())
       if (info.available) {
-        updateMessage = `Update available: v${info.version}`
+        // Hand off to the dialog, which is the only place that can actually act on it.
+        updateNotifier.show(info)
+        updateMessage = null
       } else {
         updateMessage = "You're up to date!"
       }
     } catch (error) {
-      updateMessage = 'Failed to check for updates'
+      // Report the reason rather than a flat "failed": "no published release" and
+      // "cannot reach the server" call for completely different responses from the user.
+      updateMessage = error instanceof UpdateError ? error.message : 'Failed to check for updates.'
       console.error('[Interface] Update check failed:', error)
     } finally {
       isCheckingUpdates = false
@@ -532,26 +538,12 @@
       <div>
         <Label>Check on Startup</Label>
         <p class="text-muted-foreground text-xs">
-          Automatically check for updates when the app starts
+          Look for a new version when the app starts, and offer it if one is found
         </p>
       </div>
       <Switch
         checked={settings.updateSettings.autoCheck}
         onCheckedChange={(v) => settings.setAutoCheck(v)}
-      />
-    </div>
-
-    <!-- Auto-download Updates Toggle -->
-    <div class="flex items-center justify-between">
-      <div>
-        <Label>Auto-download Updates</Label>
-        <p class="text-muted-foreground text-xs">
-          Automatically download updates in the background
-        </p>
-      </div>
-      <Switch
-        checked={settings.updateSettings.autoDownload}
-        onCheckedChange={(v) => settings.setAutoDownload(v)}
       />
     </div>
   </div>

--- a/src/lib/components/updater/UpdateDialog.svelte
+++ b/src/lib/components/updater/UpdateDialog.svelte
@@ -1,0 +1,234 @@
+<script lang="ts">
+  /**
+   * The window the user sees when a new version exists.
+   *
+   * Built on `ResponsiveModal`, so it is a centred dialog on desktop and a bottom sheet on
+   * Android without a second implementation.
+   *
+   * The two platforms end this flow differently and the component says so rather than
+   * hiding it: on desktop it downloads, installs and offers a restart; on Android it can
+   * only hand the APK to the system browser, because `canInstallInApp` is false there.
+   */
+  import * as ResponsiveModal from '$lib/components/ui/responsive-modal'
+  import { Button } from '$lib/components/ui/button'
+  import { Progress } from '$lib/components/ui/progress'
+  import { ScrollArea } from '$lib/components/ui/scroll-area'
+  import { Download, RefreshCw, ExternalLink, AlertTriangle, CheckCircle2 } from '@lucide/svelte'
+  import { updaterService, type UpdateProgress } from '$lib/services/updater'
+  import { updateNotifier } from '$lib/stores/updateNotifier.svelte'
+  import { parseMarkdown } from '$lib/utils/markdown'
+
+  type Phase = 'idle' | 'downloading' | 'installed' | 'handedOff' | 'error'
+
+  let phase = $state<Phase>('idle')
+  let progress = $state<UpdateProgress | null>(null)
+  let errorMessage = $state<string | null>(null)
+
+  const info = $derived(updateNotifier.info)
+
+  /** Null when the server sent no content length, which is what drives the indeterminate bar. */
+  const percent = $derived(
+    progress && progress.total && progress.total > 0
+      ? Math.min(100, Math.round((progress.downloaded / progress.total) * 100))
+      : null,
+  )
+
+  const changelogHtml = $derived(info?.body ? parseMarkdown(info.body) : '')
+
+  /**
+   * Why the app is stepping aside, in the user's terms. A `.deb` user is not on an
+   * unsupported platform — their package manager owns the install — and telling them
+   * otherwise would send them looking for a problem that is not there.
+   */
+  const manualInstallNote = $derived(
+    info?.manualInstallReason === 'deb-package'
+      ? 'This copy was installed from a .deb package, so your package manager owns it. The releases page will open in your browser — download the new .deb and install it the way you installed this one.'
+      : 'Aventuras cannot install its own updates on Android. The download will open in your browser.',
+  )
+
+  const handedOffNote = $derived(
+    info?.manualInstallReason === 'deb-package'
+      ? 'The releases page has opened in your browser. Download the new .deb and install it to finish updating.'
+      : 'The download has opened in your browser. Once it finishes, open the file to install the update — Android will ask you to confirm.',
+  )
+
+  const releasedOn = $derived.by(() => {
+    if (!info?.date) return null
+    // Tauri's `latest.json` carries an RFC 3339 date; the GitHub API carries an ISO one.
+    const parsed = new Date(info.date)
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toLocaleDateString()
+  })
+
+  function formatBytes(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  }
+
+  function handleOpenChange(open: boolean) {
+    // A download in flight owns the window: closing it would leave the install running
+    // with nothing to report back to.
+    if (!open && phase === 'downloading') return
+    if (!open) {
+      updateNotifier.dismiss()
+      phase = 'idle'
+      progress = null
+      errorMessage = null
+    }
+  }
+
+  async function handleInstall() {
+    phase = 'downloading'
+    errorMessage = null
+    progress = { downloaded: 0, total: null }
+
+    try {
+      const ok = await updaterService.downloadAndInstall((p) => {
+        progress = p
+      })
+      phase = ok ? 'installed' : 'error'
+      if (!ok) {
+        errorMessage = 'The update was no longer available to install. Try checking again.'
+      }
+    } catch (error) {
+      phase = 'error'
+      errorMessage = error instanceof Error ? error.message : 'The update could not be downloaded.'
+    }
+  }
+
+  async function handleOpenInBrowser() {
+    try {
+      await updaterService.openDownloadPage()
+      phase = 'handedOff'
+    } catch (error) {
+      phase = 'error'
+      errorMessage = error instanceof Error ? error.message : 'Could not open the download page.'
+    }
+  }
+
+  function handleRelaunch() {
+    void updaterService.relaunch()
+  }
+</script>
+
+{#if info}
+  <ResponsiveModal.Root open={updateNotifier.open} onOpenChange={handleOpenChange}>
+    <ResponsiveModal.Content class="p-0 sm:max-w-lg">
+      <ResponsiveModal.Header class="border-b px-6 py-4">
+        <ResponsiveModal.Title class="flex items-center gap-2">
+          <Download class="h-5 w-5 shrink-0" />
+          Update available
+        </ResponsiveModal.Title>
+        <ResponsiveModal.Description>
+          Aventuras {info.version} is available{info.currentVersion
+            ? ` — you have ${info.currentVersion}`
+            : ''}{releasedOn ? `, released ${releasedOn}` : ''}.
+        </ResponsiveModal.Description>
+      </ResponsiveModal.Header>
+
+      <div class="flex flex-col gap-4 px-6 py-4">
+        {#if changelogHtml}
+          <div class="flex flex-col gap-2">
+            <span class="text-sm font-medium">What's new</span>
+            <ScrollArea class="max-h-56 rounded-md border p-3">
+              <!-- Release notes come from the project's own signed release metadata. -->
+              <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+              <div class="release-notes text-muted-foreground text-sm">
+                {@html changelogHtml}
+              </div>
+            </ScrollArea>
+          </div>
+        {/if}
+
+        {#if phase === 'downloading'}
+          <div class="flex flex-col gap-2">
+            <Progress value={percent ?? 0} class="h-2" />
+            <span class="text-muted-foreground text-xs">
+              {#if percent !== null && progress?.total}
+                Downloading… {percent}% ({formatBytes(progress.downloaded)} of {formatBytes(
+                  progress.total,
+                )})
+              {:else if progress}
+                Downloading… {formatBytes(progress.downloaded)}
+              {:else}
+                Starting download…
+              {/if}
+            </span>
+          </div>
+        {:else if phase === 'installed'}
+          <div class="text-muted-foreground flex items-start gap-2 rounded-md border p-3 text-sm">
+            <CheckCircle2 class="mt-0.5 h-4 w-4 shrink-0 text-green-500" />
+            <span>The update is installed. Restart Aventuras to start using it.</span>
+          </div>
+        {:else if phase === 'handedOff'}
+          <div class="text-muted-foreground flex items-start gap-2 rounded-md border p-3 text-sm">
+            <ExternalLink class="mt-0.5 h-4 w-4 shrink-0" />
+            <span>{handedOffNote}</span>
+          </div>
+        {:else if phase === 'error' && errorMessage}
+          <div class="text-destructive flex items-start gap-2 rounded-md border p-3 text-sm">
+            <AlertTriangle class="mt-0.5 h-4 w-4 shrink-0" />
+            <span>{errorMessage}</span>
+          </div>
+        {:else if !info.canInstallInApp}
+          <p class="text-muted-foreground text-sm">{manualInstallNote}</p>
+        {/if}
+      </div>
+
+      <ResponsiveModal.Footer class="border-t px-6 py-4">
+        {#if phase === 'installed'}
+          <Button variant="outline" onclick={() => handleOpenChange(false)}>Later</Button>
+          <Button onclick={handleRelaunch}>
+            <RefreshCw class="mr-2 h-4 w-4" />
+            Restart now
+          </Button>
+        {:else if phase === 'handedOff'}
+          <Button onclick={() => handleOpenChange(false)}>Done</Button>
+        {:else if phase === 'downloading'}
+          <Button disabled>Downloading…</Button>
+        {:else if info.canInstallInApp}
+          <Button variant="outline" onclick={() => handleOpenChange(false)}>Not now</Button>
+          <Button onclick={handleInstall}>
+            <Download class="mr-2 h-4 w-4" />
+            {phase === 'error' ? 'Try again' : 'Download and install'}
+          </Button>
+        {:else}
+          <Button variant="outline" onclick={() => handleOpenChange(false)}>Not now</Button>
+          <Button onclick={handleOpenInBrowser}>
+            <ExternalLink class="mr-2 h-4 w-4" />
+            {info.manualInstallReason === 'deb-package' ? 'Open releases page' : 'Download update'}
+          </Button>
+        {/if}
+      </ResponsiveModal.Footer>
+    </ResponsiveModal.Content>
+  </ResponsiveModal.Root>
+{/if}
+
+<style>
+  /* Release notes are authored Markdown; give the rendered HTML enough shape to read. */
+  .release-notes :global(h1),
+  .release-notes :global(h2),
+  .release-notes :global(h3) {
+    color: var(--foreground);
+    font-weight: 600;
+    margin-block: 0.5rem 0.25rem;
+  }
+
+  .release-notes :global(ul) {
+    list-style: disc;
+    padding-inline-start: 1.25rem;
+  }
+
+  .release-notes :global(p) {
+    margin-block: 0.25rem;
+  }
+
+  .release-notes :global(a) {
+    text-decoration: underline;
+  }
+
+  .release-notes :global(code) {
+    font-family: var(--font-mono, monospace);
+    font-size: 0.85em;
+  }
+</style>

--- a/src/lib/components/updater/UpdateDialog.svelte
+++ b/src/lib/components/updater/UpdateDialog.svelte
@@ -5,15 +5,20 @@
    * Built on `ResponsiveModal`, so it is a centred dialog on desktop and a bottom sheet on
    * Android without a second implementation.
    *
-   * The two platforms end this flow differently and the component says so rather than
-   * hiding it: on desktop it downloads, installs and offers a restart; on Android it can
-   * only hand the APK to the system browser, because `canInstallInApp` is false there.
+   * The flow ends differently depending on what this copy of the app is, and the component
+   * says so rather than hiding it: a packaged desktop build downloads, installs and offers a
+   * restart; Android, a `.deb` install and an unpackaged dev build all hand off to the
+   * browser. `canInstallInApp` is the branch, `manualInstallReason` supplies the wording.
    */
   import * as ResponsiveModal from '$lib/components/ui/responsive-modal'
   import { Button } from '$lib/components/ui/button'
   import { Progress } from '$lib/components/ui/progress'
   import { Download, RefreshCw, ExternalLink, AlertTriangle, CheckCircle2 } from '@lucide/svelte'
-  import { updaterService, type UpdateProgress } from '$lib/services/updater'
+  import {
+    updaterService,
+    type UpdateProgress,
+    type ManualInstallReason,
+  } from '$lib/services/updater'
   import { updateNotifier } from '$lib/stores/updateNotifier.svelte'
   import { parseMarkdown } from '$lib/utils/markdown'
 
@@ -35,21 +40,31 @@
   const changelogHtml = $derived(info?.body ? parseMarkdown(info.body) : '')
 
   /**
-   * Why the app is stepping aside, in the user's terms. A `.deb` user is not on an
-   * unsupported platform — their package manager owns the install — and telling them
-   * otherwise would send them looking for a problem that is not there.
+   * Why the app is stepping aside, in the user's terms. The three cases are genuinely
+   * different — a `.deb` user is not on an unsupported platform, and a developer is not
+   * a user at all — and one shared message would be wrong for at least two of them.
    */
-  const manualInstallNote = $derived(
-    info?.manualInstallReason === 'deb-package'
-      ? 'This copy was installed from a .deb package, so your package manager owns it. The releases page will open in your browser — download the new .deb and install it the way you installed this one.'
-      : 'Aventuras cannot install its own updates on Android. The download will open in your browser.',
-  )
+  const MANUAL_INSTALL_NOTES: Record<ManualInstallReason, string> = {
+    'deb-package':
+      'This copy was installed from a .deb package, so your package manager owns it. The releases page will open in your browser — download the new .deb and install it the way you installed this one.',
+    unpackaged:
+      'This is an unpackaged development build, so Aventuras will not install over it — on Linux that would replace the binary you just built. The releases page will open in your browser instead.',
+    'mobile-platform':
+      'Aventuras cannot install its own updates on Android. The download will open in your browser.',
+  }
 
-  const handedOffNote = $derived(
-    info?.manualInstallReason === 'deb-package'
-      ? 'The releases page has opened in your browser. Download the new .deb and install it to finish updating.'
-      : 'The download has opened in your browser. Once it finishes, open the file to install the update — Android will ask you to confirm.',
+  const HANDED_OFF_NOTES: Record<ManualInstallReason, string> = {
+    'deb-package':
+      'The releases page has opened in your browser. Download the new .deb and install it to finish updating.',
+    unpackaged: 'The releases page has opened in your browser.',
+    'mobile-platform':
+      'The download has opened in your browser. Once it finishes, open the file to install the update — Android will ask you to confirm.',
+  }
+
+  const manualInstallNote = $derived(
+    MANUAL_INSTALL_NOTES[info?.manualInstallReason ?? 'mobile-platform'],
   )
+  const handedOffNote = $derived(HANDED_OFF_NOTES[info?.manualInstallReason ?? 'mobile-platform'])
 
   const releasedOn = $derived.by(() => {
     if (!info?.date) return null
@@ -204,7 +219,9 @@
           <Button variant="outline" onclick={() => handleOpenChange(false)}>Not now</Button>
           <Button onclick={handleOpenInBrowser}>
             <ExternalLink class="mr-2 h-4 w-4" />
-            {info.manualInstallReason === 'deb-package' ? 'Open releases page' : 'Download update'}
+            {info.manualInstallReason === 'mobile-platform'
+              ? 'Download update'
+              : 'Open releases page'}
           </Button>
         {/if}
       </ResponsiveModal.Footer>

--- a/src/lib/components/updater/UpdateDialog.svelte
+++ b/src/lib/components/updater/UpdateDialog.svelte
@@ -12,7 +12,6 @@
   import * as ResponsiveModal from '$lib/components/ui/responsive-modal'
   import { Button } from '$lib/components/ui/button'
   import { Progress } from '$lib/components/ui/progress'
-  import { ScrollArea } from '$lib/components/ui/scroll-area'
   import { Download, RefreshCw, ExternalLink, AlertTriangle, CheckCircle2 } from '@lucide/svelte'
   import { updaterService, type UpdateProgress } from '$lib/services/updater'
   import { updateNotifier } from '$lib/stores/updateNotifier.svelte'
@@ -130,13 +129,22 @@
         {#if changelogHtml}
           <div class="flex flex-col gap-2">
             <span class="text-sm font-medium">What's new</span>
-            <ScrollArea class="max-h-56 rounded-md border p-3">
-              <!-- Release notes come from the project's own signed release metadata. -->
+            <!--
+              A plain scroller, deliberately not `ScrollArea`. That component's viewport is
+              `h-full`, and `height: 100%` against a parent sized only by `max-height`
+              resolves to `auto` -- so the viewport grows to the full content height, never
+              overflows itself, and its `overflow-y: scroll` has nothing to act on while the
+              root's `overflow-hidden` silently clips the rest. `max-h` + `overflow-y-auto`
+              on one element scrolls natively, and still collapses for short notes the way a
+              fixed height would not.
+            -->
+            <div class="max-h-72 overflow-y-auto rounded-md border p-3">
+              <!-- Release notes are the project's own release body, fetched from GitHub. -->
               <!-- eslint-disable-next-line svelte/no-at-html-tags -->
               <div class="release-notes text-muted-foreground text-sm">
                 {@html changelogHtml}
               </div>
-            </ScrollArea>
+            </div>
           </div>
         {/if}
 

--- a/src/lib/services/updater.ts
+++ b/src/lib/services/updater.ts
@@ -209,11 +209,14 @@ class UpdaterService {
     // half-finished install for something the user started with one click.
     const deb = (await this.bundleType()) === 'deb'
 
+    // Prefer GitHub's release body over `latest.json`'s `notes`. See `releaseNotesFor`.
+    const notes = (await this.releaseNotesFor(update.version)) ?? update.body ?? undefined
+
     return {
       available: true,
       version: update.version,
       currentVersion: update.currentVersion,
-      body: update.body ?? undefined,
+      body: notes,
       date: update.date ?? undefined,
       canInstallInApp: !deb,
       manualInstallReason: deb ? 'deb-package' : undefined,
@@ -221,12 +224,14 @@ class UpdaterService {
     }
   }
 
-  /** Android: read the release list ourselves and compare the tag with the running build. */
-  private async checkViaGitHub(): Promise<UpdateInfo> {
-    this.updateAvailable = null
-
-    const currentVersion = await getVersion()
-
+  /**
+   * Fetches the latest published release from the GitHub API.
+   *
+   * Shared by both paths. Android needs it to find an update at all; desktop needs it only
+   * for the release notes, because `latest.json` carries the workflow's static
+   * `releaseBody` rather than what the maintainer writes on the release afterwards.
+   */
+  private async fetchLatestRelease(): Promise<GitHubRelease> {
     // AbortController rather than `AbortSignal.timeout`, which the older Android System
     // WebViews this app still runs on do not implement. Matches the rest of the codebase.
     const ctrl = new AbortController()
@@ -265,7 +270,40 @@ class UpdaterService {
       )
     }
 
-    const release = (await response.json()) as GitHubRelease
+    return (await response.json()) as GitHubRelease
+  }
+
+  /**
+   * The release notes GitHub holds for `version`, or `undefined`.
+   *
+   * `latest.json` is written by `tauri-action` at build time, so its `notes` are the
+   * workflow's fixed `releaseBody` string -- the real notes are written on the release
+   * afterwards and never reach that file. Reading them here means editing the release on
+   * GitHub updates what every client shows, with no rebuild.
+   *
+   * Only used when the tag matches the update being offered: notes belonging to a
+   * different version are worse than none, and the two files can disagree.
+   *
+   * Never throws. The update is signed and installable whatever happened here.
+   */
+  private async releaseNotesFor(version: string): Promise<string | undefined> {
+    try {
+      const release = await this.fetchLatestRelease()
+      const tag = release.tag_name?.trim().replace(/^v/, '')
+      if (!tag || tag !== version.replace(/^v/, '')) return undefined
+      return release.body?.trim() || undefined
+    } catch (error) {
+      console.error('[Updater] Could not fetch release notes:', error)
+      return undefined
+    }
+  }
+
+  /** Android: read the release list ourselves and compare the tag with the running build. */
+  private async checkViaGitHub(): Promise<UpdateInfo> {
+    this.updateAvailable = null
+
+    const currentVersion = await getVersion()
+    const release = await this.fetchLatestRelease()
     const tag = release.tag_name?.trim()
 
     if (!tag) {

--- a/src/lib/services/updater.ts
+++ b/src/lib/services/updater.ts
@@ -50,7 +50,7 @@ const GITHUB_TIMEOUT_MS = 15_000
  * other about how this particular copy was installed -- so the reason travels with the
  * update rather than being re-derived in the component.
  */
-export type ManualInstallReason = 'mobile-platform' | 'deb-package'
+export type ManualInstallReason = 'mobile-platform' | 'deb-package' | 'unpackaged'
 
 export interface UpdateInfo {
   available: boolean
@@ -176,11 +176,11 @@ class UpdaterService {
   }
 
   /**
-   * How this copy of the app was packaged, or `null` when that cannot be determined.
+   * How this copy of the app was packaged, or `null` when it was not packaged at all.
    *
-   * Tauri types this as `Promise<BundleType>`, but the Rust command returns an `Option` --
-   * an unpackaged build (`tauri dev`) yields `null`. Null is treated as "not a deb", since
-   * the alternative is sending every developer to the releases page.
+   * Tauri types this as `Promise<BundleType>`, but the Rust command returns an `Option`.
+   * The value comes from a placeholder the bundler patches into the binary at bundle time,
+   * so a `tauri dev` build -- never bundled -- yields `null` on Linux and Windows.
    */
   private async bundleType(): Promise<BundleType | null> {
     try {
@@ -202,12 +202,23 @@ class UpdaterService {
 
     this.updateAvailable = update
 
-    // A `.deb` install is sent to the releases page instead of installing in place. The
-    // plugin can technically do it -- `install_deb` shells out to `dpkg -i` through
-    // `pkexec`, falling back to zenity/kdialog and finally to a terminal `sudo` that a
-    // windowed app has no terminal for -- but that chain has too many ways to end in a
-    // half-finished install for something the user started with one click.
-    const deb = (await this.bundleType()) === 'deb'
+    const bundle = await this.bundleType()
+
+    // Two desktop cases hand off to the browser instead of installing in place.
+    //
+    // `null` means the app was never bundled -- a `tauri dev` build. Installing there is
+    // actively destructive: on Linux the plugin's `extract_path` *is* the running
+    // executable, so `install_appimage` moves the freshly built dev binary into a
+    // `TempDir`, writes the release AppImage over it, and then drops the `TempDir`,
+    // deleting the backup. The developer is left with a 100 MB AppImage where their build
+    // was, and the plugin reports success.
+    //
+    // A `.deb` is a decision rather than a hazard: `install_deb` shells out to `dpkg -i`
+    // through `pkexec`, falling back to zenity/kdialog and finally to a terminal `sudo`
+    // that a windowed app has no terminal for. Too many ways to end half-finished, and
+    // the package manager owns that install anyway.
+    const reason: ManualInstallReason | undefined =
+      bundle === null ? 'unpackaged' : bundle === 'deb' ? 'deb-package' : undefined
 
     // Prefer GitHub's release body over `latest.json`'s `notes`. See `releaseNotesFor`.
     const notes = (await this.releaseNotesFor(update.version)) ?? update.body ?? undefined
@@ -218,9 +229,9 @@ class UpdaterService {
       currentVersion: update.currentVersion,
       body: notes,
       date: update.date ?? undefined,
-      canInstallInApp: !deb,
-      manualInstallReason: deb ? 'deb-package' : undefined,
-      downloadUrl: deb ? RELEASES_PAGE : undefined,
+      canInstallInApp: reason === undefined,
+      manualInstallReason: reason,
+      downloadUrl: reason ? RELEASES_PAGE : undefined,
     }
   }
 

--- a/src/lib/services/updater.ts
+++ b/src/lib/services/updater.ts
@@ -351,11 +351,18 @@ class UpdaterService {
   }
 
   /**
-   * Downloads and installs the available update. Desktop only -- returns `false` when
-   * there is nothing staged, a download is already running, or the platform cannot install.
+   * Downloads and installs the available update. Returns `false` when there is nothing
+   * staged, a download is already running, or this build must not install over itself.
+   *
+   * That last condition is enforced here rather than only in the dialog. Android happens to
+   * be covered already -- `checkViaGitHub` leaves `updateAvailable` null -- but a `.deb`
+   * install and an unpackaged dev build both reach this with a real `Update` staged, and
+   * for the dev build installing is destructive (see `checkViaTauri`). Leaving that to the
+   * caller makes a UI branch the only thing standing between a second caller and a deleted
+   * binary.
    */
   async downloadAndInstall(onProgress?: (progress: UpdateProgress) => void): Promise<boolean> {
-    if (!this.updateAvailable || this.downloading) {
+    if (!this.updateAvailable || this.downloading || !this.lastInfo?.canInstallInApp) {
       return false
     }
 

--- a/src/lib/services/updater.ts
+++ b/src/lib/services/updater.ts
@@ -1,5 +1,56 @@
+/**
+ * Update checking, on two platforms that share nothing but the question they ask.
+ *
+ * **Desktop** goes through `@tauri-apps/plugin-updater`: it reads the signed `latest.json`
+ * published by `release.yml`, verifies it against the pubkey in `tauri.conf.json`, and can
+ * download and install the new build itself.
+ *
+ * **Android cannot use any of that.** `tauri-plugin-updater` declares Android support level
+ * `none`, and its `updater_os()` has no `target_os = "android"` branch -- so `check()` fails
+ * with `UnsupportedOs` before a single request goes out. There is no in-app install path
+ * either: an APK is installed by the system package installer, not by the app it replaces.
+ * The Android path therefore reads the GitHub Releases API directly, compares the tag with
+ * `getVersion()` itself, and hands the user a URL to open. `canInstallInApp` is what tells
+ * the UI which of the two it is looking at.
+ *
+ * Both paths resolve the *same* release: `/releases/latest` on the API excludes drafts and
+ * pre-releases, exactly as `/releases/latest/download/latest.json` does for the desktop
+ * endpoint. A release that is still a draft is invisible to both, which is the intended
+ * behaviour -- see the README's release section.
+ *
+ * One desktop install format opts out of installing in place: a `.deb` is sent to the
+ * releases page instead. `manualInstallReason` distinguishes that from the Android case,
+ * because the two need different explanations in front of the user.
+ */
+
 import { check, type Update } from '@tauri-apps/plugin-updater'
 import { relaunch } from '@tauri-apps/plugin-process'
+import { fetch as tauriHttpFetch } from '@tauri-apps/plugin-http'
+import { getVersion, getBundleType, type BundleType } from '@tauri-apps/api/app'
+import { openUrl } from '@tauri-apps/plugin-opener'
+import { isAndroid } from '$lib/utils/platform'
+import { isNewerVersion } from '$lib/utils/version'
+
+/**
+ * The repository the release workflow publishes to. Must stay in step with the `updater`
+ * endpoint in `src-tauri/tauri.conf.json`, or the two platforms will offer different
+ * versions of the app to their users.
+ */
+const RELEASE_REPO = 'AventurasTeam/Aventuras'
+const LATEST_RELEASE_API = `https://api.github.com/repos/${RELEASE_REPO}/releases/latest`
+const RELEASES_PAGE = `https://github.com/${RELEASE_REPO}/releases/latest`
+
+/** How long the Android check waits before giving up, so a dead network cannot hang startup. */
+const GITHUB_TIMEOUT_MS = 15_000
+
+/**
+ * Why the app is not installing this update itself. Absent when it is.
+ *
+ * The two cases need different words in front of the user -- one is about the device, the
+ * other about how this particular copy was installed -- so the reason travels with the
+ * update rather than being re-derived in the component.
+ */
+export type ManualInstallReason = 'mobile-platform' | 'deb-package'
 
 export interface UpdateInfo {
   available: boolean
@@ -7,6 +58,18 @@ export interface UpdateInfo {
   currentVersion?: string
   body?: string
   date?: string
+  /**
+   * Where to send the user when the app cannot install the update itself: the `.apk` asset
+   * on Android, the releases page for a `.deb` install.
+   */
+  downloadUrl?: string
+  /**
+   * Whether `downloadAndInstall` is usable for this update. See `manualInstallReason` for
+   * the cases where it is not.
+   */
+  canInstallInApp: boolean
+  /** Set exactly when `canInstallInApp` is false. */
+  manualInstallReason?: ManualInstallReason
 }
 
 export interface UpdateProgress {
@@ -14,49 +77,233 @@ export interface UpdateProgress {
   total: number | null
 }
 
+/** Why a check or install failed, in the terms the UI needs to phrase it. */
+export type UpdateErrorKind =
+  | 'unsupported' // this platform/install format cannot self-update
+  | 'no-release' // the endpoint has no published release (e.g. the draft was never published)
+  | 'network' // could not reach the endpoint
+  | 'unknown'
+
+export class UpdateError extends Error {
+  constructor(
+    readonly kind: UpdateErrorKind,
+    message: string,
+    readonly cause?: unknown,
+  ) {
+    super(message)
+    this.name = 'UpdateError'
+  }
+}
+
+/** Shape of the bits of the GitHub release payload this reads. */
+interface GitHubRelease {
+  tag_name?: string
+  name?: string
+  body?: string | null
+  published_at?: string | null
+  html_url?: string
+  assets?: { name?: string; browser_download_url?: string }[]
+}
+
+function classifyError(error: unknown): UpdateError {
+  if (error instanceof UpdateError) return error
+
+  const message = error instanceof Error ? error.message : String(error)
+
+  // The plugin's own errors arrive as plain strings over the IPC bridge.
+  if (/UnsupportedOs|UnsupportedArch|not supported/i.test(message)) {
+    return new UpdateError(
+      'unsupported',
+      'Automatic updates are not supported on this platform.',
+      error,
+    )
+  }
+  if (/ReleaseNotFound|release not found/i.test(message)) {
+    return new UpdateError(
+      'no-release',
+      'No published release was found. If a release was just built, it may still be a draft.',
+      error,
+    )
+  }
+  if (/network|timeout|timed out|dns|connect|unreachable|failed to fetch/i.test(message)) {
+    return new UpdateError('network', 'Could not reach the update server.', error)
+  }
+
+  return new UpdateError('unknown', message || 'The update check failed.', error)
+}
+
 class UpdaterService {
   private updateAvailable: Update | null = null
-  private checking = false
   private downloading = false
   private progress: UpdateProgress | null = null
+  /** Kept so the Android path can answer `getUpdateInfo()` like the desktop one does. */
+  private lastInfo: UpdateInfo | null = null
+  /**
+   * The check currently in flight, shared by every concurrent caller.
+   *
+   * The startup check and the Settings button really do race: a user who opens Settings
+   * during startup and presses the button would otherwise get an answer about no request
+   * at all, and "You're up to date!" is a specific, wrong thing to say about a check that
+   * has not come back yet. Joining the running check answers both callers correctly.
+   */
+  private inFlight: Promise<UpdateInfo> | null = null
 
   /**
-   * Check for available updates
+   * Checks for an available update on whichever path this platform has.
+   *
+   * Throws an `UpdateError` on failure rather than returning `{ available: false }`, so a
+   * caller can tell "there is no update" from "we could not find out".
    */
-  async checkForUpdates(): Promise<UpdateInfo> {
-    if (this.checking) {
-      return { available: false }
-    }
+  checkForUpdates(): Promise<UpdateInfo> {
+    this.inFlight ??= this.runCheck().finally(() => {
+      this.inFlight = null
+    })
+    return this.inFlight
+  }
 
-    this.checking = true
-
+  private async runCheck(): Promise<UpdateInfo> {
     try {
-      const update = await check()
-
-      if (update) {
-        this.updateAvailable = update
-        return {
-          available: true,
-          version: update.version,
-          currentVersion: update.currentVersion,
-          body: update.body ?? undefined,
-          date: update.date ?? undefined,
-        }
-      }
-
-      this.updateAvailable = null
-      return { available: false }
+      const info = isAndroid() ? await this.checkViaGitHub() : await this.checkViaTauri()
+      this.lastInfo = info
+      return info
     } catch (error) {
-      console.error('[Updater] Check failed:', error)
       this.updateAvailable = null
-      throw error
-    } finally {
-      this.checking = false
+      this.lastInfo = null
+      const classified = classifyError(error)
+      console.error('[Updater] Check failed:', classified.kind, classified.message)
+      throw classified
     }
   }
 
   /**
-   * Download and install the available update
+   * How this copy of the app was packaged, or `null` when that cannot be determined.
+   *
+   * Tauri types this as `Promise<BundleType>`, but the Rust command returns an `Option` --
+   * an unpackaged build (`tauri dev`) yields `null`. Null is treated as "not a deb", since
+   * the alternative is sending every developer to the releases page.
+   */
+  private async bundleType(): Promise<BundleType | null> {
+    try {
+      return (await getBundleType()) ?? null
+    } catch (error) {
+      console.error('[Updater] Could not determine the bundle type:', error)
+      return null
+    }
+  }
+
+  /** Desktop: the signed `latest.json` flow, handled entirely by the plugin. */
+  private async checkViaTauri(): Promise<UpdateInfo> {
+    const update = await check()
+
+    if (!update) {
+      this.updateAvailable = null
+      return { available: false, canInstallInApp: true }
+    }
+
+    this.updateAvailable = update
+
+    // A `.deb` install is sent to the releases page instead of installing in place. The
+    // plugin can technically do it -- `install_deb` shells out to `dpkg -i` through
+    // `pkexec`, falling back to zenity/kdialog and finally to a terminal `sudo` that a
+    // windowed app has no terminal for -- but that chain has too many ways to end in a
+    // half-finished install for something the user started with one click.
+    const deb = (await this.bundleType()) === 'deb'
+
+    return {
+      available: true,
+      version: update.version,
+      currentVersion: update.currentVersion,
+      body: update.body ?? undefined,
+      date: update.date ?? undefined,
+      canInstallInApp: !deb,
+      manualInstallReason: deb ? 'deb-package' : undefined,
+      downloadUrl: deb ? RELEASES_PAGE : undefined,
+    }
+  }
+
+  /** Android: read the release list ourselves and compare the tag with the running build. */
+  private async checkViaGitHub(): Promise<UpdateInfo> {
+    this.updateAvailable = null
+
+    const currentVersion = await getVersion()
+
+    // AbortController rather than `AbortSignal.timeout`, which the older Android System
+    // WebViews this app still runs on do not implement. Matches the rest of the codebase.
+    const ctrl = new AbortController()
+    const timer = setTimeout(() => ctrl.abort(), GITHUB_TIMEOUT_MS)
+
+    let response: Response
+    try {
+      response = await tauriHttpFetch(LATEST_RELEASE_API, {
+        method: 'GET',
+        headers: {
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+        signal: ctrl.signal,
+      })
+    } catch (error) {
+      // An aborted fetch reads as a generic DOMException, so name the real cause here
+      // rather than letting `classifyError` guess at it.
+      throw ctrl.signal.aborted
+        ? new UpdateError('network', 'The update check timed out.', error)
+        : error
+    } finally {
+      clearTimeout(timer)
+    }
+
+    if (response.status === 404) {
+      throw new UpdateError(
+        'no-release',
+        'No published release was found. If a release was just built, it may still be a draft.',
+      )
+    }
+    if (!response.ok) {
+      throw new UpdateError(
+        response.status === 403 ? 'network' : 'unknown',
+        `GitHub returned ${response.status} while checking for updates.`,
+      )
+    }
+
+    const release = (await response.json()) as GitHubRelease
+    const tag = release.tag_name?.trim()
+
+    if (!tag) {
+      throw new UpdateError('no-release', 'The latest release has no version tag.')
+    }
+    if (!isNewerVersion(tag, currentVersion)) {
+      return { available: false, currentVersion, canInstallInApp: false }
+    }
+
+    // Prefer the APK itself; fall back to the release page so the user is never left
+    // without somewhere to go when the asset is named unexpectedly.
+    const apk = release.assets?.find((asset) => asset.name?.toLowerCase().endsWith('.apk'))
+
+    return {
+      available: true,
+      version: tag.replace(/^v/, ''),
+      currentVersion,
+      body: release.body ?? undefined,
+      date: release.published_at ?? undefined,
+      downloadUrl: apk?.browser_download_url ?? release.html_url ?? RELEASES_PAGE,
+      canInstallInApp: false,
+      manualInstallReason: 'mobile-platform',
+    }
+  }
+
+  /**
+   * Opens the update's download in the system browser.
+   *
+   * The Android counterpart of `downloadAndInstall`: the browser downloads the APK and
+   * Android's own package installer takes it from there.
+   */
+  async openDownloadPage(): Promise<void> {
+    await openUrl(this.lastInfo?.downloadUrl ?? RELEASES_PAGE)
+  }
+
+  /**
+   * Downloads and installs the available update. Desktop only -- returns `false` when
+   * there is nothing staged, a download is already running, or the platform cannot install.
    */
   async downloadAndInstall(onProgress?: (progress: UpdateProgress) => void): Promise<boolean> {
     if (!this.updateAvailable || this.downloading) {
@@ -81,7 +328,7 @@ class UpdaterService {
             }
             break
           case 'Finished':
-            // Download complete
+            // Download complete; the installer runs next.
             break
         }
 
@@ -92,17 +339,16 @@ class UpdaterService {
 
       return true
     } catch (error) {
-      console.error('[Updater] Download/install failed:', error)
-      throw error
+      const classified = classifyError(error)
+      console.error('[Updater] Download/install failed:', classified.kind, classified.message)
+      throw classified
     } finally {
       this.downloading = false
       this.progress = null
     }
   }
 
-  /**
-   * Relaunch the application after update
-   */
+  /** Relaunches the app after an install. */
   async relaunch(): Promise<void> {
     try {
       await relaunch()
@@ -111,48 +357,26 @@ class UpdaterService {
     }
   }
 
-  /**
-   * Get current checking state
-   */
   isChecking(): boolean {
-    return this.checking
+    return this.inFlight !== null
   }
 
-  /**
-   * Get current downloading state
-   */
   isDownloading(): boolean {
     return this.downloading
   }
 
-  /**
-   * Get current download progress
-   */
   getProgress(): UpdateProgress | null {
     return this.progress
   }
 
-  /**
-   * Check if an update is available
-   */
   hasUpdate(): boolean {
-    return this.updateAvailable !== null
+    return this.lastInfo?.available === true
   }
 
-  /**
-   * Get the available update info
-   */
   getUpdateInfo(): UpdateInfo | null {
-    if (!this.updateAvailable) return null
-
-    return {
-      available: true,
-      version: this.updateAvailable.version,
-      currentVersion: this.updateAvailable.currentVersion,
-      body: this.updateAvailable.body ?? undefined,
-      date: this.updateAvailable.date ?? undefined,
-    }
+    return this.lastInfo?.available ? this.lastInfo : null
   }
 }
 
 export const updaterService = new UpdaterService()
+export { RELEASES_PAGE }

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -634,7 +634,6 @@ export function getDefaultWorldStateInjectionSettings(): WorldStateInjectionSett
 export function getDefaultUpdateSettings(): UpdateSettings {
   return {
     autoCheck: true,
-    autoDownload: false,
     checkInterval: 24, // Check every 24 hours
     lastChecked: null,
   }
@@ -2916,11 +2915,6 @@ class SettingsStore {
 
   async setAutoCheck(enabled: boolean) {
     this.updateSettings.autoCheck = enabled
-    await this.saveUpdateSettings()
-  }
-
-  async setAutoDownload(enabled: boolean) {
-    this.updateSettings.autoDownload = enabled
     await this.saveUpdateSettings()
   }
 

--- a/src/lib/stores/updateNotifier.svelte.ts
+++ b/src/lib/stores/updateNotifier.svelte.ts
@@ -1,0 +1,30 @@
+/**
+ * Cross-component handle for the update dialog.
+ *
+ * The dialog is mounted once, in `AppShell`, but the two things that open it are far apart:
+ * the startup check in `+page.svelte` and the "Check for Updates" button in the Interface
+ * settings tab. A store is what lets both raise the same window without either of them
+ * owning it.
+ */
+
+import type { UpdateInfo } from '$lib/services/updater'
+
+class UpdateNotifier {
+  /** Whether the dialog is showing. */
+  open = $state(false)
+  /** The update being offered. Never null while `open` is true. */
+  info = $state<UpdateInfo | null>(null)
+
+  /** Opens the dialog for an available update. Ignores a check that found nothing. */
+  show(info: UpdateInfo) {
+    if (!info.available) return
+    this.info = info
+    this.open = true
+  }
+
+  dismiss() {
+    this.open = false
+  }
+}
+
+export const updateNotifier = new UpdateNotifier()

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -733,9 +733,15 @@ export interface UISettings {
   storyMaxWidth: '2xl' | '3xl' | '4xl' | '5xl' | '7xl' | '9xl'
 }
 
+/**
+ * Note: an `autoDownload` flag lived here and is gone. It installed the update
+ * unattended, which on Windows launches the NSIS installer mid-session, and it could
+ * never do anything at all on Android, where the app cannot install its own APK. The
+ * dialog covers the same ground in one click, with the user present. A stored value for
+ * it is simply ignored, as with any other legacy settings key.
+ */
 export interface UpdateSettings {
   autoCheck: boolean // Check for updates on startup
-  autoDownload: boolean // Automatically download updates
   checkInterval: number // Hours between update checks (0 = only on startup)
   lastChecked: number | null // Timestamp of last check
 }

--- a/src/lib/utils/version.test.ts
+++ b/src/lib/utils/version.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import { parseVersion, compareVersions, isNewerVersion } from './version'
+
+describe('parseVersion', () => {
+  it('parses a plain version', () => {
+    expect(parseVersion('1.2.3')).toEqual({ major: 1, minor: 2, patch: 3, prerelease: [] })
+  })
+
+  it('accepts the v prefix that release tags carry', () => {
+    expect(parseVersion('v0.7.6')).toEqual({ major: 0, minor: 7, patch: 6, prerelease: [] })
+  })
+
+  it('splits pre-release identifiers on dots', () => {
+    expect(parseVersion('v1.0.0-pre.2')?.prerelease).toEqual(['pre', '2'])
+  })
+
+  it('discards build metadata', () => {
+    expect(parseVersion('1.0.0+20260808')).toEqual({
+      major: 1,
+      minor: 0,
+      patch: 0,
+      prerelease: [],
+    })
+  })
+
+  it('tolerates surrounding whitespace', () => {
+    expect(parseVersion('  1.0.0 ')?.major).toBe(1)
+  })
+
+  it.each(['', 'latest', '1.2', '1.2.3.4', 'v1.2.x', 'nightly-2026-08-08'])(
+    'returns null for %o',
+    (input) => {
+      expect(parseVersion(input)).toBeNull()
+    },
+  )
+})
+
+describe('compareVersions', () => {
+  it('orders by major, then minor, then patch', () => {
+    expect(compareVersions('2.0.0', '1.9.9')).toBeGreaterThan(0)
+    expect(compareVersions('1.2.0', '1.1.9')).toBeGreaterThan(0)
+    expect(compareVersions('1.1.2', '1.1.3')).toBeLessThan(0)
+  })
+
+  it('compares numerically, not lexically', () => {
+    // The whole reason this module exists: '0.10.0' < '0.9.0' as strings.
+    expect(compareVersions('0.10.0', '0.9.0')).toBeGreaterThan(0)
+    expect(compareVersions('1.0.10', '1.0.9')).toBeGreaterThan(0)
+  })
+
+  it('treats equal versions as equal regardless of the v prefix', () => {
+    expect(compareVersions('v1.2.3', '1.2.3')).toBe(0)
+  })
+
+  it('ranks a stable release above its own pre-release', () => {
+    expect(compareVersions('1.0.0', '1.0.0-pre.1')).toBeGreaterThan(0)
+    expect(compareVersions('1.0.0-pre.1', '1.0.0')).toBeLessThan(0)
+  })
+
+  it('orders pre-release numbers numerically', () => {
+    expect(compareVersions('1.0.0-pre.10', '1.0.0-pre.9')).toBeGreaterThan(0)
+  })
+
+  it('ranks a numeric identifier below an alphanumeric one', () => {
+    expect(compareVersions('1.0.0-1', '1.0.0-alpha')).toBeLessThan(0)
+  })
+
+  it('treats a longer identifier list as the later release when the prefix matches', () => {
+    expect(compareVersions('1.0.0-pre.1.1', '1.0.0-pre.1')).toBeGreaterThan(0)
+  })
+
+  it('throws rather than guessing an order for an unreadable version', () => {
+    expect(() => compareVersions('latest', '1.0.0')).toThrow(/Unparseable/)
+    expect(() => compareVersions('1.0.0', 'latest')).toThrow(/Unparseable/)
+  })
+})
+
+describe('isNewerVersion', () => {
+  it('is true only for a strictly greater candidate', () => {
+    expect(isNewerVersion('0.7.7', '0.7.6')).toBe(true)
+    expect(isNewerVersion('0.7.6', '0.7.6')).toBe(false)
+    expect(isNewerVersion('0.7.5', '0.7.6')).toBe(false)
+  })
+
+  it('does not offer a pre-release as an upgrade over the matching stable', () => {
+    expect(isNewerVersion('1.0.0-pre.1', '1.0.0')).toBe(false)
+  })
+
+  it('is false when either side is unparseable, so a bad tag cannot nag on every startup', () => {
+    expect(isNewerVersion('nightly', '0.7.6')).toBe(false)
+    expect(isNewerVersion('0.8.0', 'unknown')).toBe(false)
+  })
+})

--- a/src/lib/utils/version.ts
+++ b/src/lib/utils/version.ts
@@ -1,0 +1,104 @@
+/**
+ * Semver comparison for the update check.
+ *
+ * The desktop updater does its own comparison inside the Tauri plugin, but the Android
+ * path has none: it reads a release tag off the GitHub API and has to decide for itself
+ * whether that tag is newer than the running build. String comparison is not an option --
+ * `'0.10.0' > '0.9.0'` is false lexically and true in every sense that matters here.
+ *
+ * Kept as a plain module, with no dependency on the settings store or the Tauri APIs, so
+ * the suite can import it (`*.svelte.ts` files cannot be imported by tests -- see the
+ * README's Tests section).
+ */
+
+export interface ParsedVersion {
+  major: number
+  minor: number
+  patch: number
+  /**
+   * Dot-separated pre-release identifiers, empty for a stable release. `v1.2.3-pre.4`
+   * parses to `['pre', '4']`.
+   */
+  prerelease: string[]
+}
+
+/** `1.2.3`, `v1.2.3`, `1.2.3-pre.4`, with optional `+build` metadata that is discarded. */
+const VERSION_PATTERN = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/
+
+/**
+ * Parses a version string, returning `null` for anything unrecognised.
+ *
+ * A caller that gets `null` must not guess: a tag this cannot read is a tag whose ordering
+ * is unknown, and treating unknown as "newer" would offer an update on every check.
+ */
+export function parseVersion(input: string): ParsedVersion | null {
+  const match = VERSION_PATTERN.exec(input.trim())
+  if (!match) return null
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] ? match[4].split('.') : [],
+  }
+}
+
+/** Numeric identifiers compare numerically; anything else compares as text. */
+function compareIdentifiers(a: string, b: string): number {
+  const aNumeric = /^\d+$/.test(a)
+  const bNumeric = /^\d+$/.test(b)
+
+  if (aNumeric && bNumeric) return Number(a) - Number(b)
+  // Semver: a numeric identifier always sorts below an alphanumeric one.
+  if (aNumeric) return -1
+  if (bNumeric) return 1
+  return a < b ? -1 : a > b ? 1 : 0
+}
+
+function comparePrerelease(a: string[], b: string[]): number {
+  // A stable release outranks any pre-release of the same version.
+  if (a.length === 0 && b.length === 0) return 0
+  if (a.length === 0) return 1
+  if (b.length === 0) return -1
+
+  for (let i = 0; i < Math.min(a.length, b.length); i++) {
+    const diff = compareIdentifiers(a[i], b[i])
+    if (diff !== 0) return diff < 0 ? -1 : 1
+  }
+
+  // Every shared identifier matched, so the longer list is the later release.
+  return a.length - b.length === 0 ? 0 : a.length < b.length ? -1 : 1
+}
+
+/**
+ * Returns a negative number when `a` precedes `b`, positive when it follows, 0 when equal.
+ *
+ * Throws on an unparseable input rather than guessing an order -- see `parseVersion`.
+ */
+export function compareVersions(a: string, b: string): number {
+  const left = parseVersion(a)
+  const right = parseVersion(b)
+
+  if (!left) throw new Error(`Unparseable version: ${a}`)
+  if (!right) throw new Error(`Unparseable version: ${b}`)
+
+  if (left.major !== right.major) return left.major < right.major ? -1 : 1
+  if (left.minor !== right.minor) return left.minor < right.minor ? -1 : 1
+  if (left.patch !== right.patch) return left.patch < right.patch ? -1 : 1
+
+  return comparePrerelease(left.prerelease, right.prerelease)
+}
+
+/**
+ * Whether `candidate` is a release the user does not have yet.
+ *
+ * Returns `false` when either version is unparseable: an update prompt the user cannot
+ * make sense of, shown on every startup, is worse than a missed update.
+ */
+export function isNewerVersion(candidate: string, current: string): boolean {
+  try {
+    return compareVersions(candidate, current) > 0
+  } catch {
+    return false
+  }
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,6 +4,7 @@
   import { settings } from '$lib/stores/settings.svelte'
   import { grammarService } from '$lib/services/grammar'
   import { updaterService } from '$lib/services/updater'
+  import { updateNotifier } from '$lib/stores/updateNotifier.svelte'
   import { packService } from '$lib/services/packs/pack-service'
   import { warmupAllProfiles } from '$lib/services/modelHealthOrchestrator'
   import AppShell from '$lib/components/layout/AppShell.svelte'
@@ -39,7 +40,7 @@
 
       // Check for updates on startup if enabled (don't await, run in background)
       if (settings.updateSettings.autoCheck) {
-        const { checkInterval, lastChecked, autoDownload } = settings.updateSettings
+        const { checkInterval, lastChecked } = settings.updateSettings
         const now = Date.now()
         const shouldCheck =
           checkInterval <= 0
@@ -51,17 +52,14 @@
             .checkForUpdates()
             .then(async (updateInfo) => {
               await settings.setLastChecked(Date.now())
-              if (updateInfo.available) {
-                console.log(`[Updater] Update available: v${updateInfo.version}`)
-
-                // Auto-download if enabled
-                if (autoDownload) {
-                  console.log('[Updater] Auto-downloading update...')
-                  updaterService.downloadAndInstall().catch(console.error)
-                }
-              }
+              // Offer the update in a dialog rather than logging it: a console message
+              // reaches nobody outside a dev build.
+              updateNotifier.show(updateInfo)
             })
-            .catch(console.error)
+            // A failed startup check stays silent. The user did not ask for it, so an
+            // error toast about it would interrupt them over something they cannot act on;
+            // the manual button in Settings reports failures properly.
+            .catch((err) => console.error('[Updater] Startup check failed:', err))
         }
       }
 


### PR DESCRIPTION
Settings -> Interface -> Updates existed but could not finish the job, and the "Check on Startup" toggle reported an available update with a `console.log`.

### Android had no update path at all

`tauri-plugin-updater` declares Android support level `none`, and its `updater_os()` has branches for linux/macos/windows only. On Android `target_os` is `"android"`, so `check()` returned `UnsupportedOs` **before a request was ever sent** — the button read "Failed to check for updates" on every phone.

That path now reads the GitHub Releases API directly, compares the tag against `getVersion()`, and opens the `.apk` asset in the browser. There is no in-app install to add: an APK is installed by the system package installer, not by the app it replaces.

The comparison needs `src/lib/utils/version.ts`, since `'0.10.0' > '0.9.0'` is false lexically. It is a plain module with 22 tests, and returns `false` for an unparseable version rather than guessing — "unknown means newer" would offer an update on every startup.

### Two desktop cases hand off to the browser instead of installing

- **Unpackaged builds**, as a safety guard. On Linux the plugin's `extract_path` *is* the running executable, so in `tauri dev` "Download and install" moved the dev binary into a `TempDir`, wrote the release AppImage over it, then dropped the `TempDir` — deleting the backup — and reported success. `getBundleType()` returns `null` for a build the bundler never touched, which is exactly that case. (Does not fire on macOS, where `bundle_type()` falls back to `App`; noted in the README.)
- **`.deb` installs**, as a decision. `install_deb` shells out to `dpkg -i` through `pkexec`, falling back to zenity/kdialog and finally to a terminal `sudo` that a windowed app has no terminal for. Too many ways to end half-finished, and the package manager owns that install anyway.

`canInstallInApp` is the branch; `manualInstallReason` supplies the wording, because a `.deb` user is not on an unsupported platform and a developer is not a user at all.

### Release notes come from GitHub, not `latest.json`

`latest.json` is written by `tauri-action` at build time, so its `notes` are the fixed `releaseBody` string in `release.yml` — users saw "See the assets to download and install this version." The real notes are written on the release afterwards and can never reach that file, so both paths now read the release body from the API. Editing a published release's text updates every client with no rebuild.

The fetch is non-fatal (falls back to `latest.json`; the update is signed and installs either way) and its notes are used only when the tag matches the version being offered.

### Also here

- The dialog, on `ResponsiveModal`: centred on desktop, a bottom sheet on Android. Version, date, rendered notes, download progress, restart prompt.
- Concurrent checks share one in-flight promise. The startup check and the Settings button do race, and the loser was told "You're up to date!" about a request that had not returned.
- Errors are classified (`no-release`, `network`, `unsupported`), so a 404 from an unpublished draft no longer reads as a flat failure.
- The **Auto-download Updates** toggle is removed. It installed unattended — an NSIS installer mid-session on Windows — and could never do anything on Android. Off by default, so no existing behaviour changes. A stored value is ignored, as with any legacy settings key.
- README: how the two paths differ, that `RELEASE_REPO` and `updater.endpoints` must stay in step, and that **a draft release is invisible to the updater** — publishing the draft is what ships it.

### Testing

`build`, `lint`, `check` and the full suite (768 tests) pass. The dialog was exercised against the live v0.7.7 release from a 0.7.6 build. The Android path has not been run on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added update notifications with release notes, download progress, installation, restart, and manual-install options.
  * Added separate update flows for desktop and Android devices.
  * Updates can be checked automatically at startup or from Interface settings.
  * Added clearer handling for unsupported platforms, unavailable releases, and update errors.
  * Removed the automatic-download setting; updates are now offered for user approval.

* **Documentation**
  * Expanded update behavior and release-distribution documentation.

* **Tests**
  * Added coverage for version parsing, comparison, prereleases, and upgrade detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->