### PR TITLE
Branch navigation: land at the end of a branch, jump to its origin on demand

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1224,9 +1224,9 @@
       }
     },
     "node_modules/@lucide/svelte": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@lucide/svelte/-/svelte-1.28.0.tgz",
-      "integrity": "sha512-C1Ge84KW2z4q44/WDIEo/2KC2jby5u6mSlta7q+p6g7u0ld8sC/w1fMBiSswF+4bxAl9jlzzaVTpp79qqkiy5g==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@lucide/svelte/-/svelte-1.31.0.tgz",
+      "integrity": "sha512-pgPuLEJdF0UpsajG9eSw0YvqXVuDxB+/x58BRiC4xE/KEHiopOqT1id3KCUvRN/PUmQkN1F26sslcs/1jutlBQ==",
       "license": "ISC",
       "peerDependencies": {
         "svelte": "^5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@codemirror/state": "^6.7.1",
         "@codemirror/view": "^6.43.7",
         "@lezer/highlight": "^1.2.3",
-        "@lucide/svelte": "^1.28.0",
+        "@lucide/svelte": "^1.31.0",
         "@openrouter/ai-sdk-provider": "^3.0.0",
         "@saintno/comfyui-sdk": "0.3.1",
         "@tauri-apps/api": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@codemirror/state": "^6.7.1",
     "@codemirror/view": "^6.43.7",
     "@lezer/highlight": "^1.2.3",
-    "@lucide/svelte": "^1.28.0",
+    "@lucide/svelte": "^1.31.0",
     "@openrouter/ai-sdk-provider": "^3.0.0",
     "@saintno/comfyui-sdk": "0.3.1",
     "@tauri-apps/api": "^2.11.1",

--- a/src/lib/components/branch/BranchPanel.svelte
+++ b/src/lib/components/branch/BranchPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { story } from '$lib/stores/story.svelte'
+  import { ui } from '$lib/stores/ui.svelte'
   import { ask } from '@tauri-apps/plugin-dialog'
   import {
     GitBranch,
@@ -10,6 +11,7 @@
     Edit2,
     Check,
     X,
+    Crosshair,
   } from '@lucide/svelte'
   import type { Branch, Checkpoint } from '$lib/types'
   import { SvelteSet } from 'svelte/reactivity'
@@ -174,6 +176,24 @@
   function isCurrent(branchId: string | null): boolean {
     return story.currentStory?.currentBranchId === branchId
   }
+
+  // Ids the story view can actually scroll to. `story.entries` is the ACTIVE branch's
+  // view — main + ancestors up to their forks + the branch itself — so a branch outside
+  // the current lineage (a sibling's child, say) has its fork entry nowhere in here.
+  const visibleEntryIds = $derived(new Set(story.entries.map((e) => e.id)))
+
+  function canGoToForkPoint(branch: Branch): boolean {
+    return visibleEntryIds.has(branch.forkEntryId)
+  }
+
+  function goToForkPoint(branch: Branch) {
+    // Fork points live in the story, which may not be the panel that's up — and while
+    // it isn't, StoryView is destroyed rather than hidden (see AppShell). So the request
+    // is left on the ui store for it to pick up on mount, not emitted at it.
+    ui.requestEntryScroll(branch.forkEntryId)
+    ui.setActivePanel('story')
+    ui.closeSidebarOnMobile()
+  }
 </script>
 
 <div class="space-y-3">
@@ -298,6 +318,22 @@
           {#if isCurrent(branch.id)}
             <span class="bg-accent-500 h-2 w-2 rounded-full" title="Current branch"></span>
           {/if}
+          {@const forkReachable = canGoToForkPoint(branch)}
+          <button
+            class="text-surface-500 flex min-h-[32px] min-w-[32px] items-center justify-center p-1 transition-opacity sm:min-h-0 sm:min-w-0 sm:p-0.5 {forkReachable
+              ? 'hover:text-surface-200 sm:opacity-0 sm:group-hover:opacity-100'
+              : 'cursor-not-allowed opacity-30'}"
+            onclick={(e) => {
+              e.stopPropagation()
+              goToForkPoint(branch)
+            }}
+            disabled={!forkReachable}
+            title={forkReachable
+              ? 'Go to fork point'
+              : "Fork point is not in the current branch's timeline — switch to this branch or its parent first"}
+          >
+            <Crosshair class="h-4 w-4 sm:h-3 sm:w-3" />
+          </button>
           <button
             class="text-surface-500 hover:text-surface-200 flex min-h-[32px] min-w-[32px] items-center justify-center p-1 transition-opacity sm:min-h-0 sm:min-w-0 sm:p-0.5 sm:opacity-0 sm:group-hover:opacity-100"
             onclick={(e) => {

--- a/src/lib/components/branch/BranchPanel.svelte
+++ b/src/lib/components/branch/BranchPanel.svelte
@@ -194,6 +194,16 @@
     !!activeBranch?.forkEntryId && visibleEntryIds.has(activeBranch.forkEntryId),
   )
 
+  // Each way the button can be unavailable says so in its own words: claiming "no
+  // branching point" while entries are still loading, or "not loaded yet" for a branch
+  // that records no fork at all, would both send the reader looking for the wrong thing.
+  const forkPointTitle = $derived.by(() => {
+    if (canGoToForkPoint) return 'Jump to where this branch began'
+    if (!story.currentStory?.currentBranchId) return 'The main branch has no branching point'
+    if (!activeBranch?.forkEntryId) return 'This branch has no recorded branching point'
+    return "This branch's starting point isn't loaded yet"
+  })
+
   function goToForkPoint() {
     if (!canGoToForkPoint || !activeBranch) return
 
@@ -223,11 +233,7 @@
           : 'text-surface-600 cursor-not-allowed'}"
         onclick={goToForkPoint}
         disabled={!canGoToForkPoint}
-        title={canGoToForkPoint
-          ? 'Jump to where this branch began'
-          : !story.currentStory?.currentBranchId
-            ? 'The main branch has no branching point'
-            : "This branch's starting point isn't loaded yet"}
+        title={forkPointTitle}
       >
         <LayerArrowUp class="h-5 w-5 sm:h-4 sm:w-4" />
       </button>

--- a/src/lib/components/branch/BranchPanel.svelte
+++ b/src/lib/components/branch/BranchPanel.svelte
@@ -322,11 +322,12 @@
           <button
             class="text-surface-500 flex min-h-[32px] min-w-[32px] items-center justify-center p-1 transition-opacity sm:min-h-0 sm:min-w-0 sm:p-0.5 {forkReachable
               ? 'hover:text-surface-200 sm:opacity-0 sm:group-hover:opacity-100'
-              : 'cursor-not-allowed opacity-30'}"
+              : 'cursor-not-allowed opacity-30 sm:opacity-0 sm:group-hover:opacity-30'}"
             onclick={(e) => {
               e.stopPropagation()
               goToForkPoint(branch)
             }}
+            onkeydown={(e) => e.stopPropagation()}
             disabled={!forkReachable}
             title={forkReachable
               ? 'Go to fork point'

--- a/src/lib/components/branch/BranchPanel.svelte
+++ b/src/lib/components/branch/BranchPanel.svelte
@@ -11,10 +11,11 @@
     Edit2,
     Check,
     X,
-    Crosshair,
+    LayerArrowUp,
   } from '@lucide/svelte'
   import type { Branch, Checkpoint } from '$lib/types'
   import { SvelteSet } from 'svelte/reactivity'
+  import { supportsHover } from '$lib/utils/platform'
 
   // Track expanded branches in tree view
   let expandedBranches = $state<Set<string>>(new Set(['main']))
@@ -177,22 +178,37 @@
     return story.currentStory?.currentBranchId === branchId
   }
 
-  // Ids the story view can actually scroll to. `story.entries` is the ACTIVE branch's
-  // view — main + ancestors up to their forks + the branch itself — so a branch outside
-  // the current lineage (a sibling's child, say) has its fork entry nowhere in here.
+  // The action targets the branch being read. A per-branch control would be disabled on
+  // most rows anyway: `story.entries` is the ACTIVE branch's view — main + ancestors up
+  // to their forks + the branch itself — so any branch outside that lineage has its fork
+  // entry nowhere in it. The active branch always has its own, so this is enabled
+  // whenever there is a branching point at all, i.e. everywhere except main.
+  const activeBranch = $derived.by(() => {
+    const branchId = story.currentStory?.currentBranchId ?? null
+    if (!branchId) return null
+    return story.branches.find((b) => b.id === branchId) ?? null
+  })
+
   const visibleEntryIds = $derived(new Set(story.entries.map((e) => e.id)))
+  const canGoToForkPoint = $derived(
+    !!activeBranch?.forkEntryId && visibleEntryIds.has(activeBranch.forkEntryId),
+  )
 
-  function canGoToForkPoint(branch: Branch): boolean {
-    return visibleEntryIds.has(branch.forkEntryId)
-  }
+  function goToForkPoint() {
+    if (!canGoToForkPoint || !activeBranch) return
 
-  function goToForkPoint(branch: Branch) {
     // Fork points live in the story, which may not be the panel that's up — and while
     // it isn't, StoryView is destroyed rather than hidden (see AppShell). So the request
     // is left on the ui store for it to pick up on mount, not emitted at it.
-    ui.requestEntryScroll(branch.forkEntryId)
+    ui.requestEntryScroll(activeBranch.forkEntryId)
     ui.setActivePanel('story')
     ui.closeSidebarOnMobile()
+
+    // Where the platform can't hover, the button's tooltip can never explain itself and
+    // the panel may have just closed — so confirm the jump the way copying an entry does.
+    if (!supportsHover()) {
+      ui.showToast('Jumped to where this branch began', 'info', 2000)
+    }
   }
 </script>
 
@@ -200,18 +216,32 @@
   <!-- Header -->
   <div class="flex items-center justify-between">
     <h3 class="text-surface-200 font-medium">Branches</h3>
-    <button
-      class="btn-ghost flex min-h-[40px] min-w-[40px] items-center justify-center rounded p-2 sm:min-h-0 sm:min-w-0 sm:p-1.5 {canCreateBranch
-        ? 'text-surface-400 hover:text-surface-200'
-        : 'text-surface-600 cursor-not-allowed'}"
-      onclick={() => canCreateBranch && (showCreateForm = !showCreateForm)}
-      disabled={!canCreateBranch}
-      title={canCreateBranch
-        ? 'Create new branch from latest checkpoint'
-        : 'No checkpoints available - checkpoints are created at chapter boundaries'}
-    >
-      <Plus class="h-5 w-5 sm:h-4 sm:w-4" />
-    </button>
+    <div class="flex items-center">
+      <button
+        class="btn-ghost flex min-h-[40px] min-w-[40px] items-center justify-center rounded p-2 sm:min-h-0 sm:min-w-0 sm:p-1.5 {canGoToForkPoint
+          ? 'text-surface-400 hover:text-surface-200'
+          : 'text-surface-600 cursor-not-allowed'}"
+        onclick={goToForkPoint}
+        disabled={!canGoToForkPoint}
+        title={canGoToForkPoint
+          ? 'Jump to where this branch began'
+          : 'The main branch has no branching point'}
+      >
+        <LayerArrowUp class="h-5 w-5 sm:h-4 sm:w-4" />
+      </button>
+      <button
+        class="btn-ghost flex min-h-[40px] min-w-[40px] items-center justify-center rounded p-2 sm:min-h-0 sm:min-w-0 sm:p-1.5 {canCreateBranch
+          ? 'text-surface-400 hover:text-surface-200'
+          : 'text-surface-600 cursor-not-allowed'}"
+        onclick={() => canCreateBranch && (showCreateForm = !showCreateForm)}
+        disabled={!canCreateBranch}
+        title={canCreateBranch
+          ? 'Create new branch from latest checkpoint'
+          : 'No checkpoints available - checkpoints are created at chapter boundaries'}
+      >
+        <Plus class="h-5 w-5 sm:h-4 sm:w-4" />
+      </button>
+    </div>
   </div>
 
   <!-- Create Branch Form -->
@@ -318,23 +348,6 @@
           {#if isCurrent(branch.id)}
             <span class="bg-accent-500 h-2 w-2 rounded-full" title="Current branch"></span>
           {/if}
-          {@const forkReachable = canGoToForkPoint(branch)}
-          <button
-            class="text-surface-500 flex min-h-[32px] min-w-[32px] items-center justify-center p-1 transition-opacity sm:min-h-0 sm:min-w-0 sm:p-0.5 {forkReachable
-              ? 'hover:text-surface-200 sm:opacity-0 sm:group-hover:opacity-100'
-              : 'cursor-not-allowed opacity-30 sm:opacity-0 sm:group-hover:opacity-30'}"
-            onclick={(e) => {
-              e.stopPropagation()
-              goToForkPoint(branch)
-            }}
-            onkeydown={(e) => e.stopPropagation()}
-            disabled={!forkReachable}
-            title={forkReachable
-              ? 'Go to fork point'
-              : "Fork point is not in the current branch's timeline — switch to this branch or its parent first"}
-          >
-            <Crosshair class="h-4 w-4 sm:h-3 sm:w-3" />
-          </button>
           <button
             class="text-surface-500 hover:text-surface-200 flex min-h-[32px] min-w-[32px] items-center justify-center p-1 transition-opacity sm:min-h-0 sm:min-w-0 sm:p-0.5 sm:opacity-0 sm:group-hover:opacity-100"
             onclick={(e) => {

--- a/src/lib/components/branch/BranchPanel.svelte
+++ b/src/lib/components/branch/BranchPanel.svelte
@@ -225,7 +225,9 @@
         disabled={!canGoToForkPoint}
         title={canGoToForkPoint
           ? 'Jump to where this branch began'
-          : 'The main branch has no branching point'}
+          : !story.currentStory?.currentBranchId
+            ? 'The main branch has no branching point'
+            : "This branch's starting point isn't loaded yet"}
       >
         <LayerArrowUp class="h-5 w-5 sm:h-4 sm:w-4" />
       </button>

--- a/src/lib/components/settings/ExperimentalSettings.svelte
+++ b/src/lib/components/settings/ExperimentalSettings.svelte
@@ -270,14 +270,6 @@
     await settings.updateExperimentalFeatures({ notificationPreview: checked })
   }
 
-  async function handleBranchSwitchLandingToggle(checked: boolean) {
-    await settings.updateExperimentalFeatures({ branchSwitchLanding: checked })
-  }
-
-  async function handleBranchLandingTargetChange(target: 'last-entry' | 'fork-entry') {
-    await settings.updateExperimentalFeatures({ branchSwitchLandingTarget: target })
-  }
-
   async function handleResetAll() {
     await settings.resetExperimentalFeatures()
     stateTrackingChecked = settings.experimentalFeatures.stateTracking
@@ -474,73 +466,6 @@
       <span class="text-muted-foreground w-12 text-right font-mono text-sm">
         {settings.experimentalFeatures.autoSnapshotInterval}
       </span>
-    </div>
-  </div>
-
-  <Separator />
-
-  <!-- Branch Switch Landing -->
-  <div class="space-y-5">
-    <div class="flex items-center gap-2">
-      <GitBranch class="text-muted-foreground h-4 w-4" />
-      <Label class="text-sm font-medium">Branch Switch Landing</Label>
-    </div>
-
-    <!-- Master toggle -->
-    <div class="flex flex-row items-center justify-between">
-      <div class="space-y-0.5">
-        <Label>Position story after switching branches</Label>
-        <p class="text-muted-foreground text-xs">
-          Place the story view at a chosen point when you switch branches, instead of keeping the
-          previous branch's scroll position.
-        </p>
-        {#if settings.experimentalFeatures.branchSwitchLanding}
-          <p class="pt-1 text-xs font-medium text-amber-500">
-            Active — the story view will reposition on every branch switch.
-          </p>
-        {/if}
-      </div>
-      <Switch
-        checked={settings.experimentalFeatures.branchSwitchLanding}
-        onCheckedChange={handleBranchSwitchLandingToggle}
-      />
-    </div>
-
-    <!-- Landing target -->
-    <div class="space-y-3 {!settings.experimentalFeatures.branchSwitchLanding ? 'opacity-50' : ''}">
-      <div class="space-y-0.5">
-        <Label>Landing Target</Label>
-        <p class="text-muted-foreground text-xs">
-          Where to land: the end of the branch, or the entry it branched off from.
-        </p>
-        {#if !settings.experimentalFeatures.branchSwitchLanding}
-          <p class="text-muted-foreground pt-1 text-xs italic">
-            Requires Branch Switch Landing to be enabled.
-          </p>
-        {/if}
-      </div>
-      <div class="flex flex-row gap-2">
-        <Button
-          variant={settings.experimentalFeatures.branchSwitchLandingTarget === 'last-entry'
-            ? 'default'
-            : 'outline'}
-          size="sm"
-          disabled={!settings.experimentalFeatures.branchSwitchLanding}
-          onclick={() => handleBranchLandingTargetChange('last-entry')}
-        >
-          Last entry
-        </Button>
-        <Button
-          variant={settings.experimentalFeatures.branchSwitchLandingTarget === 'fork-entry'
-            ? 'default'
-            : 'outline'}
-          size="sm"
-          disabled={!settings.experimentalFeatures.branchSwitchLanding}
-          onclick={() => handleBranchLandingTargetChange('fork-entry')}
-        >
-          Branching checkpoint
-        </Button>
-      </div>
     </div>
   </div>
 

--- a/src/lib/components/story/StoryView.svelte
+++ b/src/lib/components/story/StoryView.svelte
@@ -90,8 +90,9 @@
     if (currentStoryId !== lastStoryId) {
       lastStoryId = currentStoryId
       prevEntryCount = story.entries.length
-      // Drop any deferred landing: its branch belongs to the story we just left
+      // Drop any deferred landing: its branch or entry belongs to the story we just left
       pendingBranchLanding = null
+      ui.consumeEntryScroll()
       anchorToBottom(story.entries.length)
       tick().then(() => performScroll())
     }
@@ -251,27 +252,36 @@
     scrollEntryIntoView(lastEntry.id)
   }
 
-  async function landOnForkEntry(branchId: string | null) {
+  // Window the virtual list around one entry and scroll to it. Returns false, having
+  // changed nothing, when the entry isn't in the current branch's view — the view can
+  // only scroll to what it can render, and the caller decides what to do instead.
+  async function landOnEntry(entryId: string): Promise<boolean> {
     const entries = story.entries
-    const forkEntryId = branchId
-      ? (story.branches.find((b) => b.id === branchId)?.forkEntryId ?? null)
-      : null
-    const idx = forkEntryId ? entries.findIndex((e) => e.id === forkEntryId) : -1
-
-    // Main branch, or fork entry not in this branch's entries → land on the last entry
-    if (!forkEntryId || idx === -1) {
-      await landOnLastEntry()
-      return
-    }
+    const idx = entries.findIndex((e) => e.id === entryId)
+    if (idx === -1) return false
 
     const total = entries.length
     prevEntryCount = total
+    // Landing away from the end is a scroll break: the next narration must not yank
+    // the view back to the bottom while the user reads where they asked to be.
     ui.setScrollBreak(true)
     windowStart = Math.max(0, idx - FORK_CONTEXT_BEFORE)
     windowEnd = Math.min(total, idx + DEFAULT_VISIBLE_ENTRIES)
     await tick()
 
-    scrollEntryIntoView(forkEntryId)
+    scrollEntryIntoView(entryId)
+    return true
+  }
+
+  async function landOnForkEntry(branchId: string | null) {
+    const forkEntryId = branchId
+      ? (story.branches.find((b) => b.id === branchId)?.forkEntryId ?? null)
+      : null
+
+    // Main branch, or fork entry not in this branch's entries → land on the last entry
+    if (!forkEntryId || !(await landOnEntry(forkEntryId))) {
+      await landOnLastEntry()
+    }
   }
 
   function performBranchLanding(branchId: string | null) {
@@ -406,11 +416,34 @@
         pendingBranchLanding = null
         if (pending) {
           performBranchLanding(pending.branchId)
-        } else {
-          scrollToBottom()
+          return
         }
+        // …as does a jump-to-entry request made from another panel, which is why the
+        // request lives on the ui store: this component is destroyed while another
+        // panel is up, so it cannot be waiting on an event when the request is made.
+        // Read untracked — consuming it must not re-run this effect and undo the
+        // landing with the scrollToBottom below.
+        const entryId = ui.consumeEntryScroll()
+        if (entryId) {
+          void landOnEntry(entryId)
+          return
+        }
+        scrollToBottom()
       })
     }
+  })
+
+  // The same request, arriving while the story panel is already up — the effect above
+  // won't re-run, since neither activePanel nor storyContainer changed. Declared after
+  // it so that on a remount the panel effect takes the request first and this one finds
+  // nothing; consumeEntryScroll is atomic, so exactly one of the two ever lands it.
+  $effect(() => {
+    const entryId = ui.pendingEntryScrollId
+    if (!entryId || ui.activePanel !== 'story' || !storyContainer) return
+    untrack(() => {
+      ui.consumeEntryScroll()
+      void landOnEntry(entryId)
+    })
   })
 
   // Format background image URL (handling raw base64 vs data URL)

--- a/src/lib/components/story/StoryView.svelte
+++ b/src/lib/components/story/StoryView.svelte
@@ -92,7 +92,7 @@
       lastStoryId = currentStoryId
       prevEntryCount = story.entries.length
       // Drop any deferred landing: its branch or entry belongs to the story we just left
-      pendingBranchLanding = null
+      pendingBranchLanding = false
       // Only when we actually left a story. This component is destroyed whenever another
       // panel is up, so every mount arrives here with lastStoryId still null and would
       // otherwise discard the very request that brought the panel back.
@@ -208,22 +208,42 @@
     })
   }
 
-  // ===== Branch switch landing (Labs: branchSwitchLanding) =====
+  // ===== Branch navigation =====
 
-  // Entries kept above the fork entry so the checkpoint has a little context
+  // How many entries before the fork point stay in the render window. This is about what
+  // exists in the DOM, not what is on screen — the visible context above the fork entry is
+  // decided by the lift in scrollEntryIntoView. Keeping a few rendered means scrolling up
+  // from the fork point doesn't immediately hit the "earlier entries hidden" divider.
   const FORK_CONTEXT_BEFORE = 5
 
-  // Landing requested while the story panel was hidden; consumed when it returns
-  let pendingBranchLanding: { branchId: string | null } | null = null
+  // Most of the viewport the preceding entry may take when lifted into view. A tall entry
+  // shows a slice; a short one shows in full, and the fork entry stays near the top either way.
+  const CONTEXT_LIFT_MAX_RATIO = 0.3
 
-  // Scroll a specific entry to the top of the viewport. Falls back to the container
-  // bottom when the element isn't in the DOM (entry outside the virtual window).
-  function scrollEntryIntoView(entryId: string) {
+  // A branch switch happened while the story panel was hidden; consumed when it returns
+  let pendingBranchLanding = false
+
+  // Scroll an entry to the top of the viewport. When `liftForContext` is set, the scroll is
+  // then pulled up so the preceding entry is partly visible, which is what makes a fork
+  // point read as a divergence from something rather than as the start of the story.
+  // Falls back to the container bottom when the element isn't in the DOM.
+  function scrollEntryIntoView(entryId: string, liftForContext = false) {
     const release = suppressScrollFor()
     requestAnimationFrame(() => {
       const el = storyContainer?.querySelector(`[data-entry-id="${entryId}"]`)
       if (el) {
         el.scrollIntoView({ block: 'start' })
+        if (liftForContext && storyContainer) {
+          const prevEl = el.previousElementSibling
+          if (prevEl) {
+            // Cap the lift so a long preceding entry can't push the fork entry off the bottom
+            const lift = Math.min(
+              prevEl.getBoundingClientRect().height,
+              CONTEXT_LIFT_MAX_RATIO * storyContainer.clientHeight,
+            )
+            storyContainer.scrollTop -= lift
+          }
+        }
       } else {
         performScroll()
       }
@@ -238,7 +258,10 @@
     })
   }
 
-  async function landOnLastEntry() {
+  // Where a branch switch leaves the reader: at the very end of the switched-to branch.
+  // The window is recomputed for this branch's own length — inheriting it from the branch
+  // being left is what clamps it to an empty slice when switching to a shorter one.
+  async function performBranchLanding() {
     const total = story.entries.length
     // Claim the current count so the auto-scroll effect doesn't see this as "entries added"
     prevEntryCount = total
@@ -246,14 +269,9 @@
     anchorToBottom(total)
     await tick()
 
-    // Land on the last entry itself, not the container bottom — action choices and
-    // padding sit below it, which would otherwise push the entry off the top.
-    const lastEntry = story.entries[story.entries.length - 1]
-    if (!lastEntry) {
-      performScroll()
-      return
-    }
-    scrollEntryIntoView(lastEntry.id)
+    // The container bottom, not the last entry's top edge: past the entry and the action
+    // choices below it is where writing continues.
+    performScroll()
   }
 
   // Window the virtual list around one entry and scroll to it. Returns false, having
@@ -273,41 +291,23 @@
     windowEnd = Math.min(total, idx + DEFAULT_VISIBLE_ENTRIES)
     await tick()
 
-    scrollEntryIntoView(entryId)
+    // Lift the scroll so the preceding entry stays partly visible: a fork point should
+    // read as a departure from something, not as the start of the story.
+    scrollEntryIntoView(entryId, true)
     return true
   }
 
-  async function landOnForkEntry(branchId: string | null) {
-    const forkEntryId = branchId
-      ? (story.branches.find((b) => b.id === branchId)?.forkEntryId ?? null)
-      : null
-
-    // Main branch, or fork entry not in this branch's entries → land on the last entry
-    if (!forkEntryId || !(await landOnEntry(forkEntryId))) {
-      await landOnLastEntry()
-    }
-  }
-
-  function performBranchLanding(branchId: string | null) {
-    if (settings.experimentalFeatures.branchSwitchLandingTarget === 'fork-entry') {
-      void landOnForkEntry(branchId)
-    } else {
-      void landOnLastEntry()
-    }
-  }
-
-  // No reactive reads in the effect body — subscribe once, unsubscribe on teardown
+  // No reactive reads in the effect bodies — subscribe once, unsubscribe on teardown
   $effect(() => {
-    return eventBus.subscribe<BranchSwitchedEvent>('BranchSwitched', (event) => {
-      if (!settings.experimentalFeatures.branchSwitchLanding) return
-
+    // The payload is unread: landing resolves everything from the store when it runs
+    return eventBus.subscribe<BranchSwitchedEvent>('BranchSwitched', () => {
       // Panel hidden: defer until the story panel comes back (see panel effect below)
       if (ui.activePanel !== 'story' || !storyContainer) {
-        pendingBranchLanding = { branchId: event.branchId }
+        pendingBranchLanding = true
         return
       }
 
-      performBranchLanding(event.branchId)
+      void performBranchLanding()
     })
   })
 
@@ -417,7 +417,7 @@
       untrack(() => {
         // A branch switch that happened while the panel was hidden lands now instead
         const pending = pendingBranchLanding
-        pendingBranchLanding = null
+        pendingBranchLanding = false
         // …as does a jump-to-entry request made from another panel, which is why the
         // request lives on the ui store: this component is destroyed while another
         // panel is up, so it cannot be waiting on an event when the request is made.
@@ -429,7 +429,7 @@
         // by the trailing effect as a second landing competing with this one.
         const entryId = ui.consumeEntryScroll()
         if (pending) {
-          performBranchLanding(pending.branchId)
+          void performBranchLanding()
           return
         }
         if (entryId && story.entries.some((e) => e.id === entryId)) {

--- a/src/lib/components/story/StoryView.svelte
+++ b/src/lib/components/story/StoryView.svelte
@@ -418,18 +418,20 @@
         // A branch switch that happened while the panel was hidden lands now instead
         const pending = pendingBranchLanding
         pendingBranchLanding = null
-        if (pending) {
-          performBranchLanding(pending.branchId)
-          return
-        }
         // …as does a jump-to-entry request made from another panel, which is why the
         // request lives on the ui store: this component is destroyed while another
         // panel is up, so it cannot be waiting on an event when the request is made.
         // Read untracked — consuming it must not re-run this effect and undo the
         // landing with the scrollToBottom below.
-        // Consumed either way, so a request that can no longer be honoured — one made
-        // for a story that was closed before the panel came back — doesn't linger.
+        // Consumed before the branch-landing return, so a request that can no longer be
+        // honoured — one made for a story that was closed before the panel came back, or
+        // one a branch landing takes precedence over — doesn't linger and get picked up
+        // by the trailing effect as a second landing competing with this one.
         const entryId = ui.consumeEntryScroll()
+        if (pending) {
+          performBranchLanding(pending.branchId)
+          return
+        }
         if (entryId && story.entries.some((e) => e.id === entryId)) {
           void landOnEntry(entryId)
           return

--- a/src/lib/components/story/StoryView.svelte
+++ b/src/lib/components/story/StoryView.svelte
@@ -88,11 +88,15 @@
     const currentStoryId = story.currentStory?.id ?? null
 
     if (currentStoryId !== lastStoryId) {
+      const isRemount = lastStoryId === null
       lastStoryId = currentStoryId
       prevEntryCount = story.entries.length
       // Drop any deferred landing: its branch or entry belongs to the story we just left
       pendingBranchLanding = null
-      ui.consumeEntryScroll()
+      // Only when we actually left a story. This component is destroyed whenever another
+      // panel is up, so every mount arrives here with lastStoryId still null and would
+      // otherwise discard the very request that brought the panel back.
+      if (!isRemount) ui.consumeEntryScroll()
       anchorToBottom(story.entries.length)
       tick().then(() => performScroll())
     }
@@ -423,8 +427,10 @@
         // panel is up, so it cannot be waiting on an event when the request is made.
         // Read untracked — consuming it must not re-run this effect and undo the
         // landing with the scrollToBottom below.
+        // Consumed either way, so a request that can no longer be honoured — one made
+        // for a story that was closed before the panel came back — doesn't linger.
         const entryId = ui.consumeEntryScroll()
-        if (entryId) {
+        if (entryId && story.entries.some((e) => e.id === entryId)) {
           void landOnEntry(entryId)
           return
         }

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -869,8 +869,6 @@ export function getDefaultExperimentalFeatures(): ExperimentalFeatures {
     backgroundGeneration: false,
     generationNotifications: false,
     notificationPreview: false,
-    branchSwitchLanding: false,
-    branchSwitchLandingTarget: 'last-entry',
   }
 }
 

--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -35,6 +35,7 @@ export interface RetrievalCacheKey {
   actionContent: string
 }
 import type { SyncMode } from '$lib/types/sync'
+import { DESKTOP_BREAKPOINT } from '$lib/constants/layout'
 import { SimpleActivationTracker } from '$lib/services/ai/retrieval/EntryRetrievalService'
 import { database } from '$lib/services/database'
 import { eventBus, type EventType } from '$lib/services/events'
@@ -350,6 +351,40 @@ class UIStore {
       // No DB persist — this is a layout constraint, not a user preference.
       // Persisting here would overwrite the desktop sidebar preference.
     }
+  }
+
+  /**
+   * Get the sidebar out of the way when a sidebar control acts on the main content.
+   * Below DESKTOP_BREAKPOINT the sidebar is a near-fullscreen overlay (see AppShell's
+   * `@media (max-width: 768px)`), so the result of such an action would be invisible.
+   * Not persisted, for the same reason as setMobileDefaults: a mobile layout constraint
+   * must not overwrite the desktop sidebar preference.
+   */
+  closeSidebarOnMobile() {
+    if (typeof window !== 'undefined' && window.innerWidth <= DESKTOP_BREAKPOINT) {
+      this.sidebarOpen = false
+    }
+  }
+
+  /**
+   * A pending request for the story view to bring one entry into view.
+   *
+   * Deliberately durable state rather than an event: the requester is typically another
+   * panel (the Branches sidebar), and AppShell destroys StoryView whenever activePanel
+   * isn't 'story'. An event emitted while switching back would reach nobody, because the
+   * subscriber remounts a tick later. StoryView consumes this once it has a container.
+   */
+  pendingEntryScrollId = $state<string | null>(null)
+
+  requestEntryScroll(entryId: string) {
+    this.pendingEntryScrollId = entryId
+  }
+
+  /** Take the pending request, if any, and clear it. */
+  consumeEntryScroll(): string | null {
+    const entryId = this.pendingEntryScrollId
+    this.pendingEntryScrollId = null
+    return entryId
   }
 
   openSettings() {

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -859,10 +859,6 @@ export interface ExperimentalFeatures {
   generationNotifications: boolean
   /** Android: Include preview of generated text in the completion notification */
   notificationPreview: boolean
-  /** Explicitly position the story view after switching branches */
-  branchSwitchLanding: boolean
-  /** Where to land when branchSwitchLanding is on */
-  branchSwitchLandingTarget: 'last-entry' | 'fork-entry'
 }
 
 // ===== World State Delta Tracking (Phase 1) =====

--- a/src/lib/utils/platform.ts
+++ b/src/lib/utils/platform.ts
@@ -11,3 +11,14 @@ export function isAndroid(): boolean {
   if (typeof navigator === 'undefined') return false
   return /Android/i.test(navigator.userAgent)
 }
+
+/**
+ * Returns `true` when the primary input can hover, i.e. when a `title` tooltip can
+ * actually explain a control. This is a capability, not a screen size: a desktop window
+ * dragged narrow still hovers, a tablet at 1024px never does.
+ */
+export function supportsHover(): boolean {
+  if (typeof window === 'undefined') return true
+  if (typeof window.matchMedia !== 'function') return !isAndroid()
+  return !window.matchMedia('(hover: none)').matches
+}


### PR DESCRIPTION
Follow-up to #421, built on top of #433.

The first three commits are **@Pento95's from #433**, carried over unchanged — the fork-point action and its mechanics are his work. The last commit withdraws the landing experiment and layers the changes discussed in the review on top. #433 can be closed in favour of this.

## The Labs setting goes away

Branch-switch landing shipped behind a toggle with two target modes. None of the three outcomes should have been a setting:

- With the toggle **off** — the default — switching from a long branch to a short one still left the view showing nothing but "N earlier entries hidden". The fix reached only readers who found the toggle.
- **"Last entry"** is what readers want on essentially every switch.
- **"Branching checkpoint"** as a mode sent the reader back to the fork on *every* switch, including returning to the branch they were actively writing in. It was a one-time jump modelled as a mode — which is what #433 makes it.

`branchSwitchLanding` and `branchSwitchLandingTarget` are removed from the Labs UI, the `ExperimentalFeatures` contract, the defaults and every logic path. **BREAKING** for anyone who had selected "Branching checkpoint".

## Ordinary switching gets its own behaviour

This is where the blank view is actually fixed, and it is not the old "Last entry" mode promoted to a default:

- The entry window is **recomputed for the switched-to branch** rather than inherited from the branch being left. Inheriting it is what clamps it to an empty slice when the new branch is shorter.
- The view rests at the **container bottom** — past the last entry and its action choices, where writing continues — rather than pinning the last entry's top edge to the viewport top, which left the end of a long narration below the fold.

## Changes to the fork-point action from #433

The transport is unchanged: the request goes on the ui store via `requestEntryScroll` / atomic `consumeEntryScroll`, because `StoryView` is destroyed rather than hidden while another panel is up, so an event emitted at it would reach nobody. Same for `landOnEntry` returning `false` untouched when the entry isn't in the active branch's view, the remount fix, and `closeSidebarOnMobile`.

What changed:

- **The control moves from per-branch rows to one button in the panel header**, acting on the branch being read. Per-branch buttons are disabled on most rows — `story.entries` is the active branch's view, so any branch outside that lineage has its fork entry nowhere in it — and they spend a row of space on mobile to say so. The active branch always contains its own fork entry, so the header button is enabled wherever a branching point exists, i.e. everywhere except main.
- **Landing on an entry lifts the scroll** so the preceding entry stays partly visible, capped at a third of the viewport so a long narration cannot displace the fork entry. Without it the fork reads as the start of the story rather than a departure from something.
- **Where the platform cannot hover**, so a tooltip can never explain the button, the jump is confirmed with a toast — keyed to `matchMedia('(hover: none)')` via a new `supportsHover()` helper rather than viewport width, so it fires on a tablet at any size and never on a narrow desktop window.

## Notes

- `@lucide/svelte` moves to 1.31.0 for the icon, in both `package.json` and the lockfile. An earlier revision of this PR bumped only the lockfile, reasoning that `^1.28.0` already permitted 1.31.0 — but permitting a working version is not requiring one, and 1.28.0 does not ship `LayerArrowUp`, so any resolve that ignored the lockfile could have picked it and failed to build.
- No database migrations, no Rust/Tauri changes. Existing installs keep two orphaned keys inside the stored `experimental_features` JSON; they are ignored and no cleanup is proposed.
- `npm run check` clean, 967 tests pass, ESLint clean.
- Known and **not** from this PR: switching to a much longer branch shows a brief scroll readjustment as the view settles. Reproduces on #433's build and on unrelated older builds, so it predates both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fork-point navigation to branch panels.
  * Branch switches now open at the bottom of the active branch.
  * Selecting a fork entry scrolls directly to it with relevant context visible.
  * Mobile sidebars close automatically during branch and entry navigation.
  * Added hover-aware notifications for supported interactions.

* **Changes**
  * Removed the experimental Branch Switch Landing settings and related controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
