### PR TITLE
Release script: push over the contributor's own remote instead of a hardcoded HTTPS URL

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -16,9 +16,9 @@ import fs from 'fs'
 import { execFileSync } from 'child_process'
 import path from 'path'
 import { bumpVersion, isValidVersion, compareVersions } from './version.js'
+import { pickReleaseRemote } from './remote.js'
 
 const rootDir = process.cwd()
-const REMOTE = 'https://github.com/AventurasTeam/Aventuras.git'
 
 const KNOWN_FLAGS = ['--dry-run', '--no-merge-back']
 
@@ -70,6 +70,14 @@ function fail(message, hint) {
   if (hint) console.error(`  ${hint}`)
   process.exit(1)
 }
+
+/**
+ * Where the release is pushed. A configured remote pointing at the release repository when
+ * there is one, so the push uses the transport and credentials that remote already has --
+ * otherwise the canonical HTTPS URL. See `remote.js` for why this is not simply `origin`,
+ * and not a hardcoded URL either.
+ */
+const { ref: REMOTE, label: REMOTE_LABEL } = pickReleaseRemote(tryGit('remote', '-v').out)
 
 // ---------------------------------------------------------------------------
 // Pre-flight. Nothing below this block writes anything.
@@ -152,10 +160,15 @@ if (tryGit('rev-parse', '--verify', `refs/heads/${releaseBranch}`).ok) {
 
 // The network checks are here, with the cheap ones, because the whole point is that
 // nothing is written until every answer is in.
-console.log(`Checking ${REMOTE} for ${tag}...`)
+console.log(`Checking ${REMOTE_LABEL} for ${tag}...`)
 const remoteRefs = tryGit('ls-remote', REMOTE, `refs/tags/${tag}`, `refs/heads/${releaseBranch}`)
 if (!remoteRefs.ok) {
-  fail('Could not reach the release remote.', `${REMOTE} — check the network and your credentials.`)
+  fail(
+    'Could not reach the release remote.',
+    `${REMOTE_LABEL} — check the network and your credentials. If no configured remote ` +
+      'points at the release repository, this falls back to an HTTPS URL, which GitHub no ' +
+      'longer accepts a password for.',
+  )
 }
 if (remoteRefs.out.includes(`refs/tags/${tag}`)) {
   fail(`Tag ${tag} already exists on the remote.`, 'That version has already been released.')
@@ -167,7 +180,7 @@ if (remoteRefs.out.includes(`refs/heads/${releaseBranch}`)) {
 console.log(`\n${currentVersion} → ${newVersion}`)
 console.log(`  branch:      ${releaseBranch}`)
 console.log(`  tag:         ${tag}`)
-console.log(`  remote:      ${REMOTE}`)
+console.log(`  remote:      ${REMOTE_LABEL}`)
 console.log(`  merge back:  ${mergeBack ? startBranch : 'no (--no-merge-back)'}`)
 
 if (dryRun) {

--- a/scripts/remote.js
+++ b/scripts/remote.js
@@ -1,0 +1,62 @@
+/**
+ * Choosing the remote `scripts/release.js` pushes a release to. Split out so it can be
+ * tested without importing the script, which cuts a release on import.
+ *
+ * The release must land on the canonical repository and never on a fork, so this cannot
+ * simply use `origin`. It used to be a hardcoded HTTPS URL, which held that guarantee but
+ * also forced the transport: GitHub dropped password authentication for HTTPS, so anyone
+ * without a credential helper could not push at all, while their working SSH remote sat
+ * unused two lines away.
+ *
+ * So: pick a *configured remote* that points at the release repository, and let git use
+ * whatever transport and credentials that remote already has. The guarantee is preserved
+ * by matching on the repository the remote points to, not on its name.
+ */
+
+export const RELEASE_REPO = 'AventurasTeam/Aventuras'
+export const RELEASE_REPO_URL = `https://github.com/${RELEASE_REPO}.git`
+
+/**
+ * Repository paths that are the release repository.
+ *
+ * `unkarelian/Aventuras` is the name it had before the rename; GitHub redirects it, so a
+ * contributor whose remote predates the move is still pointing here and their push works.
+ * The owner is part of every entry on purpose -- forks share the repository *name*, and
+ * matching on the name alone would quietly release from someone's fork.
+ */
+const RELEASE_REPO_PATHS = new Set(['aventurasteam/aventuras', 'unkarelian/aventuras'])
+
+/**
+ * `owner/name` for a GitHub remote URL, lowercased, or `null` if it is not one.
+ *
+ * Handles the forms git actually stores: `git@github.com:owner/name.git`,
+ * `https://github.com/owner/name(.git)`, and `ssh://git@github.com/owner/name.git`.
+ */
+export function githubRepoPath(url) {
+  const match = /github\.com[/:]+([^/\s]+)\/([^/\s]+?)(?:\.git)?\/?$/.exec(String(url).trim())
+  return match ? `${match[1]}/${match[2]}`.toLowerCase() : null
+}
+
+/**
+ * Picks the release remote from the output of `git remote -v`.
+ *
+ * Returns `{ ref, label }`: `ref` is what to hand to git -- a remote name when one matched,
+ * otherwise the canonical HTTPS URL, which keeps the previous behaviour for a checkout with
+ * no suitable remote (a fresh clone of a fork, say). `label` is for the console, because
+ * printing a bare name like "upstream" would hide which repository is about to be released
+ * to, and that is the one thing the operator most needs to see.
+ *
+ * Push URLs only: a remote can fetch and push to different places, and pushing is what
+ * this is for.
+ */
+export function pickReleaseRemote(remoteVerbose) {
+  for (const line of String(remoteVerbose ?? '').split('\n')) {
+    const [name, url, kind] = line.trim().split(/\s+/)
+    if (!name || !url || kind !== '(push)') continue
+    if (RELEASE_REPO_PATHS.has(githubRepoPath(url))) {
+      return { ref: name, label: `${name} (${url})` }
+    }
+  }
+
+  return { ref: RELEASE_REPO_URL, label: RELEASE_REPO_URL }
+}

--- a/scripts/remote.test.js
+++ b/scripts/remote.test.js
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { githubRepoPath, pickReleaseRemote, RELEASE_REPO_URL } from './remote.js'
+
+describe('githubRepoPath', () => {
+  it.each([
+    ['git@github.com:AventurasTeam/Aventuras.git', 'aventurasteam/aventuras'],
+    ['https://github.com/AventurasTeam/Aventuras.git', 'aventurasteam/aventuras'],
+    ['https://github.com/AventurasTeam/Aventuras', 'aventurasteam/aventuras'],
+    ['https://github.com/AventurasTeam/Aventuras/', 'aventurasteam/aventuras'],
+    ['ssh://git@github.com/AventurasTeam/Aventuras.git', 'aventurasteam/aventuras'],
+  ])('reads %o', (url, expected) => {
+    expect(githubRepoPath(url)).toBe(expected)
+  })
+
+  it('lowercases, so a differently-cased remote still matches', () => {
+    expect(githubRepoPath('git@github.com:AVENTURASTEAM/AVENTURAS.git')).toBe(
+      'aventurasteam/aventuras',
+    )
+  })
+
+  it.each(['', 'not a url', 'git@gitlab.com:AventurasTeam/Aventuras.git'])(
+    'returns null for %o',
+    (url) => {
+      expect(githubRepoPath(url)).toBeNull()
+    },
+  )
+})
+
+const line = (name, url, kind) => `${name}\t${url} (${kind})`
+
+describe('pickReleaseRemote', () => {
+  it('picks the remote pointing at the release repo, whatever it is called', () => {
+    const out = [
+      line('origin', 'git@github.com:Pento95/Aventuras.git', 'fetch'),
+      line('origin', 'git@github.com:Pento95/Aventuras.git', 'push'),
+      line('upstream', 'git@github.com:AventurasTeam/Aventuras.git', 'fetch'),
+      line('upstream', 'git@github.com:AventurasTeam/Aventuras.git', 'push'),
+    ].join('\n')
+
+    expect(pickReleaseRemote(out).ref).toBe('upstream')
+  })
+
+  it('accepts the pre-rename path, which GitHub redirects here', () => {
+    const out = line('upstream', 'git@github.com:unkarelian/Aventuras.git', 'push')
+    expect(pickReleaseRemote(out).ref).toBe('upstream')
+  })
+
+  it('never picks a fork, which shares the repository name', () => {
+    // The whole reason the match includes the owner.
+    const out = [
+      line('origin', 'git@github.com:Pento95/Aventuras.git', 'push'),
+      line('other', 'git@github.com:SomeoneElse/Aventuras.git', 'push'),
+    ].join('\n')
+
+    expect(pickReleaseRemote(out).ref).toBe(RELEASE_REPO_URL)
+  })
+
+  it('ignores fetch-only entries, since pushing is what this is for', () => {
+    const out = [
+      line('mirror', 'git@github.com:AventurasTeam/Aventuras.git', 'fetch'),
+      line('mirror', 'git@github.com:Pento95/Aventuras.git', 'push'),
+    ].join('\n')
+
+    expect(pickReleaseRemote(out).ref).toBe(RELEASE_REPO_URL)
+  })
+
+  it('falls back to the canonical URL when no remote matches', () => {
+    const out = line('origin', 'git@github.com:Pento95/Aventuras.git', 'push')
+    expect(pickReleaseRemote(out).ref).toBe(RELEASE_REPO_URL)
+  })
+
+  it.each([
+    ['', 'empty'],
+    [null, 'null'],
+    [undefined, 'undefined'],
+  ])('falls back for %o input (%s)', (input) => {
+    expect(pickReleaseRemote(input).ref).toBe(RELEASE_REPO_URL)
+  })
+
+  it('labels a matched remote with its URL, so the target repo stays visible', () => {
+    const out = line('upstream', 'git@github.com:AventurasTeam/Aventuras.git', 'push')
+    expect(pickReleaseRemote(out).label).toBe(
+      'upstream (git@github.com:AventurasTeam/Aventuras.git)',
+    )
+  })
+})


### PR DESCRIPTION
`npm run release` cannot push for anyone without an HTTPS credential helper:

```
Username for 'https://github.com': …
remote: Password authentication is not supported for Git operations.
```

`scripts/release.js` pushed to a hardcoded `https://github.com/AventurasTeam/Aventuras.git`. GitHub no longer accepts a password there, so the push fails outright — while the contributor's working SSH remote sits unused two lines away. (Present since `5fd37fcb`, February; it just needed someone to cut a release from a clone without a helper.)

### The fix

The URL was not arbitrary — releasing to `origin` would happily tag a **fork**, and hardcoding guaranteed the canonical repository. This keeps that guarantee and drops the transport:

`pickReleaseRemote` scans `git remote -v` for a remote whose **push URL points at the release repository** and hands git that remote's name, so the push uses whatever transport and credentials that remote already has. When nothing matches it falls back to the HTTPS URL, i.e. today's behaviour.

Two details that matter:

- **Matching is on the repository path, never the remote name**, so a fork cannot be selected however it is called. A test pins this.
- **`unkarelian/Aventuras` is accepted alongside `AventurasTeam/Aventuras`.** GitHub redirects the pre-rename path, so a remote predating the move still points here — and matching on the repository *name* alone would sweep up every fork, which is exactly what the owner check is for.

### Notes

- Extracted into `scripts/remote.js` rather than left inline: `release.js` cuts a release on import, so it cannot be imported by a test. 18 cases in `scripts/remote.test.js`, following the `version.js` / `version.test.js` split from #416.
- The console now prints `upstream (git@github.com:...)` instead of a bare remote name, so the repository about to be released to stays visible.
- The failure hint for an unreachable remote now names the HTTPS fallback as a likely cause.

### Testing

`lint`, `check` and the full suite (860) pass. Verified against a clone whose `upstream` is SSH:

```
Checking upstream (git@github.com:unkarelian/Aventuras.git) for v0.7.8...
  remote:      upstream (git@github.com:unkarelian/Aventuras.git)
--dry-run: every check passed, nothing was written.
```

The same command previously resolved to the HTTPS URL and prompted for a username.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
