### PR TITLE
Branches panel: jump to a branch's fork point

### DIFF
--- a/src/lib/components/branch/BranchPanel.svelte
+++ b/src/lib/components/branch/BranchPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { story } from '$lib/stores/story.svelte'
+  import { ui } from '$lib/stores/ui.svelte'
   import { ask } from '@tauri-apps/plugin-dialog'
   import {
     GitBranch,
@@ -10,6 +11,7 @@
     Edit2,
     Check,
     X,
+    Crosshair,
   } from '@lucide/svelte'
   import type { Branch, Checkpoint } from '$lib/types'
   import { SvelteSet } from 'svelte/reactivity'
@@ -174,6 +176,24 @@
   function isCurrent(branchId: string | null): boolean {
     return story.currentStory?.currentBranchId === branchId
   }
+
+  // Ids the story view can actually scroll to. `story.entries` is the ACTIVE branch's
+  // view — main + ancestors up to their forks + the branch itself — so a branch outside
+  // the current lineage (a sibling's child, say) has its fork entry nowhere in here.
+  const visibleEntryIds = $derived(new Set(story.entries.map((e) => e.id)))
+
+  function canGoToForkPoint(branch: Branch): boolean {
+    return visibleEntryIds.has(branch.forkEntryId)
+  }
+
+  function goToForkPoint(branch: Branch) {
+    // Fork points live in the story, which may not be the panel that's up — and while
+    // it isn't, StoryView is destroyed rather than hidden (see AppShell). So the request
+    // is left on the ui store for it to pick up on mount, not emitted at it.
+    ui.requestEntryScroll(branch.forkEntryId)
+    ui.setActivePanel('story')
+    ui.closeSidebarOnMobile()
+  }
 </script>
 
 <div class="space-y-3">
@@ -298,6 +318,22 @@
           {#if isCurrent(branch.id)}
             <span class="bg-accent-500 h-2 w-2 rounded-full" title="Current branch"></span>
           {/if}
+          {@const forkReachable = canGoToForkPoint(branch)}
+          <button
+            class="text-surface-500 flex min-h-[32px] min-w-[32px] items-center justify-center p-1 transition-opacity sm:min-h-0 sm:min-w-0 sm:p-0.5 {forkReachable
+              ? 'hover:text-surface-200 sm:opacity-0 sm:group-hover:opacity-100'
+              : 'cursor-not-allowed opacity-30'}"
+            onclick={(e) => {
+              e.stopPropagation()
+              goToForkPoint(branch)
+            }}
+            disabled={!forkReachable}
+            title={forkReachable
+              ? 'Go to fork point'
+              : "Fork point is not in the current branch's timeline — switch to this branch or its parent first"}
+          >
+            <Crosshair class="h-4 w-4 sm:h-3 sm:w-3" />
+          </button>
           <button
             class="text-surface-500 hover:text-surface-200 flex min-h-[32px] min-w-[32px] items-center justify-center p-1 transition-opacity sm:min-h-0 sm:min-w-0 sm:p-0.5 sm:opacity-0 sm:group-hover:opacity-100"
             onclick={(e) => {

--- a/src/lib/components/branch/BranchPanel.svelte
+++ b/src/lib/components/branch/BranchPanel.svelte
@@ -322,11 +322,12 @@
           <button
             class="text-surface-500 flex min-h-[32px] min-w-[32px] items-center justify-center p-1 transition-opacity sm:min-h-0 sm:min-w-0 sm:p-0.5 {forkReachable
               ? 'hover:text-surface-200 sm:opacity-0 sm:group-hover:opacity-100'
-              : 'cursor-not-allowed opacity-30'}"
+              : 'cursor-not-allowed opacity-30 sm:opacity-0 sm:group-hover:opacity-30'}"
             onclick={(e) => {
               e.stopPropagation()
               goToForkPoint(branch)
             }}
+            onkeydown={(e) => e.stopPropagation()}
             disabled={!forkReachable}
             title={forkReachable
               ? 'Go to fork point'

--- a/src/lib/components/story/StoryView.svelte
+++ b/src/lib/components/story/StoryView.svelte
@@ -90,8 +90,9 @@
     if (currentStoryId !== lastStoryId) {
       lastStoryId = currentStoryId
       prevEntryCount = story.entries.length
-      // Drop any deferred landing: its branch belongs to the story we just left
+      // Drop any deferred landing: its branch or entry belongs to the story we just left
       pendingBranchLanding = null
+      ui.consumeEntryScroll()
       anchorToBottom(story.entries.length)
       tick().then(() => performScroll())
     }
@@ -251,27 +252,36 @@
     scrollEntryIntoView(lastEntry.id)
   }
 
-  async function landOnForkEntry(branchId: string | null) {
+  // Window the virtual list around one entry and scroll to it. Returns false, having
+  // changed nothing, when the entry isn't in the current branch's view — the view can
+  // only scroll to what it can render, and the caller decides what to do instead.
+  async function landOnEntry(entryId: string): Promise<boolean> {
     const entries = story.entries
-    const forkEntryId = branchId
-      ? (story.branches.find((b) => b.id === branchId)?.forkEntryId ?? null)
-      : null
-    const idx = forkEntryId ? entries.findIndex((e) => e.id === forkEntryId) : -1
-
-    // Main branch, or fork entry not in this branch's entries → land on the last entry
-    if (!forkEntryId || idx === -1) {
-      await landOnLastEntry()
-      return
-    }
+    const idx = entries.findIndex((e) => e.id === entryId)
+    if (idx === -1) return false
 
     const total = entries.length
     prevEntryCount = total
+    // Landing away from the end is a scroll break: the next narration must not yank
+    // the view back to the bottom while the user reads where they asked to be.
     ui.setScrollBreak(true)
     windowStart = Math.max(0, idx - FORK_CONTEXT_BEFORE)
     windowEnd = Math.min(total, idx + DEFAULT_VISIBLE_ENTRIES)
     await tick()
 
-    scrollEntryIntoView(forkEntryId)
+    scrollEntryIntoView(entryId)
+    return true
+  }
+
+  async function landOnForkEntry(branchId: string | null) {
+    const forkEntryId = branchId
+      ? (story.branches.find((b) => b.id === branchId)?.forkEntryId ?? null)
+      : null
+
+    // Main branch, or fork entry not in this branch's entries → land on the last entry
+    if (!forkEntryId || !(await landOnEntry(forkEntryId))) {
+      await landOnLastEntry()
+    }
   }
 
   function performBranchLanding(branchId: string | null) {
@@ -406,11 +416,34 @@
         pendingBranchLanding = null
         if (pending) {
           performBranchLanding(pending.branchId)
-        } else {
-          scrollToBottom()
+          return
         }
+        // …as does a jump-to-entry request made from another panel, which is why the
+        // request lives on the ui store: this component is destroyed while another
+        // panel is up, so it cannot be waiting on an event when the request is made.
+        // Read untracked — consuming it must not re-run this effect and undo the
+        // landing with the scrollToBottom below.
+        const entryId = ui.consumeEntryScroll()
+        if (entryId) {
+          void landOnEntry(entryId)
+          return
+        }
+        scrollToBottom()
       })
     }
+  })
+
+  // The same request, arriving while the story panel is already up — the effect above
+  // won't re-run, since neither activePanel nor storyContainer changed. Declared after
+  // it so that on a remount the panel effect takes the request first and this one finds
+  // nothing; consumeEntryScroll is atomic, so exactly one of the two ever lands it.
+  $effect(() => {
+    const entryId = ui.pendingEntryScrollId
+    if (!entryId || ui.activePanel !== 'story' || !storyContainer) return
+    untrack(() => {
+      ui.consumeEntryScroll()
+      void landOnEntry(entryId)
+    })
   })
 
   // Format background image URL (handling raw base64 vs data URL)

--- a/src/lib/components/story/StoryView.svelte
+++ b/src/lib/components/story/StoryView.svelte
@@ -418,18 +418,20 @@
         // A branch switch that happened while the panel was hidden lands now instead
         const pending = pendingBranchLanding
         pendingBranchLanding = null
-        if (pending) {
-          performBranchLanding(pending.branchId)
-          return
-        }
         // …as does a jump-to-entry request made from another panel, which is why the
         // request lives on the ui store: this component is destroyed while another
         // panel is up, so it cannot be waiting on an event when the request is made.
         // Read untracked — consuming it must not re-run this effect and undo the
         // landing with the scrollToBottom below.
-        // Consumed either way, so a request that can no longer be honoured — one made
-        // for a story that was closed before the panel came back — doesn't linger.
+        // Consumed before the branch-landing return, so a request that can no longer be
+        // honoured — one made for a story that was closed before the panel came back, or
+        // one a branch landing takes precedence over — doesn't linger and get picked up
+        // by the trailing effect as a second landing competing with this one.
         const entryId = ui.consumeEntryScroll()
+        if (pending) {
+          performBranchLanding(pending.branchId)
+          return
+        }
         if (entryId && story.entries.some((e) => e.id === entryId)) {
           void landOnEntry(entryId)
           return

--- a/src/lib/components/story/StoryView.svelte
+++ b/src/lib/components/story/StoryView.svelte
@@ -88,11 +88,15 @@
     const currentStoryId = story.currentStory?.id ?? null
 
     if (currentStoryId !== lastStoryId) {
+      const isRemount = lastStoryId === null
       lastStoryId = currentStoryId
       prevEntryCount = story.entries.length
       // Drop any deferred landing: its branch or entry belongs to the story we just left
       pendingBranchLanding = null
-      ui.consumeEntryScroll()
+      // Only when we actually left a story. This component is destroyed whenever another
+      // panel is up, so every mount arrives here with lastStoryId still null and would
+      // otherwise discard the very request that brought the panel back.
+      if (!isRemount) ui.consumeEntryScroll()
       anchorToBottom(story.entries.length)
       tick().then(() => performScroll())
     }
@@ -423,8 +427,10 @@
         // panel is up, so it cannot be waiting on an event when the request is made.
         // Read untracked — consuming it must not re-run this effect and undo the
         // landing with the scrollToBottom below.
+        // Consumed either way, so a request that can no longer be honoured — one made
+        // for a story that was closed before the panel came back — doesn't linger.
         const entryId = ui.consumeEntryScroll()
-        if (entryId) {
+        if (entryId && story.entries.some((e) => e.id === entryId)) {
           void landOnEntry(entryId)
           return
         }

--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -33,6 +33,7 @@ export interface RetrievalCacheKey {
   actionContent: string
 }
 import type { SyncMode } from '$lib/types/sync'
+import { DESKTOP_BREAKPOINT } from '$lib/constants/layout'
 import { SimpleActivationTracker } from '$lib/services/ai/retrieval/EntryRetrievalService'
 import { database } from '$lib/services/database'
 import { SvelteMap, SvelteSet } from 'svelte/reactivity'
@@ -339,6 +340,40 @@ class UIStore {
       // No DB persist — this is a layout constraint, not a user preference.
       // Persisting here would overwrite the desktop sidebar preference.
     }
+  }
+
+  /**
+   * Get the sidebar out of the way when a sidebar control acts on the main content.
+   * Below DESKTOP_BREAKPOINT the sidebar is a near-fullscreen overlay (see AppShell's
+   * `@media (max-width: 768px)`), so the result of such an action would be invisible.
+   * Not persisted, for the same reason as setMobileDefaults: a mobile layout constraint
+   * must not overwrite the desktop sidebar preference.
+   */
+  closeSidebarOnMobile() {
+    if (typeof window !== 'undefined' && window.innerWidth <= DESKTOP_BREAKPOINT) {
+      this.sidebarOpen = false
+    }
+  }
+
+  /**
+   * A pending request for the story view to bring one entry into view.
+   *
+   * Deliberately durable state rather than an event: the requester is typically another
+   * panel (the Branches sidebar), and AppShell destroys StoryView whenever activePanel
+   * isn't 'story'. An event emitted while switching back would reach nobody, because the
+   * subscriber remounts a tick later. StoryView consumes this once it has a container.
+   */
+  pendingEntryScrollId = $state<string | null>(null)
+
+  requestEntryScroll(entryId: string) {
+    this.pendingEntryScrollId = entryId
+  }
+
+  /** Take the pending request, if any, and clear it. */
+  consumeEntryScroll(): string | null {
+    const entryId = this.pendingEntryScrollId
+    this.pendingEntryScrollId = null
+    return entryId
   }
 
   openSettings() {


### PR DESCRIPTION
Follow-up to #421. That PR made a branch's divergence point *visible* — the in-branch `GitBranch` marker — and made the view *land* there on a branch switch, behind the `branchSwitchLanding` Labs flag. Neither is reachable on demand: the marker is a passive icon, and the landing only fires at the moment of a switch. Scroll away and there is no way back.

This adds a per-branch button in the Branches sidebar tab.

## Reachability is a real constraint, not a detail

`story.entries` is the **active** branch's view — main, plus each ancestor up to its fork, plus the branch itself. So a branch outside the current lineage has its fork entry nowhere in it:

| Active branch | Branch B (forked off main) | Branch C (forked off B) |
| --- | --- | --- |
| main | ✅ in view | ❌ C's fork entry belongs to B |
| C | ✅ | ✅ |

The button is disabled for the unreachable case, with a tooltip naming the switch that would fix it. This mirrors how Delete already reports "has child branches" rather than silently doing nothing. `landOnEntry` independently returns `false` without touching any state when the entry isn't there, so the guard failing open is still safe.

## Why the request is store state and not an event

`AppShell` renders `StoryView` inside `{#if ui.activePanel === 'story'}` — while another panel is up the component is **destroyed**, not hidden, so its `$effect` subscriptions are gone. Clicking the button from the Lorebook panel does `setActivePanel('story')` and the component remounts a tick later; an event emitted in between would reach nobody.

So the request lives on the ui store as `pendingEntryScrollId`, and `StoryView` picks it up once it has a container. #421's `pendingBranchLanding` deferral is untouched and still covers its own case.

## Not fighting the panel effect

The panel effect scrolls to the bottom on every mount, which would undo the landing. Two things keep them apart:

- `consumeEntryScroll()` reads and clears in one step, so **exactly one** of the two consumers can ever land a given request.
- The panel effect reads it **untracked**, so clearing the request cannot re-run that effect and fall through to `scrollToBottom()`.

The second consumer is declared after the panel effect, so on a remount the panel effect takes the request first — that ordering is an optimisation, not a correctness requirement, since consumption is atomic either way.

## Also

- `landOnForkEntry`'s body is extracted as `landOnEntry(entryId)`; `landOnForkEntry` now expresses its main-branch fallback through it. No behaviour change on the #421 path.
- On mobile the sidebar is a near-fullscreen overlay (`@media (max-width: 768px)`), so it closes on the way out. Not persisted — same reason `setMobileDefaults` doesn't: a layout constraint must not overwrite the desktop sidebar preference.
- Landing away from the end sets the scroll break, so the next narration doesn't yank the view back to the bottom while you're reading where you asked to be.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added navigation from branch fork points directly to their related story entries.
  * Story panels now automatically scroll to requested entries, including when opened after the request.
  * Navigation preserves surrounding story context and falls back gracefully when an entry is unavailable.
  * Added responsive sidebar handling that closes the sidebar on smaller screens after navigation.
  * Unavailable fork points are disabled and provide explanatory tooltips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->