### PR TITLE
Sync: multi-select pull/push in the sync modal

### DIFF
--- a/src/lib/components/sync/SyncModal.svelte
+++ b/src/lib/components/sync/SyncModal.svelte
@@ -139,16 +139,19 @@
     showReceivedConflict = false
 
     try {
-      // If replacing, delete the existing story first
+      // Look up the existing same-titled story before importing: the freshly imported
+      // story shares that title and sorts first by updated_at, so finding it afterward
+      // would return the new story's own id instead of the one to replace.
       const existingId = await syncService.findStoryIdByTitle(receivedStoryPreview.title)
-      if (existingId) {
-        await syncService.createPreSyncBackup(existingId)
-        await syncService.deleteStory(existingId)
-      }
 
+      // Import the replacement before deleting anything, so a failed import never
+      // leaves the device with neither copy.
       const result = await exportService.importFromContent(receivedStoryJson, true)
 
       if (result.success) {
+        if (existingId) {
+          await syncService.deleteStory(existingId)
+        }
         await story.loadAllStories()
         syncSuccess = true
         syncMessage = `Successfully received "${receivedStoryPreview.title}"`
@@ -347,6 +350,9 @@
   }
 
   function toggleRemoteSelection(id: string) {
+    // A pending conflict warning was checked against the selection as it stood a moment
+    // ago; any change here invalidates it, so force a fresh check on the next attempt.
+    cancelConflict()
     const next = new SvelteSet(selectedRemoteIds)
     if (next.has(id)) next.delete(id)
     else next.add(id)
@@ -361,6 +367,7 @@
   }
 
   function toggleSelectAllRemote() {
+    cancelConflict()
     selectedRemoteIds =
       selectedRemoteIds.size === remoteStories.length
         ? new Set()
@@ -416,8 +423,8 @@
       }
     }
 
-    ui.setSyncMode('syncing')
     syncDirection = 'pull'
+    ui.setSyncMode('syncing')
     loading = true
     error = null
     showConflictWarning = false
@@ -426,34 +433,41 @@
     const succeeded: string[] = []
     const failed: string[] = []
 
-    // Pulled sequentially: each story is a separate authenticated request and gets
-    // its own pre-sync backup, so one failure never affects the others in the batch.
-    for (const s of storiesToPull) {
-      try {
-        const existingId = await syncService.findStoryIdByTitle(s.title)
-        if (existingId) {
-          await syncService.createPreSyncBackup(existingId)
-          await syncService.deleteStory(existingId)
-        }
+    try {
+      for (const s of storiesToPull) {
+        try {
+          // Look up the existing same-titled story before importing: the freshly imported
+          // story shares that title and sorts first by updated_at, so finding it afterward
+          // would return the new story's own id instead of the one to replace.
+          const existingId = await syncService.findStoryIdByTitle(s.title)
 
-        const storyJson = await syncService.pullStory(conn, s.id)
-        // Use skipImportedSuffix=true so synced stories keep their original title
-        const result = await exportService.importFromContent(storyJson, true)
+          // Import the replacement before deleting anything, so a failed pull/import
+          // never leaves the device with neither copy.
+          const storyJson = await syncService.pullStory(conn, s.id)
+          // Use skipImportedSuffix=true so synced stories keep their original title
+          const result = await exportService.importFromContent(storyJson, true)
 
-        if (result.success) {
-          succeeded.push(s.title)
-        } else {
+          if (result.success) {
+            if (existingId) {
+              await syncService.deleteStory(existingId)
+            }
+            succeeded.push(s.title)
+          } else {
+            failed.push(s.title)
+          }
+        } catch {
           failed.push(s.title)
         }
-      } catch {
-        failed.push(s.title)
+        syncProgress = { done: syncProgress.done + 1, total: storiesToPull.length }
       }
-      syncProgress = { done: syncProgress.done + 1, total: storiesToPull.length }
+
+      await story.loadAllStories()
+    } finally {
+      loading = false
     }
 
-    await story.loadAllStories()
-    loading = false
     reportBatchResult('pulled', succeeded, failed, storiesToPull.length)
+    if (!syncSuccess) ui.setSyncMode('connected')
   }
 
   async function pushSelectedStories() {
@@ -462,30 +476,42 @@
 
     const storiesToPush = localStories.filter((s) => selectedLocalIds.has(s.id))
 
-    ui.setSyncMode('syncing')
     syncDirection = 'push'
+    ui.setSyncMode('syncing')
     loading = true
     error = null
     syncProgress = { done: 0, total: storiesToPush.length }
 
+    // createPreSyncBackup() loads each pushed story into the global story store as a
+    // side effect; restore whatever was open before this batch once it's done.
+    const originalStoryId = story.currentStory?.id ?? null
     const succeeded: string[] = []
     const failed: string[] = []
 
-    for (const s of storiesToPush) {
-      try {
-        // Create backup before pushing (on local device)
-        await syncService.createPreSyncBackup(s.id)
-        const storyJson = await syncService.exportStoryToJson(s.id)
-        await syncService.pushStory(conn, storyJson)
-        succeeded.push(s.title)
-      } catch {
-        failed.push(s.title)
+    try {
+      for (const s of storiesToPush) {
+        try {
+          // Create backup before pushing (on local device)
+          await syncService.createPreSyncBackup(s.id)
+          const storyJson = await syncService.exportStoryToJson(s.id)
+          await syncService.pushStory(conn, storyJson)
+          succeeded.push(s.title)
+        } catch {
+          failed.push(s.title)
+        }
+        syncProgress = { done: syncProgress.done + 1, total: storiesToPush.length }
       }
-      syncProgress = { done: syncProgress.done + 1, total: storiesToPush.length }
+    } finally {
+      if (originalStoryId) {
+        await story.loadStory(originalStoryId).catch(() => {})
+      } else {
+        story.closeStory()
+      }
+      loading = false
     }
 
-    loading = false
     reportBatchResult('pushed', succeeded, failed, storiesToPush.length)
+    if (!syncSuccess) ui.setSyncMode('connected')
   }
 
   function cancelConflict() {
@@ -606,7 +632,7 @@
             <h3 class="mb-2 text-lg font-semibold">Story Already Exists</h3>
             <p class="text-muted-foreground mb-4">
               A story named "{receivedStoryPreview.title}" already exists on this device. Replacing
-              it will create a "Pre-sync backup" checkpoint first. Continue?
+              it will remove the existing copy once the new one has been imported. Continue?
             </p>
             <div class="flex gap-3">
               <Button variant="outline" onclick={cancelReceivedImport}>Cancel</Button>
@@ -693,11 +719,11 @@
               <p class="text-sm">
                 {#if conflictStoryTitles.length === 1}
                   A story named "{conflictStoryTitles[0]}" already exists on this device. Pulling
-                  will replace it after creating a "Pre-sync backup" checkpoint.
+                  will remove the existing copy once the new one has been downloaded.
                 {:else}
                   {conflictStoryTitles.length} selected stories already exist on this device:
-                  {conflictStoryTitles.join(', ')}. Pulling will replace them, each after creating
-                  its own "Pre-sync backup" checkpoint.
+                  {conflictStoryTitles.join(', ')}. Pulling will remove each existing copy once its
+                  replacement has been downloaded.
                 {/if}
               </p>
               <div class="mt-3 flex gap-2">

--- a/src/lib/components/sync/SyncModal.svelte
+++ b/src/lib/components/sync/SyncModal.svelte
@@ -148,15 +148,22 @@
       // leaves the device with neither copy.
       const result = await exportService.importFromContent(receivedStoryJson, true)
 
-      if (result.success) {
+      if (!result.success) {
+        error = result.error ?? 'Import failed'
+      } else {
         if (existingId) {
-          await syncService.deleteStory(existingId)
+          try {
+            await syncService.deleteStory(existingId)
+          } catch {
+            // The new copy imported fine but removing the old one failed: roll back
+            // the new copy rather than leave two stories with the same title.
+            await syncService.deleteStory(result.storyId!).catch(() => {})
+            throw new Error('Failed to remove the previous copy of this story')
+          }
         }
         await story.loadAllStories()
         syncSuccess = true
         syncMessage = `Successfully received "${receivedStoryPreview.title}"`
-      } else {
-        error = result.error ?? 'Import failed'
       }
     } catch (e) {
       error = e instanceof Error ? e.message : 'Import failed'
@@ -447,13 +454,20 @@
           // Use skipImportedSuffix=true so synced stories keep their original title
           const result = await exportService.importFromContent(storyJson, true)
 
-          if (result.success) {
-            if (existingId) {
-              await syncService.deleteStory(existingId)
-            }
-            succeeded.push(s.title)
-          } else {
+          if (!result.success) {
             failed.push(s.title)
+          } else if (existingId) {
+            try {
+              await syncService.deleteStory(existingId)
+              succeeded.push(s.title)
+            } catch {
+              // The new copy imported fine but removing the old one failed: roll back
+              // the new copy rather than leave two stories with the same title.
+              await syncService.deleteStory(result.storyId!).catch(() => {})
+              failed.push(s.title)
+            }
+          } else {
+            succeeded.push(s.title)
           }
         } catch {
           failed.push(s.title)
@@ -719,11 +733,11 @@
               <p class="text-sm">
                 {#if conflictStoryTitles.length === 1}
                   A story named "{conflictStoryTitles[0]}" already exists on this device. Pulling
-                  will remove the existing copy once the new one has been downloaded.
+                  will remove the existing copy once the new one has been imported.
                 {:else}
                   {conflictStoryTitles.length} selected stories already exist on this device:
                   {conflictStoryTitles.join(', ')}. Pulling will remove each existing copy once its
-                  replacement has been downloaded.
+                  replacement has been imported.
                 {/if}
               </p>
               <div class="mt-3 flex gap-2">

--- a/src/lib/components/sync/SyncModal.svelte
+++ b/src/lib/components/sync/SyncModal.svelte
@@ -17,6 +17,7 @@
   import { Html5Qrcode } from 'html5-qrcode'
   import type { SyncServerInfo, SyncStoryPreview, SyncConnectionData } from '$lib/types/sync'
   import { onDestroy } from 'svelte'
+  import { SvelteSet } from 'svelte/reactivity'
   import * as ResponsiveModal from '$lib/components/ui/responsive-modal'
   import { Button } from '$lib/components/ui/button'
   import { Card, CardHeader, CardTitle, CardDescription } from '$lib/components/ui/card'
@@ -28,14 +29,16 @@
   let connection = $state<SyncConnectionData | null>(null)
   let remoteStories = $state<SyncStoryPreview[]>([])
   let localStories = $state<SyncStoryPreview[]>([])
-  let selectedRemoteStory = $state<SyncStoryPreview | null>(null)
-  let selectedLocalStory = $state<SyncStoryPreview | null>(null)
+  let selectedRemoteIds = $state<Set<string>>(new Set())
+  let selectedLocalIds = $state<Set<string>>(new Set())
   let loading = $state(false)
   let error = $state<string | null>(null)
   let showConflictWarning = $state(false)
-  let conflictStoryTitle = $state<string | null>(null)
+  let conflictStoryTitles = $state<string[]>([])
   let syncSuccess = $state(false)
   let syncMessage = $state<string | null>(null)
+  let syncDirection = $state<'pull' | 'push' | null>(null)
+  let syncProgress = $state<{ done: number; total: number }>({ done: 0, total: 0 })
 
   // State for receiving pushed stories (when in generate mode)
   let receivedStoryJson = $state<string | null>(null)
@@ -65,14 +68,16 @@
     connection = null
     remoteStories = []
     localStories = []
-    selectedRemoteStory = null
-    selectedLocalStory = null
+    selectedRemoteIds = new Set()
+    selectedLocalIds = new Set()
     loading = false
     error = null
     showConflictWarning = false
-    conflictStoryTitle = null
+    conflictStoryTitles = []
     syncSuccess = false
     syncMessage = null
+    syncDirection = null
+    syncProgress = { done: 0, total: 0 }
     receivedStoryJson = null
     receivedStoryPreview = null
     showReceivedConflict = false
@@ -341,80 +346,151 @@
     }
   }
 
-  async function pullStory() {
-    if (!connection || !selectedRemoteStory) return
+  function toggleRemoteSelection(id: string) {
+    const next = new SvelteSet(selectedRemoteIds)
+    if (next.has(id)) next.delete(id)
+    else next.add(id)
+    selectedRemoteIds = next
+  }
 
-    // Check for conflict
-    const exists = await syncService.checkStoryExists(selectedRemoteStory.title)
-    if (exists && !showConflictWarning) {
-      conflictStoryTitle = selectedRemoteStory.title
-      showConflictWarning = true
-      return
-    }
+  function toggleLocalSelection(id: string) {
+    const next = new SvelteSet(selectedLocalIds)
+    if (next.has(id)) next.delete(id)
+    else next.add(id)
+    selectedLocalIds = next
+  }
 
-    ui.setSyncMode('syncing')
-    loading = true
-    error = null
-    showConflictWarning = false
+  function toggleSelectAllRemote() {
+    selectedRemoteIds =
+      selectedRemoteIds.size === remoteStories.length
+        ? new Set()
+        : new Set(remoteStories.map((s) => s.id))
+  }
 
-    try {
-      // If replacing, delete the existing story first
-      const existingId = await syncService.findStoryIdByTitle(selectedRemoteStory.title)
-      if (existingId) {
-        await syncService.createPreSyncBackup(existingId)
-        await syncService.deleteStory(existingId)
-      }
+  function toggleSelectAllLocal() {
+    selectedLocalIds =
+      selectedLocalIds.size === localStories.length
+        ? new Set()
+        : new Set(localStories.map((s) => s.id))
+  }
 
-      // Pull the story
-      const storyJson = await syncService.pullStory(connection, selectedRemoteStory.id)
-
-      // Import using existing import service
-      // Use skipImportedSuffix=true so synced stories keep their original title
-      const result = await exportService.importFromContent(storyJson, true)
-
-      if (result.success) {
-        await story.loadAllStories()
-        syncSuccess = true
-        syncMessage = `Successfully pulled "${selectedRemoteStory.title}"`
+  /** Summarizes a batch pull/push into the success or error banner. */
+  function reportBatchResult(
+    verb: 'pulled' | 'pushed',
+    succeeded: string[],
+    failed: string[],
+    total: number,
+  ) {
+    if (succeeded.length > 0) {
+      syncSuccess = true
+      if (failed.length > 0) {
+        syncMessage = `${verb === 'pulled' ? 'Pulled' : 'Pushed'} ${succeeded.length} of ${total} stories. Failed: ${failed.join(', ')}`
+      } else if (total === 1) {
+        syncMessage = `Successfully ${verb} "${succeeded[0]}"`
       } else {
-        error = result.error ?? 'Import failed'
+        syncMessage = `Successfully ${verb} ${succeeded.length} stories`
       }
-    } catch (e) {
-      error = e instanceof Error ? e.message : 'Pull failed'
-    } finally {
-      loading = false
+    } else {
+      error = `Failed to ${verb === 'pulled' ? 'pull' : 'push'} ${failed.length === 1 ? `"${failed[0]}"` : `${failed.length} stories`}`
     }
   }
 
-  async function pushStory() {
-    if (!connection || !selectedLocalStory) return
+  async function pullSelectedStories() {
+    if (!connection || selectedRemoteIds.size === 0) return
+    const conn = connection
+
+    const storiesToPull = remoteStories.filter((s) => selectedRemoteIds.has(s.id))
+
+    // Check for conflicts across the whole selection before touching anything
+    if (!showConflictWarning) {
+      const conflicts: string[] = []
+      for (const s of storiesToPull) {
+        if (await syncService.checkStoryExists(s.title)) {
+          conflicts.push(s.title)
+        }
+      }
+      if (conflicts.length > 0) {
+        conflictStoryTitles = conflicts
+        showConflictWarning = true
+        return
+      }
+    }
 
     ui.setSyncMode('syncing')
+    syncDirection = 'pull'
     loading = true
     error = null
+    showConflictWarning = false
+    syncProgress = { done: 0, total: storiesToPull.length }
 
-    try {
-      // Create backup before pushing (on local device)
-      await syncService.createPreSyncBackup(selectedLocalStory.id)
+    const succeeded: string[] = []
+    const failed: string[] = []
 
-      // Export the story
-      const storyJson = await syncService.exportStoryToJson(selectedLocalStory.id)
+    // Pulled sequentially: each story is a separate authenticated request and gets
+    // its own pre-sync backup, so one failure never affects the others in the batch.
+    for (const s of storiesToPull) {
+      try {
+        const existingId = await syncService.findStoryIdByTitle(s.title)
+        if (existingId) {
+          await syncService.createPreSyncBackup(existingId)
+          await syncService.deleteStory(existingId)
+        }
 
-      // Push to remote
-      await syncService.pushStory(connection, storyJson)
+        const storyJson = await syncService.pullStory(conn, s.id)
+        // Use skipImportedSuffix=true so synced stories keep their original title
+        const result = await exportService.importFromContent(storyJson, true)
 
-      syncSuccess = true
-      syncMessage = `Successfully pushed "${selectedLocalStory.title}"`
-    } catch (e) {
-      error = e instanceof Error ? e.message : 'Push failed'
-    } finally {
-      loading = false
+        if (result.success) {
+          succeeded.push(s.title)
+        } else {
+          failed.push(s.title)
+        }
+      } catch {
+        failed.push(s.title)
+      }
+      syncProgress = { done: syncProgress.done + 1, total: storiesToPull.length }
     }
+
+    await story.loadAllStories()
+    loading = false
+    reportBatchResult('pulled', succeeded, failed, storiesToPull.length)
+  }
+
+  async function pushSelectedStories() {
+    if (!connection || selectedLocalIds.size === 0) return
+    const conn = connection
+
+    const storiesToPush = localStories.filter((s) => selectedLocalIds.has(s.id))
+
+    ui.setSyncMode('syncing')
+    syncDirection = 'push'
+    loading = true
+    error = null
+    syncProgress = { done: 0, total: storiesToPush.length }
+
+    const succeeded: string[] = []
+    const failed: string[] = []
+
+    for (const s of storiesToPush) {
+      try {
+        // Create backup before pushing (on local device)
+        await syncService.createPreSyncBackup(s.id)
+        const storyJson = await syncService.exportStoryToJson(s.id)
+        await syncService.pushStory(conn, storyJson)
+        succeeded.push(s.title)
+      } catch {
+        failed.push(s.title)
+      }
+      syncProgress = { done: syncProgress.done + 1, total: storiesToPush.length }
+    }
+
+    loading = false
+    reportBatchResult('pushed', succeeded, failed, storiesToPush.length)
   }
 
   function cancelConflict() {
     showConflictWarning = false
-    conflictStoryTitle = null
+    conflictStoryTitles = []
   }
 
   async function close() {
@@ -449,7 +525,7 @@
         {:else if ui.syncMode === 'scan'}
           Scan QR Code
         {:else if ui.syncMode === 'connected'}
-          Select Story to Sync
+          Select Stories to Sync
         {:else if ui.syncMode === 'syncing'}
           Syncing...
         {/if}
@@ -462,7 +538,7 @@
         {:else if ui.syncMode === 'scan'}
           Scan the QR code shown on the other device.
         {:else if ui.syncMode === 'connected'}
-          Choose a story to transfer between devices.
+          Choose one or more stories to transfer between devices.
         {/if}
       </ResponsiveModal.Description>
     </ResponsiveModal.Header>
@@ -608,15 +684,25 @@
             <div class="mb-4 rounded-lg bg-amber-500/15 p-4 text-amber-600 dark:text-amber-500">
               <div class="mb-2 flex items-center gap-2">
                 <AlertTriangle class="h-5 w-5" />
-                <span class="font-semibold">Story Already Exists</span>
+                <span class="font-semibold">
+                  {conflictStoryTitles.length === 1
+                    ? 'Story Already Exists'
+                    : 'Stories Already Exist'}
+                </span>
               </div>
               <p class="text-sm">
-                A story named "{conflictStoryTitle}" already exists on this device. Pulling will
-                replace it after creating a "Pre-sync backup" checkpoint.
+                {#if conflictStoryTitles.length === 1}
+                  A story named "{conflictStoryTitles[0]}" already exists on this device. Pulling
+                  will replace it after creating a "Pre-sync backup" checkpoint.
+                {:else}
+                  {conflictStoryTitles.length} selected stories already exist on this device:
+                  {conflictStoryTitles.join(', ')}. Pulling will replace them, each after creating
+                  its own "Pre-sync backup" checkpoint.
+                {/if}
               </p>
               <div class="mt-3 flex gap-2">
                 <Button variant="secondary" size="sm" onclick={cancelConflict}>Cancel</Button>
-                <Button size="sm" onclick={pullStory}>Continue Anyway</Button>
+                <Button size="sm" onclick={pullSelectedStories}>Continue Anyway</Button>
               </div>
             </div>
           {/if}
@@ -624,35 +710,60 @@
           <div class="space-y-6">
             <!-- Pull Stories (from remote) -->
             <div>
-              <h3 class="text-muted-foreground mb-2 flex items-center gap-2 text-sm font-medium">
-                <Download class="h-4 w-4" />
-                Pull from Remote Device
-              </h3>
+              <div class="mb-2 flex items-center justify-between">
+                <h3 class="text-muted-foreground flex items-center gap-2 text-sm font-medium">
+                  <Download class="h-4 w-4" />
+                  Pull from Remote Device
+                </h3>
+                {#if remoteStories.length > 0}
+                  <button
+                    type="button"
+                    class="text-primary text-xs hover:underline"
+                    onclick={toggleSelectAllRemote}
+                  >
+                    {selectedRemoteIds.size === remoteStories.length
+                      ? 'Deselect all'
+                      : 'Select all'}
+                  </button>
+                {/if}
+              </div>
               {#if remoteStories.length > 0}
                 <ScrollArea class="h-40 rounded-md border p-1">
                   {#each remoteStories as remoteStory (remoteStory.id)}
                     <button
-                      class="hover:bg-accent hover:text-accent-foreground flex w-full flex-col items-start gap-1 rounded-sm px-3 py-2 text-left {selectedRemoteStory?.id ===
-                      remoteStory.id
+                      class="hover:bg-accent hover:text-accent-foreground flex w-full items-start gap-2 rounded-sm px-3 py-2 text-left {selectedRemoteIds.has(
+                        remoteStory.id,
+                      )
                         ? 'bg-accent text-accent-foreground ring-primary ring-1'
                         : ''}"
-                      onclick={() => {
-                        selectedRemoteStory = remoteStory
-                        selectedLocalStory = null
-                      }}
+                      onclick={() => toggleRemoteSelection(remoteStory.id)}
+                      aria-pressed={selectedRemoteIds.has(remoteStory.id)}
                     >
-                      <div class="flex w-full items-center justify-between">
-                        <span class="truncate font-medium">{remoteStory.title}</span>
-                        {#if remoteStory.genre}
-                          <Badge variant="secondary" class="h-5 text-[10px]"
-                            >{remoteStory.genre}</Badge
-                          >
+                      <div
+                        class="border-primary mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border {selectedRemoteIds.has(
+                          remoteStory.id,
+                        )
+                          ? 'bg-primary text-primary-foreground'
+                          : ''}"
+                      >
+                        {#if selectedRemoteIds.has(remoteStory.id)}
+                          <Check class="h-3 w-3" />
                         {/if}
                       </div>
-                      <div class="text-muted-foreground text-xs">
-                        {remoteStory.entryCount} entries • Updated {formatDate(
-                          remoteStory.updatedAt,
-                        )}
+                      <div class="flex min-w-0 flex-1 flex-col gap-1">
+                        <div class="flex w-full items-center justify-between">
+                          <span class="truncate font-medium">{remoteStory.title}</span>
+                          {#if remoteStory.genre}
+                            <Badge variant="secondary" class="h-5 text-[10px]"
+                              >{remoteStory.genre}</Badge
+                            >
+                          {/if}
+                        </div>
+                        <div class="text-muted-foreground text-xs">
+                          {remoteStory.entryCount} entries • Updated {formatDate(
+                            remoteStory.updatedAt,
+                          )}
+                        </div>
                       </div>
                     </button>
                   {/each}
@@ -666,33 +777,56 @@
 
             <!-- Push Stories (to remote) -->
             <div>
-              <h3 class="text-muted-foreground mb-2 flex items-center gap-2 text-sm font-medium">
-                <Upload class="h-4 w-4" />
-                Push to Remote Device
-              </h3>
+              <div class="mb-2 flex items-center justify-between">
+                <h3 class="text-muted-foreground flex items-center gap-2 text-sm font-medium">
+                  <Upload class="h-4 w-4" />
+                  Push to Remote Device
+                </h3>
+                {#if localStories.length > 0}
+                  <button
+                    type="button"
+                    class="text-primary text-xs hover:underline"
+                    onclick={toggleSelectAllLocal}
+                  >
+                    {selectedLocalIds.size === localStories.length ? 'Deselect all' : 'Select all'}
+                  </button>
+                {/if}
+              </div>
               {#if localStories.length > 0}
                 <ScrollArea class="h-40 rounded-md border p-1">
                   {#each localStories as localStory (localStory.id)}
                     <button
-                      class="hover:bg-accent hover:text-accent-foreground flex w-full flex-col items-start gap-1 rounded-sm px-3 py-2 text-left {selectedLocalStory?.id ===
-                      localStory.id
+                      class="hover:bg-accent hover:text-accent-foreground flex w-full items-start gap-2 rounded-sm px-3 py-2 text-left {selectedLocalIds.has(
+                        localStory.id,
+                      )
                         ? 'bg-accent text-accent-foreground ring-primary ring-1'
                         : ''}"
-                      onclick={() => {
-                        selectedLocalStory = localStory
-                        selectedRemoteStory = null
-                      }}
+                      onclick={() => toggleLocalSelection(localStory.id)}
+                      aria-pressed={selectedLocalIds.has(localStory.id)}
                     >
-                      <div class="flex w-full items-center justify-between">
-                        <span class="truncate font-medium">{localStory.title}</span>
-                        {#if localStory.genre}
-                          <Badge variant="secondary" class="h-5 text-[10px]"
-                            >{localStory.genre}</Badge
-                          >
+                      <div
+                        class="border-primary mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border {selectedLocalIds.has(
+                          localStory.id,
+                        )
+                          ? 'bg-primary text-primary-foreground'
+                          : ''}"
+                      >
+                        {#if selectedLocalIds.has(localStory.id)}
+                          <Check class="h-3 w-3" />
                         {/if}
                       </div>
-                      <div class="text-muted-foreground text-xs">
-                        Updated {formatDate(localStory.updatedAt)}
+                      <div class="flex min-w-0 flex-1 flex-col gap-1">
+                        <div class="flex w-full items-center justify-between">
+                          <span class="truncate font-medium">{localStory.title}</span>
+                          {#if localStory.genre}
+                            <Badge variant="secondary" class="h-5 text-[10px]"
+                              >{localStory.genre}</Badge
+                            >
+                          {/if}
+                        </div>
+                        <div class="text-muted-foreground text-xs">
+                          Updated {formatDate(localStory.updatedAt)}
+                        </div>
                       </div>
                     </button>
                   {/each}
@@ -710,7 +844,10 @@
         <div class="flex flex-col items-center justify-center py-12">
           <Loader2 class="text-primary h-8 w-8 animate-spin" />
           <p class="text-muted-foreground mt-4">
-            {selectedRemoteStory ? 'Pulling' : 'Pushing'} story...
+            {syncDirection === 'pull' ? 'Pulling' : 'Pushing'}
+            {syncProgress.total > 1
+              ? `${syncProgress.done}/${syncProgress.total} stories...`
+              : 'story...'}
           </p>
           <p class="text-muted-foreground/80 mt-1 text-sm">Please wait</p>
         </div>
@@ -720,17 +857,18 @@
     <!-- Footer -->
     {#if ui.syncMode === 'connected' && !showConflictWarning && !loading && !syncSuccess}
       <ResponsiveModal.Footer>
-        <div class="flex w-full justify-end gap-2">
+        <div class="flex w-full flex-wrap justify-end gap-2">
           <Button variant="outline" onclick={close}>Cancel</Button>
-          {#if selectedRemoteStory}
-            <Button onclick={pullStory}>
+          {#if selectedRemoteIds.size > 0}
+            <Button onclick={pullSelectedStories}>
               <Download class="mr-2 h-4 w-4" />
-              Pull Story
+              Pull {selectedRemoteIds.size} Selected
             </Button>
-          {:else if selectedLocalStory}
-            <Button onclick={pushStory}>
+          {/if}
+          {#if selectedLocalIds.size > 0}
+            <Button onclick={pushSelectedStories}>
               <Upload class="mr-2 h-4 w-4" />
-              Push Story
+              Push {selectedLocalIds.size} Selected
             </Button>
           {/if}
         </div>


### PR DESCRIPTION
Adds checkboxes to the Pull/Push story lists so multiple stories can be
synced in one go instead of one at a time. Each story is still pulled or
pushed via its own authenticated request, conflict check, and pre-sync
backup, run sequentially, the batch is just a loop over the existing
per-story flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for selecting and transferring multiple stories at once.
  * Added select-all controls for streamlined batch selection.
  * Added independent pull and push actions for greater control.
  * Added conflict previews before pulling stories.
  * Added per-story progress tracking with success and failure reporting.
  * Added clearer batch transfer status for both pull and push operations.
  * Improved story replacement handling during transfers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->