### PR TITLE
Image markers, database transactions, and the classifier's read of a scene

### DIFF
--- a/docs/architecture/context-injection.md
+++ b/docs/architecture/context-injection.md
@@ -9,15 +9,18 @@ Two independent services select what gets injected into the narrator prompt each
 - **Entry Retrieval** (`src/lib/services/ai/retrieval/EntryRetrievalService.ts`) — operates on static, authored **Lorebook** `Entry[]` records (characters, locations, items, factions, concepts, events).
 - **World State Injection** (`src/lib/services/ai/generation/WorldStateInjector.ts`) — operates on **live-tracked** `Character[]`/`Location[]`/`Item[]`/`StoryBeat[]` entities that the classifier updates dynamically after every turn (present characters, current location, inventory, active quests/milestones). Runs on every narrator call regardless of retrieval mode.
 
-The world-state block's sections split on **two different axes**, and conflating them is a live hazard.
-`[PROTAGONIST]`, `[CURRENT LOCATION]`, `[INVENTORY]` and `[ACTIVE THREADS]` are claims about _current
-state_; `[RELEVANT ...]` are claims about _relevance only_. Tier 1 once held nothing but the former, so
-reading "tier 1" as "current state" was safe — until stickiness was added, at which point Tier 1 also
-held entities carried forward _because_ their state condition stopped holding. Routing those through the
-state sections told the narrator the player carries a dropped item and is pursuing a finished quest, and
-left sticky locations rendered nowhere at all while `formatAlreadyInContext` still announced them.
-The rule is now explicit: state sections take Tier 1 **minus** the sticky carry-over, and sticky entries
-join Tier 2/3 in the relevance sections.
+The world-state block's sections split on **two different axes**, and tier is not one of them.
+`[PROTAGONIST]`, `[CURRENT LOCATION]`, `[CHARACTERS PRESENT]`, `[INVENTORY]` and `[ACTIVE THREADS]`
+are claims about _current state_; `[RECENTLY DEPARTED]` and `[RELEVANT ...]` are claims about
+_relevance only_. A sticky entry sits in Tier 1 precisely _because_ its state condition stopped
+holding, so routing it through a state section tells the narrator the player carries a dropped item,
+is pursuing a finished quest, or is talking to someone who walked out. State sections therefore take
+Tier 1 **minus** the sticky carry-over, and the carry-over is rendered as what it is.
+
+Characters get three headings rather than two: `[CHARACTERS PRESENT]` (Tier 1, in the scene),
+`[RECENTLY DEPARTED]` (the sticky carry-over) and `[KNOWN CHARACTERS]` (Tier 2/3 — named or chosen,
+but not there). The departed are rendered without their appearance: descriptors exist for the image
+prompt, and nothing is drawn of someone off-screen.
 
 Anything in the result's `all` must be renderable somewhere in the block, because `all` is what the
 retrieval agent is told the narrator already has. `WorldStateInjector.test.ts` pins that invariant.
@@ -38,8 +41,12 @@ the call, not the tier: a leftover under the budget still goes in.
 **Only a leftover the model _chose_ counts as an activation.** Wholesale inclusion means "there was
 little of it", which says nothing about relevance — and since the branch holds every uncovered
 record, recording it would make the entire pool sticky on every turn of any story under the budget,
-so Tier 1 would absorb it and stickiness would never expire. Both services exclude it; the world
-state side once claimed to and did not.
+so Tier 1 would absorb it and stickiness would never expire. Both services exclude it.
+
+**World-state characters are the one Tier 1 type that records an activation**, and the exception is
+the point: an `active` character _is_ a character in the scene, so Tier 1 membership is the presence
+signal. Without it a character has no activation to fade from, and the turn the classifier marks them
+away they leave the prompt outright instead of receding through `[RECENTLY DEPARTED]`.
 
 **Tier 2 runs twice, and the second pass is where indirect relevance lives.** The first pass matches
 what the scene _says_ — the player's action and the recent story. The second matches whatever is
@@ -248,9 +255,10 @@ turn appends both an action and a narration, so a duration of N covers roughly N
 converts for display; the services stay in positions because that is what they measure.
 Activations are persisted per story under `lorebook_activation_<storyId>` and restored on load.
 
-What creates an activation is Tier 2 and a _chosen_ Tier 3 — see the Tier 3 note above for why the
-wholesale branch does not. The timer is **not** refreshed while an entry is sticky, and cannot be: a
-sticky entry sits in Tier 1, Tier 1 is excluded from the candidate pool, and only Tier 2/3 record.
+What creates an activation is Tier 2, a _chosen_ Tier 3, and — in World State Injection only —
+a character in Tier 1. See the Tier 3 note above for why the wholesale branch does not, and the
+Tier 1 note for why characters do. The timer is **not** refreshed while an entry is sticky, and
+cannot be: a sticky entry sits in Tier 1 and is excluded from the candidate pool.
 So an entry named every single turn still drops out when its window expires and is re-matched the
 turn after. That is deliberate — it is what stops a once-relevant entry pinning itself in the prompt
 forever — but it makes the duration a hard ceiling on continuous presence, not a sliding one.

--- a/docs/architecture/lore-management.md
+++ b/docs/architecture/lore-management.md
@@ -11,6 +11,12 @@ name, shared alias, token containment, length-scaled edit distance, grouped tran
 service and not a corner of the lorebook's, because `ai/lorebook`'s barrel pulls in the SDK
 and through it a rune store, which no plain module can be imported alongside.
 
+**Every form is compared against every form** — a name and an alias are the same kind of
+evidence, and comparing only the two primary names missed an alias that had drifted or grown
+a title. The comparison is by whole tokens, which is what makes it boundary-aware without a
+length floor: `Ren` is a word of `Ren Wald` and is not a word of `Renwald`, so a short name
+is a candidate in the first case and not in the second.
+
 **The world state is the pool that actually grows.** The classifier mints a new `Character`
 whenever the story calls someone by a different title, so one measured save held
 `Baron Kaelen` and `Forge-Master Kaelen`, `Captain Vor'koth`, `General Vor'koth` and
@@ -62,9 +68,9 @@ one. Several things hold that down, and only the last is optional:
   re-proposed the same consolidation it had already "done". `merges` and `deletedEntries` now
   come back with the result and reach the caller's existing `onMergeEntries` / `onDeleteEntry`.
 - **Changes land in the snapshot as they are made.** The array the tools read is the array the
-  session mutates, so an entry created on step 2 is visible to `list_entries` on step 3. It is
-  never spliced: the model holds indices from the prompt and from every listing it has read, so
-  a delete keeps its slot and joins `removedIndices` — hidden from listings, refused by
+  session mutates, so an entry created on step 2 is addressable on step 3, at the index its tool
+  result reported. It is never spliced: the model holds indices from the prompt and from every
+  result it has read, so a delete keeps its slot and joins `removedIndices` — refused by
   everything that takes an index.
 - **`create_entry` refuses a name that already exists**, matching on names and aliases through
   `foldName`. The refusal says to update that index instead. The vault assistant does not
@@ -98,7 +104,12 @@ one. Several things hold that down, and only the last is optional:
   `stopOnCompletedTerminalTool`, reading the tool's answer rather than its call. The refusal is
   capped at two: the agent may be right that the groups are distinct, and a run that cannot end
   returns nothing. `keep_separate` is how it says so, and it must name **every** index of a
-  group: closing on one shared index dismissed neighbours the agent had never read.
+  group: closing on one shared index dismissed neighbours the agent had never read. An index a
+  merge or a delete has already consumed counts as named — the worklist stops printing those,
+  so demanding them back would leave any group that survived a consolidation impossible to
+  close. `groupIsSettledBy` and `formatDuplicateGroup` sit together in `duplicates/names.ts`
+  for that reason: they are the two halves of one rule, and drifting apart is what deadlocked
+  the run.
 
   **Resolved means the group collapsed**, not that a member was touched. An update is what the
   agent does anyway on its next task, so counting it opened the gate without consolidating
@@ -139,13 +150,16 @@ cut is what costs: on a 41-chapter story the block goes from ~9k characters to ~
 it because those summaries are this task's input (the median summary is 1,223 characters, so the
 cut showed 16% of one), because the block is the cacheable head of the prompt, and because the
 only other way to recover the missing text is `query_chapter` — a whole chapter read by a second
-model. `list_entries` stays: after a merge or a delete it is the only view of the list as it now
-stands, and the prompt says so, so it is not called before there is anything to see. It takes a
-`query` and a `limit` — the query matches names, aliases, keywords and descriptions through the
-same `entityNameMatches` the retrieval side searches with, and the cap exists because a tool
-result stays in the prompt for the rest of the run. It is deliberately **not**
-`search_entries`: that tool addresses entries by id, and every write here goes by index, so
-mixing the two addressing schemes is how the `lorebookId` bug happens again.
+model. **`list_entries` went the same way, and for the same reason.** The prompt already carries every
+entry with the index the tools take, so the only thing the tool could add was the list _after_
+the session had changed it — and capped at twenty rows it answered that with a fifth of a large
+lorebook and no way to page, which a model reads as "the rest is gone". What it was really being
+asked was "where did my own work land", and `create_entry` and `merge_entries` now answer that
+directly: both report the index their result was appended at, and a merge also names the indices
+it consumed. The agent follows the index space from its own results. The tool stays on the vault
+assistant, which browses several lorebooks and has no list in its prompt — where it is
+deliberately **not** `search_entries`: that tool addresses entries by id, and every write here
+goes by index, so mixing the two addressing schemes is how the `lorebookId` bug happens again.
 
 **What each field is for is a contract, and it is split between the code and the prompt.**
 `EntryRetrievalService` matches an entry's name, its aliases _and_ its keywords against the

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -61,9 +61,36 @@ The story is an append-only list of `StoryEntry` rows (`user_action`, `narration
 [inactive]` came back as the name, missed `sameEntityName`, and created a second
   character — four of thirty-eight on a measured 41-chapter save, two carrying the
   subject's own `relationship` verbatim. Name and attributes are now separate lines
-  (`relationship:`, `status:`, `appearance:`), in
-  `ClassifierService.formatExistingCharacters`, in the story-beat list beside it, and in
-  `WorldStateInjector`'s narrator block, whose prose the classifier also reads.
+  (`relationship:`, `status:`, `appearance:`), in every list `ClassifierService` renders —
+  characters, locations, items, story beats — and in `WorldStateInjector`'s narrator block,
+  whose prose the classifier also reads. One name per line also holds names a
+  comma-separated list could not: locations and items were CSV until they carried state.
+
+  **State reaches the classifier only where it can act on it.** `appearance:` goes with a
+  character in the scene, `description:` with the current location, and an item's
+  `quantity`/`equipped`/`location` only when they differ from the default — because each of
+  those is a whole-value replacement, and a model cannot rewrite what it was not shown. The
+  same rule sizes the prompt: on a large cast the omitted halves are most of it.
+
+  **`scene.currentLocationName` is the only thing that moves the scene.** It creates the
+  location if the name is new, marks it `current` and `visited`, and clears the previous
+  one. `locationUpdates.changes.current` and `newLocations[].current` did the same job from
+  two other places, applied in an order the model could not see, so a response naming two
+  places kept whichever ran last — and the merge path set a second `current` without
+  clearing the first. Both are gone from the schema.
+
+  **Presence is reported, departure is inferred.** The classifier answers one question about the
+  cast — `scene.presentCharacterNames`, every *other* character in the scene at the end of the
+  passage; the protagonist is in every scene by definition and is added by the consumers — and
+  `resolveCharacterPresence` (`services/generation/characterPresence.ts`) turns the complement into
+  `inactive`. Asking a model to name thirty absent characters produces nothing; asking it to name
+  the three in front of it is the question the passage answers. The inference is refused whenever
+  the list carries no signal: a salvaged or failed classification, or an empty array — which the
+  schema defaults, so "the model said nobody" and "the model did not answer" arrive identically.
+  `characterUpdates.status` stays for what the scene states outright, `deceased` above all, and
+  wins over the inference. `appearance:` is sent to the classifier only for characters in the
+  scene, and the template forbids rewriting an appearance it was not shown, so a returning
+  character keeps the descriptors it accumulated.
 
 - **`worldStateDelta`** on an entry records what its classification changed, which is what makes
   retry, time-travel delete and regenerate reversible (`rollbackService`).

--- a/docs/architecture/persistence.md
+++ b/docs/architecture/persistence.md
@@ -15,6 +15,21 @@ The database, the native layer that moves bytes around it, and the settings blob
 - **Line endings matter**: `sqlx` checksums each migration file to detect drift, so migrations must use LF
   line endings on every platform. This is enforced by `.gitattributes` (forces `eol=lf` for
   `src-tauri/migrations/*.sql`) and by the `check_migrations` pre-commit hook below.
+- **Never `BEGIN` from the frontend**: `tauri-plugin-sql` runs every `execute()` on an arbitrary
+  connection from an `sqlx` pool, and exposes no way to pin one (`Pool::connect` in the plugin's
+  `wrapper.rs` takes no options). A `BEGIN` therefore opens a transaction that the following statements
+  never join and the `COMMIT` never finds, while the connection that opened it keeps a write lock that
+  turns every later write into `database is locked`. Prefer one statement that is atomic by itself — a
+  multi-row `INSERT`, an `UPDATE ... WHERE`. When several statements must land together, send them as a
+  batch to **`database.transaction()`**, which hands them to the `db_transaction` Rust command
+  (`src-tauri/src/db_tx.rs`): one connection, a real transaction, rollback on the first error, and the
+  rows affected by each statement back. Values travel as bound parameters — never interpolate into the
+  SQL. Keep the SQL in `database.ts` rather than in components, as
+  `deleteRuntimeVariableEverywhere` and its neighbours do.
+- **A read the batch depends on belongs inside it**, as a subquery. The runtime-variable writes reach
+  their rows through `SELECT id FROM stories WHERE pack_id = ?` rather than resolving the ids first:
+  the batch is atomic, the round trip that fed it was not, and a story assigned to the pack in
+  between kept a variable the pack no longer had.
 
 ## The Native (Rust) Layer
 
@@ -29,14 +44,18 @@ Rust owns the bytes**: only small parameters (paths, ids) cross the IPC bridge.
   ordering and foreign keys stay in TypeScript where they are tested), then `avt_import_images`
   re-reads the file and streams each base64 payload straight into SQLite. Peak memory is one image
   regardless of file size.
+- **`db.rs`** — where the live database is and how to open a writable pool to it. The one place
+  that knows the filename and the busy_timeout; close what it hands back.
+- **`db_tx.rs`** — the `db_transaction` command: a batch of statements on one connection, which is
+  the only place a frontend transaction can come from (see the bullet above).
 - **`migration_patch.rs`** — patches `sqlx`'s stored migration checksums (see
   [Database and Migrations](#database-and-migrations)).
 - **`sync/`** — the LAN sync server (`start_sync_server`, `sync_connect`, `sync_pull_story`,
   `sync_push_story`, …), paired via QR code.
 
-`backup.rs`, `avt_import.rs` and `migration_patch.rs` (via the `lib.rs` setup hook) open
-`sqlite:aventura.db` under Tauri's **app config dir** — see the migrations section for why that is
-not the app data dir. `sync/` never touches the database directly; it moves stories over the
+`db.rs` (for `avt_import.rs`, `db_tx.rs` and `backup.rs`) and `migration_patch.rs` (via the
+`lib.rs` setup hook) open `sqlite:aventura.db` under Tauri's **app config dir** — see the
+migrations section for why that is not the app data dir. `sync/` never touches the database directly; it moves stories over the
 `tauri-plugin-sql` connection on the JS side.
 
 ## Settings Migrations

--- a/src-tauri/src/avt_import.rs
+++ b/src-tauri/src/avt_import.rs
@@ -25,9 +25,10 @@ use std::io::{BufReader, Read};
 use serde::de::{DeserializeSeed, IgnoredAny, MapAccess, SeqAccess, Visitor};
 use serde::Deserializer;
 use serde_json::{Map, Value};
-use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use sqlx::SqlitePool;
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
+
+use crate::db::{open_rw_pool, IMPORT_BUSY_TIMEOUT};
 
 /// The JSON key holding the base64 payload — the only thing this module works to avoid.
 const IMAGE_DATA_KEY: &str = "imageData";
@@ -325,30 +326,6 @@ impl<'de, F: FnMut(ImageRow) -> Result<(), String>> Visitor<'de> for ImportRootS
     }
 }
 
-/// Open a writable pool to the live database.
-///
-/// The sql plugin holds its own connection to the same file, and WAL allows only one writer at a
-/// time, so a generous busy_timeout is what keeps a concurrent app write from turning into
-/// SQLITE_BUSY here.
-async fn open_rw_pool(app: &AppHandle) -> Result<SqlitePool, String> {
-    let db = app
-        .path()
-        .app_config_dir()
-        .map_err(|e| format!("failed to resolve app config dir: {e}"))?
-        .join("aventura.db");
-
-    let options = SqliteConnectOptions::new()
-        .filename(&db)
-        .create_if_missing(false)
-        .busy_timeout(std::time::Duration::from_secs(30));
-
-    SqlitePoolOptions::new()
-        .max_connections(1)
-        .connect_with(options)
-        .await
-        .map_err(|e| format!("failed to open database: {e}"))
-}
-
 /// Stream every mapped image from an `.avt` straight into SQLite.
 ///
 /// `mapping` is the small table JS produced while importing the structure: it decides which images
@@ -370,7 +347,7 @@ pub async fn avt_import_images(
         .map(|m| (m.old_image_id, m.new_entry_id))
         .collect();
 
-    let pool = open_rw_pool(&app).await?;
+    let pool = open_rw_pool(&app, IMPORT_BUSY_TIMEOUT).await?;
     let reader = BufReader::new(open_source(&app, &src_path)?);
 
     let result = import_images_from(reader, pool.clone(), story_id, entry_by_image).await;
@@ -484,6 +461,7 @@ fn uuid_v4() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
     use sqlx::Row;
     use std::alloc::{GlobalAlloc, Layout, System};
     use std::sync::atomic::{AtomicUsize, Ordering};

--- a/src-tauri/src/backup.rs
+++ b/src-tauri/src/backup.rs
@@ -18,14 +18,7 @@ use tauri::{AppHandle, Manager};
 use zip::write::SimpleFileOptions;
 use zip::{CompressionMethod, ZipArchive, ZipWriter};
 
-/// Path to the live application database (app_config_dir/aventura.db).
-fn db_path(app: &AppHandle) -> Result<PathBuf, String> {
-    Ok(app
-        .path()
-        .app_config_dir()
-        .map_err(|e| format!("failed to resolve app config dir: {e}"))?
-        .join("aventura.db"))
-}
+use crate::db::db_path;
 
 /// Open the export destination for writing, returning a real `std::fs::File`.
 ///

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+//! Access to the live application database from the native side.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use sqlx::SqlitePool;
+use tauri::{AppHandle, Manager};
+
+/// Path to the live application database (app_config_dir/aventura.db).
+pub fn db_path(app: &AppHandle) -> Result<PathBuf, String> {
+    Ok(app
+        .path()
+        .app_config_dir()
+        .map_err(|e| format!("failed to resolve app config dir: {e}"))?
+        .join("aventura.db"))
+}
+
+/// How long a caller waits for the write lock before it reports SQLITE_BUSY.
+///
+/// The sql plugin holds its own connection to the same file and WAL allows one writer at a time,
+/// so this is what keeps a concurrent app write from failing outright. It is the caller's to
+/// choose because the two ends of the range are different jobs: a background import can afford
+/// to wait, and a wait nobody asked for is time the user spends in front of a frozen control.
+pub const IMPORT_BUSY_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// A batch behind a control the user is looking at. Long enough to ride out a turn's writes,
+/// short enough that a lock held by something wedged surfaces as an error instead of a freeze.
+pub const INTERACTIVE_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Open a writable single-connection pool to the live database.
+///
+/// Close the pool when done: dropping it leaves the connection to be reaped asynchronously,
+/// still holding whatever the last statement took.
+pub async fn open_rw_pool(app: &AppHandle, busy_timeout: Duration) -> Result<SqlitePool, String> {
+    let options = SqliteConnectOptions::new()
+        .filename(db_path(app)?)
+        .create_if_missing(false)
+        .busy_timeout(busy_timeout);
+
+    SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(options)
+        .await
+        .map_err(|e| format!("failed to open database: {e}"))
+}

--- a/src-tauri/src/db_tx.rs
+++ b/src-tauri/src/db_tx.rs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+//! A real multi-statement transaction for the frontend.
+//!
+//! `tauri-plugin-sql` runs every `execute()` on an arbitrary connection from its pool and
+//! exposes no way to pin one, so a `BEGIN` issued from JS is never joined by the statements
+//! that follow it and its `COMMIT` reaches a connection with nothing to commit — while the
+//! connection that opened it keeps a write lock. This command takes the whole batch at once
+//! and runs it on a single connection, which is the only place atomicity can come from.
+
+use serde::Deserialize;
+use sqlx::{AssertSqlSafe, SqlitePool};
+use tauri::AppHandle;
+
+use crate::db::{open_rw_pool, INTERACTIVE_BUSY_TIMEOUT};
+
+/// One statement and its bound parameters.
+///
+/// Values arrive as JSON. Only the shapes SQLite takes from this app are bound: strings,
+/// numbers, booleans and null. A nested array or object is a caller mistake, not something
+/// to silently stringify.
+#[derive(Deserialize)]
+pub struct TxStatement {
+    sql: String,
+    #[serde(default)]
+    params: Vec<serde_json::Value>,
+}
+
+/// Run every statement in one transaction, in order. Rolls back on the first error.
+///
+/// Returns the number of rows each statement affected, so a caller can tell an update that
+/// matched nothing from one that did.
+#[tauri::command]
+pub async fn db_transaction(
+    app: AppHandle,
+    statements: Vec<TxStatement>,
+) -> Result<Vec<u64>, String> {
+    if statements.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let pool = open_rw_pool(&app, INTERACTIVE_BUSY_TIMEOUT).await?;
+    let result = run_statements(&pool, &statements).await;
+    pool.close().await;
+    result
+}
+
+/// The batch itself, split out so the pool is closed on every path.
+async fn run_statements(pool: &SqlitePool, statements: &[TxStatement]) -> Result<Vec<u64>, String> {
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| format!("failed to begin transaction: {e}"))?;
+
+    let mut affected = Vec::with_capacity(statements.len());
+
+    for statement in statements {
+        // The SQL is written in the app's own data layer and every value travels as a
+        // bound parameter below — never interpolated. `AssertSqlSafe` is required because
+        // the string is not a literal here; it grants this command no reach that
+        // `tauri-plugin-sql`, which already executes arbitrary SQL from the same frontend,
+        // does not already have.
+        let mut query = sqlx::query(AssertSqlSafe(statement.sql.as_str()));
+
+        for param in &statement.params {
+            query = match param {
+                serde_json::Value::Null => query.bind(None::<String>),
+                serde_json::Value::Bool(b) => query.bind(*b),
+                serde_json::Value::String(s) => query.bind(s.clone()),
+                // `as_u64` before `as_f64`, and rejected: SQLite's INTEGER is signed 64-bit,
+                // so a value past `i64::MAX` has no exact representation to bind. Falling
+                // through to `as_f64` — which succeeds for every `u64` — would round it and
+                // store the wrong id.
+                serde_json::Value::Number(n) => {
+                    if let Some(i) = n.as_i64() {
+                        query.bind(i)
+                    } else if n.is_u64() {
+                        return Err(format!("integer parameter too large for SQLite: {n}"));
+                    } else if let Some(f) = n.as_f64() {
+                        query.bind(f)
+                    } else {
+                        return Err(format!("unsupported numeric parameter: {n}"));
+                    }
+                }
+                other => {
+                    return Err(format!(
+                        "unsupported parameter type in transaction: {other}"
+                    ))
+                }
+            };
+        }
+
+        match query.execute(&mut *tx).await {
+            Ok(result) => affected.push(result.rows_affected()),
+            Err(e) => {
+                // Explicit rather than by drop, so a rollback that itself fails is reported
+                // instead of disappearing.
+                if let Err(rollback) = tx.rollback().await {
+                    return Err(format!("statement failed ({e}); rollback also failed: {rollback}"));
+                }
+                return Err(format!("statement failed, transaction rolled back: {e}"));
+            }
+        }
+    }
+
+    tx.commit()
+        .await
+        .map_err(|e| format!("failed to commit transaction: {e}"))?;
+
+    Ok(affected)
+}

--- a/src-tauri/src/db_tx.rs
+++ b/src-tauri/src/db_tx.rs
@@ -10,8 +10,17 @@
 use serde::Deserialize;
 use sqlx::{AssertSqlSafe, SqlitePool};
 use tauri::AppHandle;
+use tokio::sync::Mutex;
 
 use crate::db::{open_rw_pool, INTERACTIVE_BUSY_TIMEOUT};
+
+/// One batch at a time, whoever asks.
+///
+/// Each call opens its own connection, so two of them otherwise race for the file's write
+/// lock and the loser spends `INTERACTIVE_BUSY_TIMEOUT` before failing — work rolled back
+/// over a conflict that queueing avoids entirely. A rename issued right after a delete is
+/// enough to hit it. Waiting here costs the same time without the error.
+static TX_LOCK: Mutex<()> = Mutex::const_new(());
 
 /// One statement and its bound parameters.
 ///
@@ -37,6 +46,8 @@ pub async fn db_transaction(
     if statements.is_empty() {
         return Ok(Vec::new());
     }
+
+    let _queued = TX_LOCK.lock().await;
 
     let pool = open_rw_pool(&app, INTERACTIVE_BUSY_TIMEOUT).await?;
     let result = run_statements(&pool, &statements).await;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,8 @@ use tauri_plugin_sql::{Migration, MigrationKind};
 
 mod avt_import;
 mod backup;
+mod db;
+mod db_tx;
 mod migration_patch;
 mod sync;
 
@@ -296,6 +298,7 @@ pub fn run() {
             import_saf_to_temp,
             avt_import::avt_read_light,
             avt_import::avt_import_images,
+            db_tx::db_transaction,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/lib/components/debug/LorebookDebugPanel.svelte
+++ b/src/lib/components/debug/LorebookDebugPanel.svelte
@@ -87,18 +87,20 @@
    * every prompt until someone changes it, a carry-over leaves on its own in a few turns,
    * and live state comes and goes with the scene. Only the first is a standing cost.
    */
-  const groupLabels: Record<string, { label: string; description: string }> = {
+  const protagonistName = $derived(story.protagonist?.name ?? 'the protagonist')
+
+  const groupLabels = $derived<Record<string, { label: string; description: string }>>({
     always: {
       label: 'Always Inject',
       description: 'Pinned by the author — in every prompt until the mode is changed',
     },
     carried: {
       label: 'Carried Over',
-      description: 'Recently relevant; leaves on its own when the countdown runs out',
+      description: `Was live state until recently — a character who left the scene, an item ${protagonistName} dropped. Fades out on its own when the countdown runs out`,
     },
     state: {
       label: 'Live State',
-      description: "Where you are, who's present, what you're carrying, active quests",
+      description: `Where ${protagonistName} is, who is in the scene now, what they are carrying, what's still open`,
     },
     matched: { label: 'Keyword Matched', description: 'Named directly by the scene' },
     viaScene: {
@@ -113,7 +115,7 @@
       label: 'LLM Selected',
       description: 'The leftover was over budget, so the LLM picked from it',
     },
-  }
+  })
 
   /** Tiers 1 and 3 each cover more than one behaviour, so both are shown split. */
   function groupsOf(entries: RetrievalSnapshotEntry[]) {

--- a/src/lib/components/lorebook/LorebookView.svelte
+++ b/src/lib/components/lorebook/LorebookView.svelte
@@ -11,7 +11,8 @@
   import LorebookImportModal from './LorebookImportModal.svelte'
   import LorebookExportModal from './LorebookExportModal.svelte'
   import LorebookVaultImportModal from './LorebookVaultImportModal.svelte'
-  import { BookOpen, Plus, ArrowLeft, Loader2, Bot } from '@lucide/svelte'
+  import { BookOpen, Plus, ArrowLeft, Loader2, Bot, AlertCircle, RotateCcw } from '@lucide/svelte'
+  import { runManualLoreManagement } from '$lib/services/generation'
 
   import { Button } from '$lib/components/ui/button'
   import { Alert, AlertDescription, AlertTitle } from '$lib/components/ui/alert'
@@ -147,6 +148,49 @@
             </span>
           {/if}
         </AlertDescription>
+      </Alert>
+    </div>
+  {/if}
+
+  <!-- Lore Management Error Banner with Retry -->
+  {#if ui.loreManagementError}
+    <div class="bg-destructive/10 border-destructive/20 border-b p-4">
+      <Alert variant="destructive" class="border-none bg-transparent p-0">
+        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div class="flex items-start gap-2.5">
+            <AlertCircle class="text-destructive mt-0.5 h-5 w-5 flex-shrink-0" />
+            <div>
+              <AlertTitle class="text-destructive mb-0 text-sm font-semibold"
+                >Lore Management Failed</AlertTitle
+              >
+              <AlertDescription class="text-destructive/90 mt-0.5 text-xs">
+                {ui.loreManagementError}
+              </AlertDescription>
+            </div>
+          </div>
+          <div class="flex items-center gap-2 self-end sm:self-auto">
+            <!-- Retry does not dismiss the banner: `startLoreManagement` clears it once a run
+                 actually begins, and one that cannot start — no story loaded, or a session
+                 already going — would otherwise look like it worked. -->
+            <Button
+              variant="outline"
+              size="sm"
+              class="border-destructive/30 text-destructive hover:bg-destructive/10 h-8 text-xs"
+              onclick={() => void runManualLoreManagement()}
+            >
+              <RotateCcw class="mr-1.5 h-3.5 w-3.5" />
+              Retry
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              class="text-muted-foreground h-8 text-xs"
+              onclick={() => ui.clearLoreManagementError()}
+            >
+              Dismiss
+            </Button>
+          </div>
+        </div>
       </Alert>
     </div>
   {/if}

--- a/src/lib/components/settings/AdvancedSettings.svelte
+++ b/src/lib/components/settings/AdvancedSettings.svelte
@@ -3,6 +3,8 @@
     settings,
     CLASSIFIER_WINDOW_MIN,
     CLASSIFIER_WINDOW_MAX,
+    ENTRY_RETRIEVAL_WINDOW_MIN,
+    ENTRY_RETRIEVAL_WINDOW_MAX,
   } from '$lib/stores/settings.svelte'
   import {
     ChevronDown,
@@ -294,8 +296,8 @@
               label: 'Recent Entries Window',
               value: system.entryRetrieval.recentEntriesCount,
               display: `${system.entryRetrieval.recentEntriesCount} entries`,
-              min: CLASSIFIER_WINDOW_MIN,
-              max: CLASSIFIER_WINDOW_MAX,
+              min: ENTRY_RETRIEVAL_WINDOW_MIN,
+              max: ENTRY_RETRIEVAL_WINDOW_MAX,
               step: 1,
               help: view.help.entryRecentEntries,
               onChange: (v) => {
@@ -650,8 +652,8 @@
               label: 'Recent Entries Window',
               value: system.classifier.recentEntriesWindow,
               display: `${system.classifier.recentEntriesWindow} entries`,
-              min: 2,
-              max: 15,
+              min: CLASSIFIER_WINDOW_MIN,
+              max: CLASSIFIER_WINDOW_MAX,
               step: 1,
               help: 'Recent story entries sent whole alongside the passage being classified. Two per turn — an action and a narration',
               onChange: (v) => {

--- a/src/lib/components/settings/AdvancedSettings.svelte
+++ b/src/lib/components/settings/AdvancedSettings.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-  import { settings } from '$lib/stores/settings.svelte'
+  import {
+    settings,
+    CLASSIFIER_WINDOW_MIN,
+    CLASSIFIER_WINDOW_MAX,
+  } from '$lib/stores/settings.svelte'
   import {
     ChevronDown,
     RotateCcw,
@@ -290,8 +294,8 @@
               label: 'Recent Entries Window',
               value: system.entryRetrieval.recentEntriesCount,
               display: `${system.entryRetrieval.recentEntriesCount} entries`,
-              min: 2,
-              max: 15,
+              min: CLASSIFIER_WINDOW_MIN,
+              max: CLASSIFIER_WINDOW_MAX,
               step: 1,
               help: view.help.entryRecentEntries,
               onChange: (v) => {
@@ -643,18 +647,15 @@
         <Collapsible.Content>
           <div class="bg-muted/10 space-y-6 border-t p-4">
             {@render sliderRow({
-              label: 'Chat History Truncation (Words)',
-              value: system.classifier.chatHistoryTruncation,
-              display:
-                system.classifier.chatHistoryTruncation === 0
-                  ? 'No Limit'
-                  : String(system.classifier.chatHistoryTruncation),
-              min: 0,
-              max: 500,
-              step: 50,
-              ends: ['Unlimited', '500 Words'],
+              label: 'Recent Entries Window',
+              value: system.classifier.recentEntriesWindow,
+              display: `${system.classifier.recentEntriesWindow} entries`,
+              min: 2,
+              max: 15,
+              step: 1,
+              help: 'Recent story entries sent whole alongside the passage being classified. Two per turn — an action and a narration',
               onChange: (v) => {
-                system.classifier.chatHistoryTruncation = v
+                system.classifier.recentEntriesWindow = v
                 saveSystem()
               },
             })}

--- a/src/lib/components/settings/TTSSettings.svelte
+++ b/src/lib/components/settings/TTSSettings.svelte
@@ -107,6 +107,11 @@
     { value: 'microsoft', label: 'Windows System TTS (Microsoft SAPI)' },
   ] as const
 
+  const audioFormats = [
+    { value: 'mp3', label: 'MP3 (smaller)' },
+    { value: 'wav', label: 'WAV (widest support)' },
+  ] as const
+
   /**
    * Validate TTS settings before preview
    */
@@ -352,6 +357,36 @@
           }}
           placeholder="tts-1"
         />
+      </div>
+
+      <!-- Audio format -->
+      <div>
+        <Label class="mb-2 block">Audio Format</Label>
+        <Select.Root
+          type="single"
+          value={settings.systemServicesSettings.tts.responseFormat}
+          onValueChange={(v) => {
+            settings.systemServicesSettings.tts.responseFormat = v as 'mp3' | 'wav'
+            settings.saveSystemServicesSettings()
+          }}
+        >
+          <Select.Trigger class="h-10 w-full">
+            {audioFormats.find(
+              (f) => f.value === settings.systemServicesSettings.tts.responseFormat,
+            )?.label ?? 'Select format'}
+          </Select.Trigger>
+          <Select.Content>
+            {#each audioFormats as format (format.value)}
+              <Select.Item value={format.value} label={format.label}>
+                {format.label}
+              </Select.Item>
+            {/each}
+          </Select.Content>
+        </Select.Root>
+        <p class="text-muted-foreground mt-1 text-xs">
+          Switch to WAV if the endpoint answers with "response_format must be wav or pcm" — a local
+          runtime built without an MP3 encoder will.
+        </p>
       </div>
     {/if}
 

--- a/src/lib/components/settings/tabs/generation.svelte
+++ b/src/lib/components/settings/tabs/generation.svelte
@@ -74,6 +74,8 @@
             <Input
               type="number"
               class="h-9 w-24 text-left"
+              min={LLM_TIMEOUT_MIN_SECONDS}
+              max={LLM_TIMEOUT_MAX_SECONDS}
               value={Math.round(settings.apiSettings.llmTimeoutMs / 1000)}
               oninput={(e) => {
                 const seconds = parseInt(e.currentTarget.value, 10)

--- a/src/lib/components/settings/tabs/images.svelte
+++ b/src/lib/components/settings/tabs/images.svelte
@@ -14,6 +14,7 @@
     getProviderSamplerInfo,
     listLoras,
     generateImage,
+    requiresApiKey,
     ComfyMode,
     type ImageModelInfo,
   } from '$lib/services/ai/image'
@@ -1133,8 +1134,7 @@
       />
     </div>
 
-    <!-- comfy and a1111 don't require API keys -->
-    {#if profileProviderType !== 'comfyui' && profileProviderType !== 'a1111'}
+    {#if requiresApiKey(profileProviderType)}
       <div class="space-y-2">
         <Label>API Key</Label>
         <div class="flex gap-2">

--- a/src/lib/components/settings/tabs/story-settings.svelte
+++ b/src/lib/components/settings/tabs/story-settings.svelte
@@ -90,6 +90,10 @@
 
   const storySettings = $derived(story.currentStory?.settings ?? {})
   const imageGenEnabled = $derived(hasRequiredCredentials())
+  const backgroundImagesAvailable = $derived(hasRequiredCredentials('background'))
+  const portraitReferenceAvailable = $derived(
+    hasRequiredCredentials('portrait') || hasRequiredCredentials('reference'),
+  )
 
   // Track only customSystemPrompt so the effect below doesn't fire on unrelated
   // setting changes (tone, pov, etc.) and overwrite an unsaved draft.
@@ -212,6 +216,8 @@
     tone={storySettings.tone ?? ''}
     visualProseMode={storySettings.visualProseMode ?? false}
     imageGenerationEnabled={imageGenEnabled}
+    {backgroundImagesAvailable}
+    {portraitReferenceAvailable}
     imageGenerationMode={storySettings.imageGenerationMode ?? 'none'}
     backgroundImagesEnabled={storySettings.backgroundImagesEnabled ?? false}
     referenceMode={storySettings.referenceMode ?? false}

--- a/src/lib/components/shared/WritingStyleFields.svelte
+++ b/src/lib/components/shared/WritingStyleFields.svelte
@@ -5,15 +5,20 @@
   import { Input } from '$lib/components/ui/input'
   import { Switch } from '$lib/components/ui/switch'
   import { BookOpen, User, Eye, AlignLeft } from '@lucide/svelte'
-  import type { POV, Tense, TargetLength } from '$lib/types'
+  import type { POV, Tense, TargetLength, ImageGenerationMode } from '$lib/types'
 
   interface Props {
     selectedPOV: POV
     selectedTense: Tense
     tone: string
     visualProseMode: boolean
+    /** Standard image slot is usable — gates the image mode choice. */
     imageGenerationEnabled: boolean
-    imageGenerationMode: 'none' | 'agentic' | 'inline'
+    /** Background slot is usable. Defaults to `imageGenerationEnabled`. */
+    backgroundImagesAvailable?: boolean
+    /** Portrait or reference slot is usable. Defaults to `imageGenerationEnabled`. */
+    portraitReferenceAvailable?: boolean
+    imageGenerationMode: ImageGenerationMode
     backgroundImagesEnabled: boolean
     referenceMode: boolean
     targetLength?: TargetLength
@@ -25,7 +30,7 @@
     onTenseChange: (v: Tense) => void
     onToneChange: (v: string) => void
     onVisualProseModeChange: (v: boolean) => void
-    onImageGenerationModeChange: (v: 'none' | 'agentic' | 'inline') => void
+    onImageGenerationModeChange: (v: ImageGenerationMode) => void
     onBackgroundImagesEnabledChange: (v: boolean) => void
     onReferenceModeChange: (v: boolean) => void
     onTargetLengthChange?: (v: TargetLength) => void
@@ -43,6 +48,8 @@
     tone,
     visualProseMode,
     imageGenerationEnabled,
+    backgroundImagesAvailable,
+    portraitReferenceAvailable,
     imageGenerationMode,
     backgroundImagesEnabled,
     referenceMode,
@@ -60,6 +67,36 @@
     disabledFields,
     disabledReason,
   }: Props = $props()
+
+  const IMAGE_MODES: { value: ImageGenerationMode; label: string; description: string }[] = [
+    {
+      value: 'none',
+      label: 'Text Only',
+      description: 'Pure text adventure. No images will be generated.',
+    },
+    {
+      value: 'agentic',
+      label: 'Agent Mode',
+      description: 'AI decides when to generate images based on the story.',
+    },
+    {
+      value: 'inline',
+      label: 'Inline Mode',
+      description: 'Images are embedded directly in the text flow.',
+    },
+  ]
+
+  const backgroundAvailable = $derived(backgroundImagesAvailable ?? imageGenerationEnabled)
+  const portraitAvailable = $derived(portraitReferenceAvailable ?? imageGenerationEnabled)
+
+  // An unconfigured option can still be turned off, never on: the current selection stays
+  // reachable so a story set up on another machine isn't stuck with it.
+  function modeLocked(value: ImageGenerationMode): boolean {
+    return !imageGenerationEnabled && value !== 'none' && value !== imageGenerationMode
+  }
+  const imageProfileMissing = $derived(
+    !imageGenerationEnabled || !backgroundAvailable || !portraitAvailable,
+  )
 
   /** Must match the ranges `formatLengthInstruction` asks for, which differ per mode. */
   const LENGTH_RANGES = {
@@ -258,99 +295,85 @@
   {/if}
 
   <!-- Visuals Configuration -->
-  {#if imageGenerationEnabled}
-    <section class="space-y-2 pt-1">
-      <Label class="flex items-center gap-2 text-base font-semibold">
-        <Eye class="h-4 w-4" />
-        Visual Experience
-      </Label>
+  <section class="space-y-2 pt-1">
+    <Label class="flex items-center gap-2 text-base font-semibold">
+      <Eye class="h-4 w-4" />
+      Visual Experience
+    </Label>
 
-      <RadioGroup.Root
-        value={imageGenerationMode}
-        onValueChange={(v) => onImageGenerationModeChange(v as 'none' | 'agentic' | 'inline')}
-        class="grid grid-cols-1 gap-4 md:grid-cols-3"
+    {#if imageProfileMissing}
+      <p class="text-muted-foreground text-xs">
+        Options without a configured image profile can only be turned off. Set one up in Settings →
+        Images.
+      </p>
+    {/if}
+
+    <RadioGroup.Root
+      value={imageGenerationMode}
+      onValueChange={(v) => onImageGenerationModeChange(v as ImageGenerationMode)}
+      class="grid grid-cols-1 gap-4 md:grid-cols-3"
+    >
+      {#each IMAGE_MODES as option (option.value)}
+        {@const locked = modeLocked(option.value)}
+        <div class="relative" class:opacity-50={locked}>
+          <Label
+            for="img-{option.value}"
+            class="border-muted bg-popover has-[[data-state=checked]]:border-primary has-[[data-state=checked]]:bg-primary/5 has-[:focus-visible]:ring-ring flex h-full flex-col justify-between rounded-xl border-2 p-4 has-[:focus-visible]:ring-2 {locked
+              ? 'cursor-not-allowed'
+              : 'hover:bg-accent cursor-pointer'}"
+          >
+            <div class="mb-2 flex w-full items-start justify-between">
+              <span class="font-semibold">{option.label}</span>
+              <RadioGroup.Item
+                value={option.value}
+                id="img-{option.value}"
+                disabled={locked}
+                class="sr-only"
+              />
+            </div>
+            <div class="text-muted-foreground text-xs font-normal">{option.description}</div>
+          </Label>
+        </div>
+      {/each}
+    </RadioGroup.Root>
+
+    <!-- Extra Image Toggles -->
+    <div class="grid grid-cols-1 gap-4 pt-2 md:grid-cols-2">
+      <div
+        class="flex items-center space-x-2"
+        class:opacity-50={!backgroundAvailable && !backgroundImagesEnabled}
       >
-        <!-- No Images -->
-        <div class="relative">
-          <Label
-            for="img-none"
-            class="border-muted bg-popover hover:bg-accent has-[[data-state=checked]]:border-primary has-[[data-state=checked]]:bg-primary/5 has-[:focus-visible]:ring-ring flex h-full cursor-pointer flex-col justify-between rounded-xl border-2 p-4 has-[:focus-visible]:ring-2"
-          >
-            <div class="mb-2 flex w-full items-start justify-between">
-              <span class="font-semibold">Text Only</span>
-              <RadioGroup.Item value="none" id="img-none" class="sr-only" />
-            </div>
-            <div class="text-muted-foreground text-xs font-normal">
-              Pure text adventure. No images will be generated.
-            </div>
-          </Label>
-        </div>
-
-        <!-- Agent Mode -->
-        <div class="relative">
-          <Label
-            for="img-auto"
-            class="border-muted bg-popover hover:bg-accent has-[[data-state=checked]]:border-primary has-[[data-state=checked]]:bg-primary/5 has-[:focus-visible]:ring-ring flex h-full cursor-pointer flex-col justify-between rounded-xl border-2 p-4 has-[:focus-visible]:ring-2"
-          >
-            <div class="mb-2 flex w-full items-start justify-between">
-              <span class="font-semibold">Agent Mode</span>
-              <RadioGroup.Item value="agentic" id="img-auto" class="sr-only" />
-            </div>
-            <div class="text-muted-foreground text-xs font-normal">
-              AI decides when to generate images based on the story.
-            </div>
-          </Label>
-        </div>
-
-        <!-- Inline Mode -->
-        <div class="relative">
-          <Label
-            for="img-inline"
-            class="border-muted bg-popover hover:bg-accent has-[[data-state=checked]]:border-primary has-[[data-state=checked]]:bg-primary/5 has-[:focus-visible]:ring-ring flex h-full cursor-pointer flex-col justify-between rounded-xl border-2 p-4 has-[:focus-visible]:ring-2"
-          >
-            <div class="mb-2 flex w-full items-start justify-between">
-              <span class="font-semibold">Inline Mode</span>
-              <RadioGroup.Item value="inline" id="img-inline" class="sr-only" />
-            </div>
-            <div class="text-muted-foreground text-xs font-normal">
-              Images are embedded directly in the text flow.
-            </div>
-          </Label>
-        </div>
-      </RadioGroup.Root>
-
-      <!-- Extra Image Toggles -->
-      <div class="grid grid-cols-1 gap-4 pt-2 md:grid-cols-2">
-        <div class="flex items-center space-x-2">
-          <Switch
-            id="bg-images"
-            checked={backgroundImagesEnabled}
-            onCheckedChange={onBackgroundImagesEnabledChange}
-          />
-          <div class="grid gap-1.5 leading-none">
-            <Label for="bg-images">Background Images</Label>
-            <p class="text-muted-foreground text-xs">
-              Generate immersive background images for scenes.
-            </p>
-          </div>
-        </div>
-
-        <div class="flex items-center space-x-2">
-          <Switch
-            id="reference-mode"
-            checked={referenceMode}
-            onCheckedChange={onReferenceModeChange}
-          />
-          <div class="grid gap-1.5 leading-none">
-            <Label for="reference-mode">Portrait Reference Mode</Label>
-            <p class="text-muted-foreground text-xs">
-              Use character portraits as visual references.
-            </p>
-          </div>
+        <Switch
+          id="bg-images"
+          checked={backgroundImagesEnabled}
+          disabled={!backgroundAvailable && !backgroundImagesEnabled}
+          onCheckedChange={onBackgroundImagesEnabledChange}
+        />
+        <div class="grid gap-1.5 leading-none">
+          <Label for="bg-images">Background Images</Label>
+          <p class="text-muted-foreground text-xs">
+            Generate immersive background images for scenes.
+          </p>
         </div>
       </div>
-    </section>
-  {/if}
+
+      <div
+        class="flex items-center space-x-2"
+        class:opacity-50={!portraitAvailable && !referenceMode}
+      >
+        <Switch
+          id="reference-mode"
+          checked={referenceMode}
+          disabled={!portraitAvailable && !referenceMode}
+          onCheckedChange={onReferenceModeChange}
+        />
+        <div class="grid gap-1.5 leading-none">
+          <Label for="reference-mode">Portrait Reference Mode</Label>
+          <p class="text-muted-foreground text-xs">Use character portraits as visual references.</p>
+        </div>
+      </div>
+    </div>
+  </section>
 
   <!-- Visual Prose Styling -->
   <section class="space-y-2 pt-1">

--- a/src/lib/components/story/StoryEntry.svelte
+++ b/src/lib/components/story/StoryEntry.svelte
@@ -432,8 +432,11 @@
     }
 
     try {
-      await inlineImageService.processNarrativeForInlineImages(context)
+      const queued = await inlineImageService.processNarrativeForInlineImages(context)
       await loadEmbeddedImages()
+      if (queued === 0) {
+        ui.showToast('Nothing left to recreate for this entry', 'info')
+      }
     } catch (err) {
       console.error('[StoryEntry] Failed to recreate missing images:', err)
       ui.showToast('Could not recreate the missing image', 'error')
@@ -986,11 +989,13 @@
   )
 
   /**
-   * How long an image may sit before the retry is offered: the same wait the user set for
-   * a generation request on the Generation tab, since it is the same question — how long
-   * before this is not coming back.
+   * How long an image may sit before the retry is offered: the wait the user set for a
+   * generation request, plus a margin. The image request aborts at `llmTimeoutMs` and
+   * records its own failure, so offering the retry at that exact mark races the abort and
+   * leaves two generations writing one record.
    */
-  const stuckThresholdMs = $derived(settings.apiSettings.llmTimeoutMs)
+  const IMAGE_STUCK_GRACE_MS = 30000
+  const stuckThresholdMs = $derived(settings.apiSettings.llmTimeoutMs + IMAGE_STUCK_GRACE_MS)
 
   const unfinishedImages = $derived(
     embeddedImages.filter((img) => img.status === 'pending' || img.status === 'generating'),
@@ -1019,9 +1024,23 @@
    * of a fresh narration every tag is legitimately without one.
    */
   const MISSING_RECORD_GRACE_MS = 5000
+
+  /**
+   * A tag left without a record because the entry already spent its per-message budget was
+   * skipped, not lost: the rescan refuses it for the same reason, so it is reported as a
+   * limit rather than offered a recovery that can only do nothing.
+   */
+  const overImageBudget = $derived(
+    (() => {
+      const maxImages = settings.systemServicesSettings.imageGeneration.maxImagesPerMessage ?? 3
+      return maxImages !== 0 && embeddedImages.length >= maxImages
+    })(),
+  )
+
   const picOptions = $derived({
     stuckIds: stuckImageIds,
     offerMissingRecovery: now - entry.createdAt >= MISSING_RECORD_GRACE_MS,
+    overBudget: overImageBudget,
   })
 
   // `now` decides two things — which unfinished images are old enough to offer a retry,

--- a/src/lib/components/story/StoryEntry.svelte
+++ b/src/lib/components/story/StoryEntry.svelte
@@ -44,8 +44,8 @@
   } from '$lib/services/events'
   import {
     inlineImageService,
-    retryImageGeneration,
     resolveStylePrompt,
+    retryImageGeneration,
   } from '$lib/services/ai/image'
   import { database } from '$lib/services/database'
   import { onMount } from 'svelte'
@@ -56,8 +56,8 @@
   import { Textarea } from '$lib/components/ui/textarea'
   import { Input } from '$lib/components/ui/input'
   import * as ResponsiveModal from '$lib/components/ui/responsive-modal'
-  import { IMAGE_STUCK_THRESHOLD_MS } from '$lib/services/ai/image/constants'
-  import { SvelteSet } from 'svelte/reactivity'
+  import { SvelteMap, SvelteSet } from 'svelte/reactivity'
+  import { escapeHtml } from '$lib/utils/inlineImageParser'
   import { extractSentenceAt, expandRangeBidirectional } from '$lib/utils/text'
 
   let { entry }: { entry: StoryEntry } = $props()
@@ -257,17 +257,8 @@
 
   // Inline image edit state
 
-  // Timer for checking stuck images
+  // Clock for the stuck-image affordance, moved only when that affordance can change.
   let now = $state(Date.now())
-
-  onMount(() => {
-    const interval = setInterval(() => {
-      now = Date.now()
-    }, 1000)
-    return () => {
-      clearInterval(interval)
-    }
-  })
 
   // Helper to get which branch a checkpoint belongs to (by checking its last entry's branchId)
   function getCheckpointBranchId(checkpoint: {
@@ -361,13 +352,68 @@
     checkpointName = ''
   }
 
-  // Load embedded images for narration entries
+  // Reads of this entry's images race each other: five callers fire the full load without
+  // awaiting it, and the single-row refreshes below run alongside them. Every read takes a
+  // ticket when it leaves, so an arriving snapshot can be told which rows were read after
+  // it and keep those instead of reinstating its own older copy — dropping the snapshot
+  // outright would leave the entry holding only the rows a refresh happened to bring in.
+  let readTicket = 0
+  let loadTicket = 0
+  let loadsInFlight = 0
+  const refreshedRows = new SvelteMap<string, { ticket: number; image: EmbeddedImage }>()
+
   async function loadEmbeddedImages() {
     if (entry.type !== 'narration') return
+    const ticket = ++readTicket
+    loadTicket = ticket
+    loadsInFlight++
     try {
-      embeddedImages = await database.getEmbeddedImagesForEntry(entry.id)
+      const loaded = await database.getEmbeddedImagesForEntry(entry.id)
+      if (loadTicket !== ticket) return
+
+      // What is left is newer than this snapshot; the rest is the snapshot's to supply.
+      for (const [id, row] of refreshedRows) {
+        if (row.ticket < ticket) refreshedRows.delete(id)
+      }
+
+      const merged = loaded.map((img) => refreshedRows.get(img.id)?.image ?? img)
+      const loadedIds = new Set(loaded.map((img) => img.id))
+      for (const [id, row] of refreshedRows) {
+        if (!loadedIds.has(id)) merged.push(row.image)
+      }
+      embeddedImages = merged
     } catch (err) {
       console.error('[StoryEntry] Failed to load embedded images:', err)
+    } finally {
+      loadsInFlight--
+      if (loadsInFlight === 0) refreshedRows.clear()
+    }
+  }
+
+  /**
+   * Refresh one image rather than the whole entry.
+   *
+   * A full reload pulls every image's base64 back through the IPC bridge, and a burst of
+   * four generations raises eight of these — the payload that `getEmbeddedImageMetaForStory`
+   * exists to keep off Android's heap.
+   */
+  async function refreshEmbeddedImage(imageId: string) {
+    if (entry.type !== 'narration') return
+    const ticket = ++readTicket
+    try {
+      const image = await database.getEmbeddedImage(imageId)
+      if (!image || image.entryId !== entry.id) return
+
+      // Only a load that is still out needs to be told about this row; with none in
+      // flight the map would just hold a second copy of every payload.
+      if (loadsInFlight > 0) refreshedRows.set(imageId, { ticket, image })
+      const index = embeddedImages.findIndex((img) => img.id === imageId)
+      embeddedImages =
+        index === -1
+          ? [...embeddedImages, image]
+          : embeddedImages.map((img) => (img.id === imageId ? image : img))
+    } catch (err) {
+      console.error('[StoryEntry] Failed to refresh embedded image:', err)
     }
   }
 
@@ -385,8 +431,13 @@
       referenceMode: story.currentStory.settings?.referenceMode ?? false,
     }
 
-    await inlineImageService.processNarrativeForInlineImages(context)
-    await loadEmbeddedImages()
+    try {
+      await inlineImageService.processNarrativeForInlineImages(context)
+      await loadEmbeddedImages()
+    } catch (err) {
+      console.error('[StoryEntry] Failed to recreate missing images:', err)
+      ui.showToast('Could not recreate the missing image', 'error')
+    }
   }
 
   // State for inline image view modal
@@ -827,9 +878,9 @@
 
   // Manage inline image display
   $effect(() => {
-    // Clean up any existing inline image displays
-    const existingDisplays = document.querySelectorAll('.inline-image-display')
-    existingDisplays.forEach((el) => el.remove())
+    // Scoped to this entry: a document-wide query would tear the open display out of
+    // every other entry while leaving their expandedImageId set.
+    storyTextContainer?.querySelectorAll('.inline-image-display').forEach((el) => el.remove())
 
     if (!expandedImageId || !clickedElement || !expandedImage) return
 
@@ -847,7 +898,7 @@
       if (isRegenerating) {
         innerHtml += `
           <div class="inline-image-content-wrapper">
-            <img src="data:image/png;base64,${expandedImage.imageData}" alt="${expandedImage.sourceText}" class="inline-image-content regenerating-image" />
+            <img src="data:image/png;base64,${expandedImage.imageData}" alt="${escapeHtml(expandedImage.sourceText)}" class="inline-image-content regenerating-image" />
             <div class="regenerating-overlay">
               <div class="regenerating-content">
                 <svg class="regenerating-spinner" viewBox="0 0 50 50">
@@ -861,18 +912,18 @@
         // Clickable image - opens modal
         innerHtml += `
           <div class="inline-image-content-wrapper clickable-image" data-image-id="${expandedImage.id}">
-            <img src="data:image/png;base64,${expandedImage.imageData}" alt="${expandedImage.sourceText}" class="inline-image-content" />
+            <img src="data:image/png;base64,${expandedImage.imageData}" alt="${escapeHtml(expandedImage.sourceText)}" class="inline-image-content" />
           </div>`
       }
     } else if (expandedImage.status === 'generating') {
-      const isStuck = now - expandedImage.createdAt > IMAGE_STUCK_THRESHOLD_MS
+      const isStuck = now - expandedImage.createdAt >= stuckThresholdMs
       innerHtml += `<div class="inline-image-placeholder generating">
         <div class="placeholder-spinner"></div>
         <span class="placeholder-status">Generating...</span>
         ${isStuck ? `<button class="inline-image-retry" data-image-id="${expandedImage.id}">Force Retry</button>` : ''}
       </div>`
     } else if (expandedImage.status === 'pending') {
-      const isStuck = now - expandedImage.createdAt > IMAGE_STUCK_THRESHOLD_MS
+      const isStuck = now - expandedImage.createdAt >= stuckThresholdMs
       innerHtml += `<div class="inline-image-placeholder pending">
         <div class="placeholder-icon">⏳</div>
         <span class="placeholder-status">Queued...</span>
@@ -934,19 +985,79 @@
     expandedImageId ? embeddedImages.find((img) => img.id === expandedImageId) : null,
   )
 
+  /**
+   * How long an image may sit before the retry is offered: the same wait the user set for
+   * a generation request on the Generation tab, since it is the same question — how long
+   * before this is not coming back.
+   */
+  const stuckThresholdMs = $derived(settings.apiSettings.llmTimeoutMs)
+
+  const unfinishedImages = $derived(
+    embeddedImages.filter((img) => img.status === 'pending' || img.status === 'generating'),
+  )
+
+  /**
+   * Images waiting long enough that the retry affordance is worth offering.
+   *
+   * An image being retried is excluded: the retry does not move `createdAt`, so the row
+   * would keep the button through its own second attempt and every click would start
+   * another generation over the same record.
+   */
+  const stuckImageIds = $derived(
+    new Set(
+      unfinishedImages
+        .filter(
+          (img) => now - img.createdAt >= stuckThresholdMs && !regeneratingImageIds.has(img.id),
+        )
+        .map((img) => img.id),
+    ),
+  )
+
+  /**
+   * A `<pic>` tag whose record is missing is only worth reporting once the entry has had
+   * time to write them: they are created after the entry itself, so for the first moments
+   * of a fresh narration every tag is legitimately without one.
+   */
+  const MISSING_RECORD_GRACE_MS = 5000
+  const picOptions = $derived({
+    stuckIds: stuckImageIds,
+    offerMissingRecovery: now - entry.createdAt >= MISSING_RECORD_GRACE_MS,
+  })
+
+  // `now` decides two things — which unfinished images are old enough to offer a retry,
+  // and whether a tag without a record counts as lost — and each crosses its line once.
+  // Wake for the nearest crossing rather than every second: one timer per entry with
+  // something outstanding, instead of one per entry forever. Reading `now` re-arms this
+  // for the crossing after the one it just served.
+  $effect(() => {
+    const deadlines = [
+      ...unfinishedImages.map((img) => img.createdAt + stuckThresholdMs - now),
+      entry.createdAt + MISSING_RECORD_GRACE_MS - now,
+    ].filter((remaining) => remaining > 0)
+    if (deadlines.length === 0) return
+
+    const timer = setTimeout(
+      () => {
+        now = Date.now()
+      },
+      Math.min(...deadlines),
+    )
+    return () => clearTimeout(timer)
+  })
+
   // Subscribe to ImageReady, ImageQueued, and TTS events
   onMount(() => {
     // Subscribe to ImageQueued events to reload images when new records are created during streaming
     const unsubImageQueued = eventBus.subscribe<ImageQueuedEvent>('ImageQueued', (event) => {
       if (event.entryId === entry.id) {
-        loadEmbeddedImages()
+        refreshEmbeddedImage(event.imageId)
       }
     })
 
     // Subscribe to ImageReady events to reload images when one completes
     const unsubImageReady = eventBus.subscribe<ImageReadyEvent>('ImageReady', (event) => {
       if (event.entryId === entry.id) {
-        loadEmbeddedImages()
+        refreshEmbeddedImage(event.imageId)
       }
     })
 
@@ -1563,10 +1674,16 @@
               embeddedImages,
               entry.id,
               regeneratingImageIds,
+              picOptions,
             )}
           {:else}
             <!-- Standard mode (handles both agentic and inline images) -->
-            {@html processStoryContent(displayContent, embeddedImages, regeneratingImageIds)}
+            {@html processStoryContent(
+              displayContent,
+              embeddedImages,
+              regeneratingImageIds,
+              picOptions,
+            )}
           {/if}
         {:else if entry.type === 'user_action'}
           <!-- User action: show original input (before translation).

--- a/src/lib/components/vault/prompts/RuntimeVariableManager.svelte
+++ b/src/lib/components/vault/prompts/RuntimeVariableManager.svelte
@@ -121,10 +121,7 @@
 
   async function handleDeleteVariable(variable: RuntimeVariable) {
     try {
-      await database.withTransaction(async () => {
-        await database.deleteRuntimeVariable(variable.id)
-        await database.clearRuntimeVarFromEntities(packId, variable.id)
-      })
+      await database.deleteRuntimeVariableEverywhere(packId, variable.id)
       onVariablesChanged()
     } catch (error) {
       console.error('[RuntimeVariableManager] Failed to delete variable:', error)
@@ -137,10 +134,7 @@
     newVariableName: string,
   ) {
     try {
-      await database.withTransaction(async () => {
-        await database.updateRuntimeVariable(variableId, { variableName: newVariableName })
-        await database.renameRuntimeVarInEntities(packId, variableId, newVariableName)
-      })
+      await database.renameRuntimeVariableEverywhere(packId, variableId, newVariableName)
       onVariablesChanged()
     } catch (error) {
       console.error('[RuntimeVariableManager] Failed to rename variable:', error)
@@ -149,16 +143,7 @@
 
   async function handleTypeChange(variable: RuntimeVariable, newType: RuntimeVariableType) {
     try {
-      await database.withTransaction(async () => {
-        await database.clearRuntimeVarFromEntities(packId, variable.id)
-        await database.updateRuntimeVariable(variable.id, {
-          variableType: newType,
-          defaultValue: undefined,
-          minValue: undefined,
-          maxValue: undefined,
-          enumOptions: undefined,
-        })
-      })
+      await database.changeRuntimeVariableTypeEverywhere(packId, variable.id, newType)
       onVariablesChanged()
     } catch (error) {
       console.error('[RuntimeVariableManager] Failed to change variable type:', error)
@@ -189,13 +174,18 @@
     group[index].sortOrder = group[newIndex].sortOrder
     group[newIndex].sortOrder = tempOrder
 
-    await database.withTransaction(async () => {
-      await database.updateRuntimeVariable(group[index].id, { sortOrder: group[index].sortOrder })
-      await database.updateRuntimeVariable(group[newIndex].id, {
-        sortOrder: group[newIndex].sortOrder,
-      })
-    })
-    onVariablesChanged()
+    try {
+      await database.swapRuntimeVariableOrder(
+        { id: group[index].id, sortOrder: group[index].sortOrder },
+        { id: group[newIndex].id, sortOrder: group[newIndex].sortOrder },
+      )
+      onVariablesChanged()
+    } catch (error) {
+      console.error('[RuntimeVariableManager] Failed to reorder variables:', error)
+      // The rows kept their old order, so the list has to as well.
+      group[newIndex].sortOrder = group[index].sortOrder
+      group[index].sortOrder = tempOrder
+    }
   }
 
   // Load entity counts for all variables

--- a/src/lib/components/wizard/st-import-steps/StepImportStyle.svelte
+++ b/src/lib/components/wizard/st-import-steps/StepImportStyle.svelte
@@ -5,7 +5,7 @@
   import { ScrollArea } from '$lib/components/ui/scroll-area'
   import WritingStyleFields from '$lib/components/shared/WritingStyleFields.svelte'
   import { hasRequiredCredentials } from '$lib/services/ai/image'
-  import type { StoryMode, POV } from '$lib/types'
+  import type { StoryMode, POV, ImageGenerationMode } from '$lib/types'
   import type { Tense } from '$lib/services/ai/wizard/ScenarioService'
 
   interface Props {
@@ -14,7 +14,7 @@
     selectedTense: Tense
     tone: string
     visualProseMode: boolean
-    imageGenerationMode: 'none' | 'agentic' | 'inline'
+    imageGenerationMode: ImageGenerationMode
     backgroundImagesEnabled: boolean
     referenceMode: boolean
     importChatAsEntries: boolean
@@ -26,7 +26,7 @@
     onTenseChange: (v: Tense) => void
     onToneChange: (v: string) => void
     onVisualProseModeChange: (v: boolean) => void
-    onImageGenerationModeChange: (v: 'none' | 'agentic' | 'inline') => void
+    onImageGenerationModeChange: (v: ImageGenerationMode) => void
     onBackgroundImagesEnabledChange: (v: boolean) => void
     onReferenceModeChange: (v: boolean) => void
     onImportChatToggle: (v: boolean) => void

--- a/src/lib/components/wizard/steps/Step7WritingStyle.svelte
+++ b/src/lib/components/wizard/steps/Step7WritingStyle.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import WritingStyleFields from '$lib/components/shared/WritingStyleFields.svelte'
   import { ScrollArea } from '$lib/components/ui/scroll-area'
-  import type { POV, Tense, TargetLength } from '$lib/types'
+  import type { POV, Tense, TargetLength, ImageGenerationMode } from '$lib/types'
 
   interface Props {
     selectedPOV: POV
@@ -9,7 +9,7 @@
     tone: string
     visualProseMode: boolean
     imageGenerationEnabled: boolean
-    imageGenerationMode: 'none' | 'agentic' | 'inline'
+    imageGenerationMode: ImageGenerationMode
     backgroundImagesEnabled: boolean
     referenceMode: boolean
     targetLength?: TargetLength
@@ -18,7 +18,7 @@
     onTenseChange: (v: Tense) => void
     onToneChange: (v: string) => void
     onVisualProseModeChange: (v: boolean) => void
-    onImageGenerationModeChange: (v: 'none' | 'agentic' | 'inline') => void
+    onImageGenerationModeChange: (v: ImageGenerationMode) => void
     onBackgroundImagesEnabledChange: (v: boolean) => void
     onReferenceModeChange: (v: boolean) => void
     onTargetLengthChange?: (v: TargetLength) => void

--- a/src/lib/services/ai/core/factory.ts
+++ b/src/lib/services/ai/core/factory.ts
@@ -45,7 +45,7 @@ export class ServiceFactory {
   createClassifierService(): ClassifierService {
     return new ClassifierService(
       'classifier',
-      settings.systemServicesSettings.classifier.chatHistoryTruncation,
+      settings.systemServicesSettings.classifier.recentEntriesWindow,
     )
   }
 

--- a/src/lib/services/ai/generation/ClassifierService.ts
+++ b/src/lib/services/ai/generation/ClassifierService.ts
@@ -26,6 +26,8 @@ import { ContextBuilder } from '$lib/services/context'
 import { database } from '$lib/services/database'
 import { createLogger } from '$lib/log'
 import { stripPicTags } from '$lib/utils/inlineImageParser'
+import { stripNarratorMarkup } from '$lib/utils/text'
+import { recentContent, AS_PROSE } from '$lib/utils/recentContent'
 import {
   classificationResultSchema,
   clampNumber,
@@ -59,11 +61,11 @@ export interface ClassificationContext {
  * Service that classifies narrative responses to extract world state changes.
  */
 export class ClassifierService extends BaseAIService {
-  private chatHistoryTruncation: number
+  private recentEntriesWindow: number
 
-  constructor(serviceId: ServiceId, chatHistoryTruncation: number = 100) {
+  constructor(serviceId: ServiceId, recentEntriesWindow: number = 7) {
     super(serviceId)
-    this.chatHistoryTruncation = chatHistoryTruncation
+    this.recentEntriesWindow = recentEntriesWindow
   }
 
   /**
@@ -103,14 +105,12 @@ export class ClassifierService extends BaseAIService {
 
     // Format existing entities for the prompt
     const existingCharacters = this.formatExistingCharacters(context.existingCharacters)
-    const existingLocations = context.existingLocations.map((l) => l.name).join(', ') || '(none)'
-    const existingItems = context.existingItems.map((i) => i.name).join(', ') || '(none)'
+    const existingLocations = this.formatExistingLocations(context.existingLocations)
+    const existingItems = this.formatExistingItems(context.existingItems)
     const existingBeats = this.formatExistingBeats(context.existingStoryBeats)
 
     // Build chat history block if entries provided
-    const chatHistoryBlock = visibleEntries
-      ? this.buildChatHistoryBlock(visibleEntries, currentStoryTime)
-      : ''
+    const chatHistoryBlock = visibleEntries ? this.buildChatHistoryBlock(visibleEntries) : ''
 
     // Build time info
     const currentTimeInfo = currentStoryTime
@@ -128,16 +128,16 @@ export class ClassifierService extends BaseAIService {
     ctx.add({
       genre: context.story.genre ? `Genre: ${context.story.genre}` : '',
       mode,
-      entityCounts: `${context.existingCharacters.length} characters, ${context.existingLocations.length} locations, ${context.existingItems.length} items`,
       currentTimeInfo,
       chatHistoryBlock,
       inputLabel: mode === 'creative-writing' ? 'Author Direction' : 'Player Action',
-      userAction: stripPicTags(context.userAction),
-      narrativeResponse: stripPicTags(context.narrativeResponse),
+      userAction: cleanForClassification(context.userAction),
+      narrativeResponse: cleanForClassification(context.narrativeResponse),
       existingCharacters,
       existingLocations,
       existingItems,
       existingBeats,
+      hasStoryBeats: existingBeats !== '(none)',
       storyBeatTypes: 'milestone, quest, revelation, event, plot_point',
       itemLocationOptions: 'inventory, worn, ground, or specific location name',
       defaultItemLocation: 'inventory',
@@ -403,24 +403,31 @@ export class ClassifierService extends BaseAIService {
    * Format existing characters for the prompt.
    *
    * **The name is the whole of its line.** The model reads this list and writes names back,
-   * so a rendered suffix — `- Ada (claimed as a consort) [inactive]` — came back as the
-   * name and minted a second character: four of thirty-eight on a measured save. Attributes
-   * are indented `label: value` lines instead, which a name containing parentheses cannot
-   * be confused with.
+   * so a rendered suffix — `- Ada (claimed as a consort) [inactive]` — comes back as the
+   * name and mints a second character. Attributes are indented `label: value` lines
+   * instead, which a name containing parentheses cannot be confused with.
+   *
+   * `appearance` is sent only for characters in the scene. It is there to be rewritten, and
+   * only someone present can have their look updated; on a large cast it is also most of
+   * the prompt. The template forbids rewriting an appearance that is not shown, so a
+   * returning character keeps the descriptors it accumulated.
    */
   private formatExistingCharacters(characters: Character[]): string {
     if (characters.length === 0) return '(none)'
 
     return characters
       .map((c) => {
+        const status = c.status ?? 'active'
         let entry = `- ${c.name}`
         if (c.relationship) entry += `\n  relationship: ${c.relationship}`
-        // `active` is printed too. Hiding it made the list asymmetric: the model was
-        // reminded to reactivate someone who returned and never that anyone was marked
-        // present, so nobody was ever marked away and the narrator's [PRESENT] section grew
-        // to every character in the story.
-        entry += `\n  status: ${c.status ?? 'active'}`
-        if (c.visualDescriptors && Object.keys(c.visualDescriptors).length > 0) {
+        // `active` is printed too, or the list is asymmetric: the model would be reminded to
+        // report a return and never a departure.
+        entry += `\n  status: ${status}`
+        if (
+          status === 'active' &&
+          c.visualDescriptors &&
+          Object.keys(c.visualDescriptors).length > 0
+        ) {
           entry += `\n  appearance: ${this.formatVisualDescriptors(c.visualDescriptors)}`
         }
         return entry
@@ -447,6 +454,51 @@ export class ClassifierService extends BaseAIService {
   }
 
   /**
+   * Format existing locations for the prompt.
+   *
+   * One name per line, as with characters: a comma-separated list cannot hold a name that
+   * contains a comma, and this list is copied back verbatim.
+   *
+   * Only the current location carries its description. A passage can re-describe the place
+   * it happens in and no other, and `description` is a whole-value replacement — the model
+   * must not rewrite one it was never shown.
+   */
+  private formatExistingLocations(locations: Location[]): string {
+    if (locations.length === 0) return '(none)'
+
+    return locations
+      .map((l) => {
+        let entry = `- ${l.name}`
+        if (l.current) {
+          entry += `\n  current: true`
+          if (l.description) entry += `\n  description: ${l.description}`
+        }
+        return entry
+      })
+      .join('\n')
+  }
+
+  /**
+   * Format existing items for the prompt.
+   *
+   * State is printed only where it differs from the default, so the list stays short: an
+   * unequipped single item sitting in the inventory is just its name.
+   */
+  private formatExistingItems(items: Item[]): string {
+    if (items.length === 0) return '(none)'
+
+    return items
+      .map((i) => {
+        let entry = `- ${i.name}`
+        if (i.quantity > 1) entry += `\n  quantity: ${i.quantity}`
+        if (i.equipped) entry += `\n  equipped: true`
+        if (i.location && i.location !== 'inventory') entry += `\n  location: ${i.location}`
+        return entry
+      })
+      .join('\n')
+  }
+
+  /**
    * Format existing story beats for the prompt.
    */
   private formatExistingBeats(beats: StoryBeat[]): string {
@@ -468,27 +520,24 @@ export class ClassifierService extends BaseAIService {
   }
 
   /**
-   * Build chat history block for context.
+   * Recent turns, whole. The window is short because these entries carry the scene the
+   * classifier reports on -- who is present, what changed -- and that lives at the end of
+   * a narration, which any per-entry truncation cuts off first.
    */
-  private buildChatHistoryBlock(entries: StoryEntry[], _currentTime?: TimeTracker | null): string {
+  private buildChatHistoryBlock(entries: StoryEntry[]): string {
     if (entries.length === 0) return ''
 
-    const recentEntries = entries.slice(-this.chatHistoryTruncation)
-
-    const formatted = recentEntries
-      .map((e) => {
-        const prefix = e.type === 'user_action' ? '[ACTION]' : '[NARRATIVE]'
-        let timeInfo = ''
-        if (e.metadata?.timeStart) {
-          const t = e.metadata.timeStart
-          timeInfo = ` (at Y${t.years}D${t.days} ${String(t.hours).padStart(2, '0')}:${String(t.minutes).padStart(2, '0')})`
-        }
-        // Always strip pic tags for classification to avoid confusion
-        const cleanContent = stripPicTags(e.content)
-        return `${prefix}${timeInfo} ${cleanContent.slice(0, 500)}${cleanContent.length > 500 ? '...' : ''}`
-      })
-      .join('\n\n')
+    const formatted = recentContent(entries, this.recentEntriesWindow, AS_PROSE, {
+      roles: true,
+      time: true,
+      transform: cleanForClassification,
+    })
 
     return `## Recent Chat History\n${formatted}\n`
   }
+}
+
+/** Neither the image markup nor the narrator's layout is part of the passage to classify. */
+function cleanForClassification(content: string): string {
+  return stripNarratorMarkup(stripPicTags(content))
 }

--- a/src/lib/services/ai/generation/WorldStateInjector.test.ts
+++ b/src/lib/services/ai/generation/WorldStateInjector.test.ts
@@ -349,11 +349,14 @@ describe('WorldStateInjector', () => {
       const block = result.contextBlock
 
       expect(block).toContain('[PROTAGONIST]')
-      expect(block.indexOf('Kestrel')).toBeLessThan(block.indexOf('[KNOWN CHARACTERS]'))
+      expect(block.indexOf('Kestrel')).toBeLessThan(block.indexOf('[CHARACTERS PRESENT]'))
 
-      const known = block.slice(block.indexOf('[KNOWN CHARACTERS]'), block.indexOf('[INVENTORY]'))
-      expect(known).not.toContain('Kestrel')
-      expect(known).toContain('Aria')
+      const present = block.slice(
+        block.indexOf('[CHARACTERS PRESENT]'),
+        block.indexOf('[INVENTORY]'),
+      )
+      expect(present).not.toContain('Kestrel')
+      expect(present).toContain('Aria')
     })
 
     it('carries traits and appearance, which image generation depends on', async () => {
@@ -368,6 +371,66 @@ describe('WorldStateInjector', () => {
 
       expect(result.tier2.map((e) => e.name)).not.toContain('Kestrel')
       expect(result.tier3.map((e) => e.name)).not.toContain('Kestrel')
+    })
+  })
+
+  describe('characters leaving the scene', () => {
+    const tracked = () => {
+      const positions = new Map<string, number>()
+      return {
+        getLastActivation: (id: string) => positions.get(id) ?? null,
+        recordActivation: (id: string, p: number) => positions.set(id, p),
+        currentPosition: 0,
+      }
+    }
+
+    const seen = {
+      ...worldState,
+      characters: [
+        { ...characters[0], visualDescriptors: { hair: 'silver braid' } },
+        characters[1],
+      ] as Character[],
+    }
+    const away = {
+      ...seen,
+      characters: [{ ...seen.characters[0], status: 'inactive' }, characters[1]] as Character[],
+    }
+
+    it('records an activation for a character in the scene', async () => {
+      // Tier 1 is the presence signal: without this there is nothing for the carry-over to
+      // fade from, and a character who leaves drops out of the prompt in one turn.
+      const tracker = tracked()
+      await injector.buildContext(seen, '', [], { activationTracker: tracker, storyId: undefined })
+
+      expect(tracker.getLastActivation('c1')).toBe(0)
+    })
+
+    it('carries a character who just left, under its own heading', async () => {
+      const tracker = tracked()
+      await injector.buildContext(seen, '', [], { activationTracker: tracker, storyId: undefined })
+      const result = await injector.buildContext(away, '', [], {
+        activationTracker: tracker,
+        storyId: undefined,
+      })
+
+      expect(result.tier1.find((e) => e.name === 'Aria')?.metadata?.sticky).toBe(true)
+      expect(result.contextBlock).toContain('[RECENTLY DEPARTED]')
+      expect(result.contextBlock).not.toContain('[CHARACTERS PRESENT]')
+    })
+
+    it('stops sending the appearance of someone who is no longer in the scene', async () => {
+      const tracker = tracked()
+      const present = await injector.buildContext(seen, '', [], {
+        activationTracker: tracker,
+        storyId: undefined,
+      })
+      const departed = await injector.buildContext(away, '', [], {
+        activationTracker: tracker,
+        storyId: undefined,
+      })
+
+      expect(present.contextBlock).toContain('silver braid')
+      expect(departed.contextBlock).not.toContain('silver braid')
     })
   })
 

--- a/src/lib/services/ai/generation/WorldStateInjector.ts
+++ b/src/lib/services/ai/generation/WorldStateInjector.ts
@@ -21,11 +21,9 @@
  * overlap: a lorebook Entry is authored lore that does not change unless someone edits
  * it, while these are records the classifier rewrites every turn.
  *
- * Runs in full on every narrator turn, in every Memory Retrieval mode -- as does
- * EntryRetrievalService now. Agentic Retrieval stands in for neither: its tools reach
- * Lorebook entries and chapters, it is never shown live WorldState, and it no longer selects
- * anything. It used to suppress this service's Tier 3 on the reasoning that "the agent
- * already did LLM selection"; that conflated two disjoint candidate pools and is gone.
+ * Runs in full on every narrator turn, in every Memory Retrieval mode, as does
+ * EntryRetrievalService. Agentic Retrieval stands in for neither: its tools reach Lorebook
+ * entries and chapters, and it is never shown live WorldState.
  *
  * Called from `RetrievalPhase`, in the same stage as EntryRetrievalService and before memory
  * retrieval -- which is what lets the memory step be told what the narrator already has.
@@ -285,20 +283,25 @@ export class WorldStateInjector extends BaseAIService {
       })
     }
 
-    // Record Tier 2 and Tier 3 activations for stickiness (mirrors EntryRetrievalService).
+    // Record activations for stickiness (mirrors EntryRetrievalService).
     //
     // After Tier 3, not between the tiers: an entity the LLM *picked* is as much "relevant
-    // this turn" as one matched by name, and recording only Tier 2 made the expensive
-    // signal the shorter-lived one.
+    // this turn" as one matched by name.
     //
     // A *wholesale* Tier 3 is excluded, exactly as in `EntryRetrievalService`. It means the
     // leftover was small, which says nothing about relevance — and since every uncovered
     // entity is in it, recording it would make the entire world state sticky on every turn
     // of any story under the budget, i.e. on most stories. Stickiness would then never
     // expire and Tier 1 would absorb the whole pool.
+    //
+    // Characters are the one Tier 1 type recorded here, and the exception is the point: an
+    // active character *is* a character in the scene, so Tier 1 membership is the presence
+    // signal. Without it a character has no activation to fade from, and the turn the
+    // classifier marks them away they leave the prompt outright instead of receding.
     const activated = tier3IsWholesale ? tier2 : [...tier2, ...tier3]
     if (activationTracker) {
-      for (const entry of activated) {
+      const present = tier1.filter((e) => e.type === 'character' && !e.metadata?.sticky)
+      for (const entry of [...present, ...activated]) {
         activationTracker.recordActivation(entry.id, currentPosition)
       }
     }
@@ -753,7 +756,31 @@ export class WorldStateInjector extends BaseAIService {
    * cannot drift -- and so the appearance fallback for the pre-object `visualDescriptors`
    * format is maintained once.
    */
-  private renderCharacterDetail(char: WorldStateContextEntry, relationship?: unknown): string {
+  /** One heading and its bullets, or nothing at all when there is no one to list. */
+  private renderCharacterSection(
+    heading: string,
+    chars: WorldStateContextEntry[],
+    withAppearance: boolean,
+  ): string {
+    if (chars.length === 0) return ''
+
+    let block = `\n\n${heading}`
+    for (const char of chars) {
+      // Name, then a separator that is not a parenthesis. This block reaches the narrator,
+      // whose prose the classifier reads back, and `Name (relationship)` is a form the
+      // classifier returns as a name — see `ClassifierService.formatExistingCharacters`.
+      block += `\n• ${char.name}`
+      if (char.description) block += ` - ${char.description}`
+      block += this.renderCharacterDetail(char, char.metadata?.relationship, withAppearance)
+    }
+    return block
+  }
+
+  private renderCharacterDetail(
+    char: WorldStateContextEntry,
+    relationship?: unknown,
+    withAppearance = true,
+  ): string {
     let out = ''
 
     const traits = char.metadata?.traits
@@ -766,7 +793,7 @@ export class WorldStateInjector extends BaseAIService {
     }
 
     let appearanceStr = ''
-    if (vd) {
+    if (vd && withAppearance) {
       if (Array.isArray(vd) && vd.length > 0) {
         appearanceStr = vd.join(', ')
       } else if (typeof vd === 'object') {
@@ -806,21 +833,12 @@ export class WorldStateInjector extends BaseAIService {
    * World state only. Whatever memory retrieval produced is concatenated by the caller --
    * see `buildContext`.
    *
-   * The sections split along two axes at once, and conflating them is what went wrong when
-   * stickiness was added to Tier 1. `[INVENTORY]` and `[ACTIVE THREADS]` are *claims about
-   * current state*; `[RELEVANT ...]` are claims about relevance only. Tier 1 used to
-   * contain nothing but the former, so reading "tier 1" as "current state" was safe. It is
-   * not any more: a sticky entry is in Tier 1 precisely *because* its state condition
-   * stopped holding -- an item that left the inventory, a beat that just completed. Sending
-   * those through the state sections told the narrator the protagonist carries an item they
-   * dropped and is pursuing a quest they finished.
-   *
-   * So the state sections take Tier 1 minus the sticky carry-over, and the sticky entries
-   * join Tier 2 and Tier 3 in the relevance sections, which is what they are. That also
-   * gives sticky locations somewhere to go: they matched neither `metadata.current` nor
-   * "tier 2 or 3", so they were rendered nowhere at all -- while still being counted in
-   * `all`, and so announced to the retrieval agent, via `formatAlreadyInContext`, as
-   * already in a prompt they never reached.
+   * The sections split along two axes at once, and tier is not one of them. `[CHARACTERS
+   * PRESENT]`, `[INVENTORY]` and `[ACTIVE THREADS]` are *claims about current state*;
+   * `[RECENTLY DEPARTED]` and `[RELEVANT ...]` are claims about relevance only. A sticky
+   * entry sits in Tier 1 precisely *because* its state condition stopped holding — an item
+   * that left the inventory, a character who left the room — so the state sections take
+   * Tier 1 minus the sticky carry-over, and the carry-over is rendered as what it is.
    */
   private buildContextBlock(
     tier1: WorldStateContextEntry[],
@@ -847,31 +865,28 @@ export class WorldStateInjector extends BaseAIService {
     // The protagonist, on their own. Rendered with the same detail as an NPC -- traits and
     // appearance matter more here than anywhere, since image generation and second-person
     // narration both lean on them -- but never in the list of people in the scene.
-    const you = tier1.find((e) => e.type === 'character' && e.metadata?.protagonist)
-    if (you) {
-      block += `\n\n[PROTAGONIST]\n${you.name}`
-      if (you.description) block += ` - ${you.description}`
-      block += this.renderCharacterDetail(you)
+    const protagonist = tier1.find((e) => e.type === 'character' && e.metadata?.protagonist)
+    if (protagonist) {
+      block += `\n\n[PROTAGONIST]\n${protagonist.name}`
+      if (protagonist.description) block += ` - ${protagonist.description}`
+      block += this.renderCharacterDetail(protagonist)
     }
 
-    // Characters (combine from all tiers)
-    const allChars = [...tier1, ...tier2, ...tier3].filter(
-      (e) => e.type === 'character' && !e.metadata?.protagonist,
-    )
-    if (allChars.length > 0) {
-      block += '\n\n[KNOWN CHARACTERS]'
-      for (const char of allChars) {
-        // Name, then a separator that is not a parenthesis. This block reaches the
-        // narrator, whose prose the classifier reads back, and `Name (relationship)` is a
-        // form the classifier has been observed to return as a name — see
-        // `ClassifierService.formatExistingCharacters`.
-        block += `\n• ${char.name}`
-        if (char.description) {
-          block += ` - ${char.description}`
-        }
-        block += this.renderCharacterDetail(char, char.metadata?.relationship)
-      }
-    }
+    // Characters, split along the same axis as everything else here: who is in the scene is
+    // state, who was in it recently is relevance. Merging the three told the narrator that
+    // someone who walked out two turns ago is standing in the room.
+    const isCharacter = (e: WorldStateContextEntry) =>
+      e.type === 'character' && !e.metadata?.protagonist
+
+    const present = current.filter(isCharacter)
+    const departed = tier1.filter(isSticky).filter(isCharacter)
+    const known = [...tier2, ...tier3].filter(isCharacter)
+
+    // Appearance is dropped for the departed: it is there for the image prompt, and nothing
+    // is drawn of someone off-screen.
+    block += this.renderCharacterSection('[CHARACTERS PRESENT]', present, true)
+    block += this.renderCharacterSection('[RECENTLY DEPARTED]', departed, false)
+    block += this.renderCharacterSection('[KNOWN CHARACTERS]', known, true)
 
     // Inventory: state, so Tier 1 minus the sticky carry-over.
     const inventoryItems = current.filter((e) => e.type === 'item')

--- a/src/lib/services/ai/image/InlineImageService.ts
+++ b/src/lib/services/ai/image/InlineImageService.ts
@@ -36,8 +36,10 @@ export class InlineImageGenerationService {
    * Process narrative content for <pic> tags and generate images.
    * This is the main entry point called after narrative generation completes
    * when inline image mode is enabled.
+   *
+   * @returns how many tags were queued, so a caller can tell a no-op from work done.
    */
-  async processNarrativeForInlineImages(context: InlineImageContext): Promise<void> {
+  async processNarrativeForInlineImages(context: InlineImageContext): Promise<number> {
     const imageSettings = settings.systemServicesSettings.imageGeneration
 
     // Extract all <pic> tags from the narrative
@@ -45,7 +47,7 @@ export class InlineImageGenerationService {
 
     if (picTags.length === 0) {
       log('No <pic> tags found in narrative')
-      return
+      return 0
     }
 
     log('Found <pic> tags', {
@@ -75,7 +77,7 @@ export class InlineImageGenerationService {
 
     if (missingTags.length === 0) {
       log('Every <pic> tag in this entry already has a record')
-      return
+      return 0
     }
 
     // Existing records count against the limit: it is a budget per message, not per call.
@@ -94,7 +96,7 @@ export class InlineImageGenerationService {
       })
     }
 
-    if (tagsToProcess.length === 0) return
+    if (tagsToProcess.length === 0) return 0
 
     // Process each tag
     for (const tag of tagsToProcess) {
@@ -102,6 +104,7 @@ export class InlineImageGenerationService {
     }
 
     log('All inline images queued', { count: tagsToProcess.length })
+    return tagsToProcess.length
   }
 
   /**

--- a/src/lib/services/ai/image/InlineImageService.ts
+++ b/src/lib/services/ai/image/InlineImageService.ts
@@ -12,14 +12,11 @@
  */
 
 import type { Character, EmbeddedImage } from '$lib/types'
-import {
-  generateImage as registryGenerateImage,
-  supportsImageGeneration,
-} from './providers/registry'
+import { runImageGeneration } from './imageUtils'
 import { database } from '$lib/services/database'
 import { settings } from '$lib/stores/settings.svelte'
-import { emitImageQueued, emitImageReady, emitImageAnalysisFailed } from '$lib/services/events'
-import { normalizeImageDataUrl, expectedPixels, type ImageSpec } from '$lib/utils/image'
+import { emitImageQueued } from '$lib/services/events'
+import { normalizeImageDataUrl, expectedPixels } from '$lib/utils/image'
 import { extractPicTags, type ParsedPicTag } from '$lib/utils/inlineImageParser'
 import { resolveStylePrompt } from './stylePrompt'
 import { createLogger } from '$lib/log'
@@ -35,22 +32,6 @@ export interface InlineImageContext {
 }
 
 export class InlineImageGenerationService {
-  /**
-   * Check if inline image generation is enabled and configured.
-   * Uses profile-based configuration - checks if a valid image-capable profile is selected.
-   */
-  static isEnabled(): boolean {
-    const imageSettings = settings.systemServicesSettings.imageGeneration
-
-    const profileId = imageSettings.profileId
-    if (!profileId) return false
-
-    const profile = settings.getImageProfile(profileId)
-    if (!profile) return false
-
-    return supportsImageGeneration(profile.providerType)
-  }
-
   /**
    * Process narrative content for <pic> tags and generate images.
    * This is the main entry point called after narrative generation completes
@@ -75,17 +56,45 @@ export class InlineImageGenerationService {
       })),
     })
 
-    // Apply max images limit
-    const maxImages = imageSettings.maxImagesPerMessage ?? 3
-    const tagsToProcess = maxImages === 0 ? picTags : picTags.slice(0, maxImages)
+    // Tags that already have a record are not generated again. On a fresh narration there
+    // are none and this costs one empty query; on the recovery rescan it is the whole
+    // point, since a second record for a tag shadows the first — the render map is keyed
+    // on `sourceText` — and the working image is replaced by a fresh generation.
+    const recordedTexts = await database.getEmbeddedImageSourceTextsForEntry(context.entryId)
 
-    if (tagsToProcess.length < picTags.length) {
+    // The set carries the tags accepted so far as well as the recorded ones: a narration
+    // can repeat a tag verbatim, and two records under one `sourceText` shadow each other
+    // exactly as a duplicate of an existing record would.
+    const seen = new Set(recordedTexts)
+    const missingTags: ParsedPicTag[] = []
+    for (const tag of picTags) {
+      if (seen.has(tag.originalTag)) continue
+      seen.add(tag.originalTag)
+      missingTags.push(tag)
+    }
+
+    if (missingTags.length === 0) {
+      log('Every <pic> tag in this entry already has a record')
+      return
+    }
+
+    // Existing records count against the limit: it is a budget per message, not per call.
+    // Counted as rows, not as distinct texts — an entry that already carries a duplicate
+    // pair has spent two of the budget.
+    const maxImages = imageSettings.maxImagesPerMessage ?? 3
+    const remaining = maxImages === 0 ? missingTags.length : maxImages - recordedTexts.length
+    const tagsToProcess = missingTags.slice(0, Math.max(0, remaining))
+
+    if (tagsToProcess.length < missingTags.length) {
       log('Limiting to max images', {
-        found: picTags.length,
+        missing: missingTags.length,
+        alreadyRecorded: recordedTexts.length,
         processing: tagsToProcess.length,
         maxAllowed: maxImages,
       })
     }
+
+    if (tagsToProcess.length === 0) return
 
     // Process each tag
     for (const tag of tagsToProcess) {
@@ -194,86 +203,18 @@ export class InlineImageGenerationService {
     emitImageQueued(imageId, context.entryId)
 
     // Start async generation (fire-and-forget)
-    this.generateImage(
+    runImageGeneration({
       imageId,
-      fullPrompt,
+      entryId: context.entryId,
+      prompt: fullPrompt,
       profileId,
-      modelToUse,
-      sizeToUse,
-      context.entryId,
-      referenceImageUrls,
-    ).catch((error) => {
+      model: modelToUse,
+      size: sizeToUse,
+      referenceImages: referenceImageUrls,
+      notifyFailure: true,
+    }).catch((error) => {
       log('Async inline image generation failed', { imageId, error })
     })
-  }
-
-  /**
-   * Generate a single image using the SDK (runs asynchronously)
-   */
-  private async generateImage(
-    imageId: string,
-    prompt: string,
-    profileId: string,
-    model: string,
-    size: ImageSpec,
-    entryId: string,
-    referenceImageUrls?: string[],
-  ): Promise<void> {
-    try {
-      // Update status to generating
-      await database.updateEmbeddedImage(imageId, { status: 'generating' })
-
-      log('Generating inline image via SDK', {
-        imageId,
-        profileId,
-        model,
-        hasReference: !!referenceImageUrls?.length,
-      })
-
-      // Generate image using SDK
-      const result = await registryGenerateImage({
-        profileId,
-        model,
-        prompt,
-        size,
-        referenceImages: referenceImageUrls,
-      })
-
-      if (!result.base64) {
-        throw new Error('No image data returned')
-      }
-
-      // Update record with image data
-      await database.updateEmbeddedImage(imageId, {
-        imageData: result.base64,
-        status: 'complete',
-      })
-
-      log('Inline image generated successfully', {
-        imageId,
-        hasReference: !!referenceImageUrls,
-      })
-
-      // Emit ready event
-      emitImageReady(imageId, entryId, true)
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error'
-      log('Inline image generation failed', { imageId, error: errorMessage })
-
-      try {
-        // Update record with error
-        await database.updateEmbeddedImage(imageId, {
-          status: 'failed',
-          errorMessage,
-        })
-      } finally {
-        // Emit ready event (with failure) and notify UI. In a `finally` because the
-        // `ImageQueued` emitted when this was scheduled has to be balanced even if
-        // recording the failure is itself what failed.
-        emitImageReady(imageId, entryId, false)
-        emitImageAnalysisFailed(entryId, errorMessage)
-      }
-    }
   }
 }
 

--- a/src/lib/services/ai/image/InlineImageTracker.test.ts
+++ b/src/lib/services/ai/image/InlineImageTracker.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const createEmbeddedImage = vi.fn().mockResolvedValue(undefined)
+const updateEmbeddedImage = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('$lib/services/database', () => ({
+  database: {
+    createEmbeddedImage: (...args: unknown[]) => createEmbeddedImage(...args),
+    updateEmbeddedImage: (...args: unknown[]) => updateEmbeddedImage(...args),
+    // The style lookup the tracker awaits before it registers a tag.
+    getPackTemplate: async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      return { content: 'style' }
+    },
+  },
+}))
+
+vi.mock('$lib/stores/settings.svelte', () => ({
+  settings: {
+    systemServicesSettings: {
+      imageGeneration: { profileId: 'p1', styleId: 'st', size: 'square', referenceProfileId: 'p1' },
+    },
+    getImageProfile: () => ({ id: 'p1', model: 'm', providerType: 'openai' }),
+  },
+}))
+
+vi.mock('./providers/registry', () => ({
+  supportsImageGeneration: () => true,
+  generateImage: async () => ({ base64: null, error: 'no backend in test' }),
+}))
+
+vi.mock('$lib/services/events', () => ({
+  emitImageQueued: vi.fn(),
+  emitImageReady: vi.fn(),
+  emitImageAnalysisFailed: vi.fn(),
+}))
+
+const { InlineImageTracker } = await import('./InlineImageTracker')
+
+const TAG = '<pic prompt="a long enough prompt to pass the floor"></pic>'
+
+describe('InlineImageTracker', () => {
+  beforeEach(() => {
+    createEmbeddedImage.mockClear()
+    updateEmbeddedImage.mockClear()
+  })
+
+  it('records a tag seen in the final chunk, flushed before its style lookup resolves', async () => {
+    const tracker = new InlineImageTracker('story', 'entry', () => [])
+
+    tracker.processChunk(`The room fell silent. ${TAG}`, false)
+    // No await in between: this is the ordering the streaming pipeline produces, where
+    // the entry is saved the moment the last chunk lands.
+    await tracker.flushToDatabase()
+
+    expect(createEmbeddedImage).toHaveBeenCalledTimes(1)
+    expect(createEmbeddedImage.mock.calls[0][0]).toMatchObject({
+      entryId: 'entry',
+      sourceText: TAG,
+      generationMode: 'inline',
+    })
+  })
+
+  it('reports work in flight before the tag reaches the pending list', () => {
+    const tracker = new InlineImageTracker('story', 'entry', () => [])
+
+    tracker.processChunk(TAG, false)
+
+    expect(tracker.hasPendingImages).toBe(true)
+  })
+})

--- a/src/lib/services/ai/image/InlineImageTracker.ts
+++ b/src/lib/services/ai/image/InlineImageTracker.ts
@@ -19,6 +19,7 @@ import {
   generateImage as registryGenerateImage,
   supportsImageGeneration,
 } from './providers/registry'
+import { recordImageResult } from './imageUtils'
 import { database } from '$lib/services/database'
 import { settings } from '$lib/stores/settings.svelte'
 import { emitImageQueued, emitImageReady } from '$lib/services/events'
@@ -46,6 +47,15 @@ export class InlineImageTracker {
   private processedTags = new Set<string>()
   /** Pending image generations (results stored in memory until flushed) */
   private pendingImages: PendingImage[] = []
+  /**
+   * Generations that have started but not yet reached `pendingImages`.
+   *
+   * `startGeneration` only registers a tag after an async style-prompt lookup, so a tag
+   * from the last streamed chunk is still in flight when the entry is saved. A flush that
+   * does not wait for these leaves their images generated but unrecorded, and an
+   * unrecorded image is deleted from the narration at render time.
+   */
+  private starting = new Set<Promise<void>>()
 
   constructor(
     private storyId: string,
@@ -61,10 +71,17 @@ export class InlineImageTracker {
    */
   processChunk(accumulatedContent: string, referenceMode: boolean): void {
     const tags = extractPicTags(accumulatedContent)
+    // 0 means unlimited, matching the non-streaming path in InlineImageService.
+    const maxImages = settings.systemServicesSettings.imageGeneration.maxImagesPerMessage ?? 3
 
     for (const tag of tags) {
       if (this.processedTags.has(tag.originalTag)) {
         continue
+      }
+
+      if (maxImages !== 0 && this.processedTags.size >= maxImages) {
+        log('Reached the per-message image limit, ignoring the remaining tags', { maxImages })
+        return
       }
 
       this.processedTags.add(tag.originalTag)
@@ -74,10 +91,12 @@ export class InlineImageTracker {
         characters: tag.characters,
       })
 
-      // Fire-and-forget: style prompt fetch + generation start is async
-      this.startGeneration(tag, referenceMode).catch((error) => {
-        log('startGeneration failed', { error })
-      })
+      const started: Promise<void> = this.startGeneration(tag, referenceMode)
+        .catch((error) => {
+          log('startGeneration failed', { error })
+        })
+        .finally(() => this.starting.delete(started))
+      this.starting.add(started)
     }
   }
 
@@ -200,6 +219,11 @@ export class InlineImageTracker {
    * Call this AFTER the story entry has been created.
    */
   async flushToDatabase(): Promise<void> {
+    // A tag that arrives while we wait joins the set, so drain it rather than snapshot it.
+    while (this.starting.size > 0) {
+      await Promise.all(this.starting)
+    }
+
     if (this.pendingImages.length === 0) {
       log('No pending images to flush')
       return
@@ -236,18 +260,7 @@ export class InlineImageTracker {
 
       // Update record when generation completes (non-blocking)
       pending.generationPromise
-        .then(async (result) => {
-          await database.updateEmbeddedImage(pending.id, {
-            imageData: result.base64 || '',
-            status: result.base64 ? 'complete' : 'failed',
-            errorMessage: result.error,
-          })
-          emitImageReady(pending.id, this.entryId, !!result.base64)
-          log('Image record updated', {
-            imageId: pending.id,
-            status: result.base64 ? 'complete' : 'failed',
-          })
-        })
+        .then((result) => recordImageResult(pending.id, this.entryId, result))
         .catch((error) => {
           log('Failed to update image record', { imageId: pending.id, error })
           // The `Queued` above is still outstanding: a rejected generation that never
@@ -273,6 +286,6 @@ export class InlineImageTracker {
    * Check if there are pending images being generated.
    */
   get hasPendingImages(): boolean {
-    return this.pendingImages.length > 0
+    return this.pendingImages.length > 0 || this.starting.size > 0
   }
 }

--- a/src/lib/services/ai/image/constants.ts
+++ b/src/lib/services/ai/image/constants.ts
@@ -4,6 +4,4 @@ export const POLLINATIONS_REFERENCE_MODEL_ID = 'kontext'
 export const DEFAULT_AVG_PROMPT_TOKENS = 100
 export const DEFAULT_AVG_IMAGE_TOKENS = 1000
 
-export const IMAGE_STUCK_THRESHOLD_MS = 10 * 60 * 1000 // 10 minutes
-
 export const DEFAULT_FALLBACK_STYLE_PROMPT = `Soft cel-shaded anime illustration. Muted pastel color palette with low saturation. Diffused ambient lighting, subtle linework blending into colors. Smooth gradients, slight bloom effect on highlights. Dreamy, airy atmosphere. Studio Ghibli-inspired. Soft shadows, watercolor texture hints in background.`

--- a/src/lib/services/ai/image/imageUtils.test.ts
+++ b/src/lib/services/ai/image/imageUtils.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ImageProfileSlot } from './imageUtils'
+
+const state = {
+  imageGeneration: {
+    profileId: null as string | null,
+    backgroundProfileId: null as string | null,
+    portraitProfileId: null as string | null,
+    referenceProfileId: null as string | null,
+  },
+  profiles: {} as Record<string, { id: string; providerType: string; apiKey: string }>,
+}
+
+vi.mock('$lib/stores/settings.svelte', () => ({
+  settings: {
+    get imageGeneration() {
+      return state.imageGeneration
+    },
+    systemServicesSettings: {
+      get imageGeneration() {
+        return state.imageGeneration
+      },
+    },
+    getImageProfile: (id: string) => state.profiles[id],
+  },
+}))
+
+vi.mock('./providers/registry', () => ({
+  supportsImageGeneration: (providerType: string) => providerType !== 'no-backend',
+  requiresApiKey: (providerType: string) => providerType === 'openai',
+}))
+
+const { isImageGenerationEnabled, hasRequiredCredentials } = await import('./imageUtils')
+
+const SLOTS: ImageProfileSlot[] = ['standard', 'background', 'portrait', 'reference']
+
+const setSlotIds = (
+  standard: string | null,
+  background: string | null,
+  portrait: string | null,
+  reference: string | null,
+) => {
+  state.imageGeneration.profileId = standard
+  state.imageGeneration.backgroundProfileId = background
+  state.imageGeneration.portraitProfileId = portrait
+  state.imageGeneration.referenceProfileId = reference
+}
+
+beforeEach(() => {
+  setSlotIds('p-std', null, null, null)
+  state.profiles = {
+    'p-std': { id: 'p-std', providerType: 'openai', apiKey: '' },
+    'p-bg': { id: 'p-bg', providerType: 'local', apiKey: '' },
+    'p-port': { id: 'p-port', providerType: 'local', apiKey: '' },
+    'p-ref': { id: 'p-ref', providerType: 'local', apiKey: '' },
+    'p-local': { id: 'p-local', providerType: 'local', apiKey: '' },
+  }
+})
+
+describe('hasRequiredCredentials', () => {
+  it('does not fall back to the standard profile for background', () => {
+    setSlotIds('p-std', null, null, null)
+
+    expect(hasRequiredCredentials('background')).toBe(false)
+  })
+
+  it('is true when the background profile supports generation and needs no api key', () => {
+    setSlotIds('p-std', 'p-bg', null, null)
+
+    expect(hasRequiredCredentials('background')).toBe(true)
+  })
+
+  it('does not fall back to the standard profile for portrait', () => {
+    setSlotIds('p-std', null, null, null)
+
+    expect(hasRequiredCredentials('portrait')).toBe(false)
+  })
+
+  it('does not fall back to the standard profile for reference', () => {
+    setSlotIds('p-std', null, null, null)
+
+    expect(hasRequiredCredentials('reference')).toBe(false)
+  })
+
+  it('requires the api key when the provider needs one', () => {
+    setSlotIds('p-std', null, null, null)
+
+    expect(hasRequiredCredentials('standard')).toBe(false)
+
+    state.profiles['p-std'].apiKey = 'sk-test'
+
+    expect(hasRequiredCredentials('standard')).toBe(true)
+  })
+})
+
+describe('isImageGenerationEnabled', () => {
+  it('is false for background when backgroundProfileId is unset, even with a standard profile', () => {
+    setSlotIds('p-std', null, null, null)
+
+    expect(isImageGenerationEnabled(undefined, 'background')).toBe(false)
+  })
+
+  it('is true for standard when the profile supports generation', () => {
+    setSlotIds('p-std', null, null, null)
+
+    expect(isImageGenerationEnabled(undefined, 'standard')).toBe(true)
+  })
+
+  it('is false for non-background slots when generation mode is none', () => {
+    setSlotIds('p-std', 'p-bg', null, null)
+
+    expect(isImageGenerationEnabled({ imageGenerationMode: 'none' }, 'standard')).toBe(false)
+    // background is exempt from the story-level mode.
+    expect(isImageGenerationEnabled({ imageGenerationMode: 'none' }, 'background')).toBe(true)
+  })
+})
+
+describe('agreement between isImageGenerationEnabled and hasRequiredCredentials', () => {
+  const scenarios: Array<{ name: string; apply: () => void }> = [
+    {
+      name: 'no profile ids at all',
+      apply: () => setSlotIds(null, null, null, null),
+    },
+    {
+      name: 'every slot on a keyless provider',
+      apply: () => setSlotIds('p-local', 'p-bg', 'p-port', 'p-ref'),
+    },
+    {
+      name: 'every slot on a key provider with the key set',
+      apply: () => {
+        setSlotIds('p-std', 'p-std', 'p-std', 'p-std')
+        state.profiles['p-std'].apiKey = 'sk-test'
+      },
+    },
+    {
+      name: 'only standard set',
+      apply: () => {
+        setSlotIds('p-std', null, null, null)
+        state.profiles['p-std'].apiKey = 'sk-test'
+      },
+    },
+    {
+      name: 'ids pointing at missing profiles',
+      apply: () => setSlotIds('ghost', 'ghost', 'ghost', 'ghost'),
+    },
+  ]
+
+  for (const scenario of scenarios) {
+    for (const slot of SLOTS) {
+      it(`agree for ${slot} — ${scenario.name}`, () => {
+        scenario.apply()
+
+        expect(isImageGenerationEnabled({}, slot)).toBe(hasRequiredCredentials(slot))
+      })
+    }
+  }
+})

--- a/src/lib/services/ai/image/imageUtils.ts
+++ b/src/lib/services/ai/image/imageUtils.ts
@@ -4,13 +4,13 @@
  * Helper functions for image generation using the standalone provider registry.
  */
 
-import { generateImage, supportsImageGeneration } from './providers/registry'
+import { generateImage, supportsImageGeneration, requiresApiKey } from './providers/registry'
 import { database } from '$lib/services/database'
 import { settings } from '$lib/stores/settings.svelte'
-import type { StorySettings } from '$lib/types'
+import type { EmbeddedImage, StorySettings } from '$lib/types'
 import { emitImageQueued, emitImageReady, emitImageAnalysisFailed } from '$lib/services/events'
 import { createLogger } from '$lib/log'
-import { expectedPixels, defaultImageSpec } from '$lib/utils/image'
+import { expectedPixels, defaultImageSpec, type ImageSpec } from '$lib/utils/image'
 
 const log = createLogger('ImageUtils')
 
@@ -44,12 +44,22 @@ export function isImageGenerationEnabled(
   return supportsImageGeneration(profile.providerType)
 }
 
+export type ImageProfileSlot = 'standard' | 'background' | 'portrait' | 'reference'
+
+const SLOT_PROFILE_KEYS = {
+  standard: 'profileId',
+  background: 'backgroundProfileId',
+  portrait: 'portraitProfileId',
+  reference: 'referenceProfileId',
+} as const satisfies Record<ImageProfileSlot, string>
+
 /**
- * Check if required credentials are configured for image generation.
+ * Check if required credentials are configured for a given image slot.
+ * Slots other than `standard` fall back to it, matching the Images settings tab.
  */
-export function hasRequiredCredentials(): boolean {
+export function hasRequiredCredentials(slot: ImageProfileSlot = 'standard'): boolean {
   const imageSettings = settings.systemServicesSettings.imageGeneration
-  const profileId = imageSettings?.profileId
+  const profileId = imageSettings?.[SLOT_PROFILE_KEYS[slot]] || imageSettings?.profileId
   if (!profileId) return false
 
   const profile = settings.getImageProfile(profileId)
@@ -57,11 +67,7 @@ export function hasRequiredCredentials(): boolean {
 
   if (!supportsImageGeneration(profile.providerType)) return false
 
-  return (
-    !!profile.apiKey ||
-    profile.providerType === 'pollinations' ||
-    profile.providerType === 'comfyui'
-  )
+  return !requiresApiKey(profile.providerType) || !!profile.apiKey
 }
 
 /**
@@ -90,7 +96,104 @@ export function getProviderDisplayName(): string {
 }
 
 /**
- * Retry image generation for a failed/existing image using current settings.
+ * Write a finished generation onto its record.
+ *
+ * `ImageReady` goes out in a `finally`: it balances the `ImageQueued` the caller emitted
+ * when it scheduled the work, and the header's in-flight count has to come back down even
+ * when recording the outcome is itself what failed.
+ */
+export async function recordImageResult(
+  imageId: string,
+  entryId: string,
+  result: { base64: string | null; error?: string },
+): Promise<void> {
+  try {
+    if (result.base64) {
+      await database.updateEmbeddedImage(imageId, {
+        imageData: result.base64,
+        status: 'complete',
+      })
+    } else {
+      await database.updateEmbeddedImage(imageId, {
+        status: 'failed',
+        errorMessage: result.error ?? 'Image generation failed',
+      })
+    }
+  } catch (error) {
+    log('Failed to record image result', { imageId, error })
+  } finally {
+    emitImageReady(imageId, entryId, !!result.base64)
+  }
+}
+
+export interface ImageGenerationRequest {
+  imageId: string
+  entryId: string
+  prompt: string
+  profileId: string
+  model: string
+  size: ImageSpec
+  referenceImages?: string[]
+  /** Also raise the user-facing failure notice. Off for analyzed scenes, which report
+   *  their failures through the analysis phase instead. */
+  notifyFailure?: boolean
+  /** Written with the flip to `generating`, so a caller resetting the row for a fresh
+   *  attempt spends one round trip and not two. */
+  recordUpdates?: Partial<EmbeddedImage>
+}
+
+/**
+ * Run one generation against an existing record and record what came back.
+ *
+ * Returns the base64 payload so a caller with a further use for it — saving a portrait
+ * onto its character — does not have to read the row back.
+ */
+export async function runImageGeneration(request: ImageGenerationRequest): Promise<string | null> {
+  const { imageId, entryId, prompt, profileId, model, size, referenceImages } = request
+
+  let base64: string | null = null
+  let failure: string | undefined
+
+  // Its own try: a failed status flip is a database problem, not a generation failure, and
+  // reporting it as one raises a user-facing notice for the wrong thing. The generation goes
+  // ahead regardless — `recordImageResult` writes the terminal status either way.
+  try {
+    await database.updateEmbeddedImage(imageId, {
+      ...request.recordUpdates,
+      status: 'generating',
+    })
+  } catch (error) {
+    log('Failed to mark the image generating', { imageId, error })
+  }
+
+  try {
+    log('Generating image', { imageId, profileId, model, hasReference: !!referenceImages?.length })
+    const result = await generateImage({ profileId, model, prompt, size, referenceImages })
+
+    if (!result.base64) throw new Error('No image data returned')
+    base64 = result.base64
+  } catch (error) {
+    failure = error instanceof Error ? error.message : 'Unknown error'
+    log('Image generation failed', { imageId, error: failure })
+  }
+
+  await recordImageResult(imageId, entryId, { base64, error: failure })
+
+  if (failure && request.notifyFailure) {
+    emitImageAnalysisFailed(entryId, failure)
+  }
+
+  return base64
+}
+
+/**
+ * Retry a failed or stuck image, as a regular scene image at the current settings.
+ *
+ * Deliberately regular, whatever the row was generated as. An img2img reference cannot be
+ * reproduced at all — the references are the portraits of the characters the analysis
+ * named, and that list is not kept on the row — and a portrait is not worth reproducing:
+ * a retry only rewrites the row, never `characters.portrait`, so the entry gets a picture
+ * and the character keeps the one it has.
  */
 export async function retryImageGeneration(imageId: string, prompt: string): Promise<void> {
   if (!isImageGenerationEnabled()) {
@@ -117,48 +220,23 @@ export async function retryImageGeneration(imageId: string, prompt: string): Pro
   const size = imageSettings.size
   const { width, height } = expectedPixels(size)
 
-  await database.updateEmbeddedImage(imageId, {
-    prompt,
-    model,
-    status: 'generating',
-    errorMessage: undefined,
-    width,
-    height,
-  })
-
   log('Retrying image generation', { imageId, profileId, model, size })
 
-  // Both branches below emit `ImageReady`, which decrements the header's in-flight count —
+  // `runImageGeneration` emits `ImageReady`, which decrements the header's in-flight count —
   // so the retry has to announce itself, or it spends another image's increment and the
   // indicator disappears while that one is still generating.
   emitImageQueued(imageId, image.entryId)
 
-  try {
-    const result = await generateImage({ profileId, model, prompt, size })
-
-    if (!result.base64) {
-      throw new Error('No image data returned')
-    }
-
-    await database.updateEmbeddedImage(imageId, {
-      imageData: result.base64,
-      status: 'complete',
-    })
-
-    log('Image retry successful', { imageId })
-    emitImageReady(imageId, image.entryId, true)
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error'
-    log('Image retry failed', { imageId, error: errorMessage })
-
-    await database.updateEmbeddedImage(imageId, {
-      status: 'failed',
-      errorMessage,
-    })
-
-    emitImageReady(imageId, image.entryId, false)
-    emitImageAnalysisFailed(image.entryId, errorMessage)
-  }
+  await runImageGeneration({
+    imageId,
+    entryId: image.entryId,
+    prompt,
+    profileId,
+    model,
+    size,
+    notifyFailure: true,
+    recordUpdates: { prompt, model, width, height },
+  })
 }
 
 /**

--- a/src/lib/services/ai/image/imageUtils.ts
+++ b/src/lib/services/ai/image/imageUtils.ts
@@ -14,36 +14,6 @@ import { expectedPixels, defaultImageSpec, type ImageSpec } from '$lib/utils/ima
 
 const log = createLogger('ImageUtils')
 
-/**
- * Check if image generation is enabled and has valid configuration.
- * Now checks Image Profiles instead of API Profiles.
- */
-export function isImageGenerationEnabled(
-  storySettings?: StorySettings,
-  type: 'standard' | 'background' | 'portrait' | 'reference' = 'standard',
-): boolean {
-  const imageSettings = settings.systemServicesSettings.imageGeneration
-
-  if (storySettings) {
-    if (type !== 'background' && storySettings.imageGenerationMode === 'none') return false
-  } else {
-    if (!imageSettings?.profileId) return false
-  }
-
-  // Determine which profileId to check based on type
-  let profileId: string | null = imageSettings.profileId
-  if (type === 'background') profileId = imageSettings.backgroundProfileId
-  if (type === 'portrait') profileId = imageSettings.portraitProfileId
-  if (type === 'reference') profileId = imageSettings.referenceProfileId
-
-  if (!profileId) return false
-
-  const profile = settings.getImageProfile(profileId)
-  if (!profile) return false
-
-  return supportsImageGeneration(profile.providerType)
-}
-
 export type ImageProfileSlot = 'standard' | 'background' | 'portrait' | 'reference'
 
 const SLOT_PROFILE_KEYS = {
@@ -54,12 +24,44 @@ const SLOT_PROFILE_KEYS = {
 } as const satisfies Record<ImageProfileSlot, string>
 
 /**
+ * Each slot answers for itself: an unset slot profile means unconfigured, never a reason to
+ * spend the standard one. The settings UI and the generation paths read this same value, and
+ * they have to agree — a slot the UI offers and generation then refuses fails in silence.
+ */
+function slotProfileId(slot: ImageProfileSlot): string | null {
+  return settings.systemServicesSettings.imageGeneration?.[SLOT_PROFILE_KEYS[slot]] ?? null
+}
+
+/**
+ * Check if image generation is enabled and has valid configuration.
+ * Now checks Image Profiles instead of API Profiles.
+ */
+export function isImageGenerationEnabled(
+  storySettings?: StorySettings,
+  type: ImageProfileSlot = 'standard',
+): boolean {
+  const imageSettings = settings.systemServicesSettings.imageGeneration
+
+  if (storySettings) {
+    if (type !== 'background' && storySettings.imageGenerationMode === 'none') return false
+  } else {
+    if (!imageSettings?.profileId) return false
+  }
+
+  const profileId = slotProfileId(type)
+  if (!profileId) return false
+
+  const profile = settings.getImageProfile(profileId)
+  if (!profile) return false
+
+  return supportsImageGeneration(profile.providerType)
+}
+
+/**
  * Check if required credentials are configured for a given image slot.
- * Slots other than `standard` fall back to it, matching the Images settings tab.
  */
 export function hasRequiredCredentials(slot: ImageProfileSlot = 'standard'): boolean {
-  const imageSettings = settings.systemServicesSettings.imageGeneration
-  const profileId = imageSettings?.[SLOT_PROFILE_KEYS[slot]] || imageSettings?.profileId
+  const profileId = slotProfileId(slot)
   if (!profileId) return false
 
   const profile = settings.getImageProfile(profileId)

--- a/src/lib/services/ai/image/index.ts
+++ b/src/lib/services/ai/image/index.ts
@@ -8,11 +8,7 @@
  */
 
 // Main inline image service
-export {
-  InlineImageGenerationService,
-  inlineImageService,
-  type InlineImageContext,
-} from './InlineImageService'
+export { inlineImageService, type InlineImageContext } from './InlineImageService'
 
 // Inline image tracker for streaming
 export { InlineImageTracker } from './InlineImageTracker'
@@ -23,12 +19,10 @@ export { ImageAnalysisService, type ImageAnalysisContext } from './ImageAnalysis
 // Provider registry (replaces modelListing.ts)
 export {
   generateImage,
-  listImageModels,
   listImageModelsByProvider,
   getProviderSamplerInfo,
   listLoras,
-  clearModelsCache,
-  supportsImageGeneration,
+  requiresApiKey,
   type ImageModelInfo,
 } from './providers/registry'
 
@@ -36,20 +30,17 @@ export {
 export {
   isImageGenerationEnabled,
   hasRequiredCredentials,
+  type ImageProfileSlot,
   getProviderDisplayName,
   retryImageGeneration,
   generatePortrait,
+  runImageGeneration,
 } from './imageUtils'
 
 // Style template resolution
 export { resolveStylePrompt, resolveStylePromptForPack } from './stylePrompt'
 
 // Constants
-export {
-  DEFAULT_FALLBACK_STYLE_PROMPT,
-  POLLINATIONS_DEFAULT_MODEL_ID,
-  POLLINATIONS_REFERENCE_MODEL_ID,
-  IMAGE_STUCK_THRESHOLD_MS,
-} from './constants'
+export { DEFAULT_FALLBACK_STYLE_PROMPT } from './constants'
 // Provider types
 export { ComfyMode } from './providers/comfy'

--- a/src/lib/services/ai/image/providers/comfy.ts
+++ b/src/lib/services/ai/image/providers/comfy.ts
@@ -29,13 +29,6 @@ export enum ComfyMode {
   UnetTxt2Img = 'unet-txt2img',
 }
 
-export const ComfyModes: Record<ComfyMode, any> = {
-  [ComfyMode.CustomWorkflow]: null,
-  [ComfyMode.BasicTxt2Img]: BasicTxt2ImgWorkflow,
-  [ComfyMode.LoraTxt2Img]: LoraTxt2ImgWorkflow,
-  [ComfyMode.UnetTxt2Img]: UnetTxt2ImgWorkflow,
-}
-
 // Tracks which model names came from diffusion_models/, keyed by baseUrl.
 // Values are Promises to prevent parallel fetches for the same baseUrl.
 const unetModelNames = new Map<string, Promise<Set<string>>>()

--- a/src/lib/services/ai/image/providers/registry.test.ts
+++ b/src/lib/services/ai/image/providers/registry.test.ts
@@ -16,7 +16,7 @@ vi.mock('$lib/stores/debug.svelte', () => ({
   },
 }))
 
-import { supportsImageGeneration, generateImage } from './registry'
+import { supportsImageGeneration, requiresApiKey, generateImage } from './registry'
 import { settings } from '$lib/stores/settings.svelte'
 import type { ImageProviderType } from '$lib/types'
 
@@ -50,6 +50,32 @@ describe('Image Provider Registry', () => {
 
     it('returns false for unknown providers', () => {
       expect(supportsImageGeneration('unknown-provider')).toBe(false)
+    })
+  })
+
+  describe('requiresApiKey', () => {
+    it.each(['comfyui', 'a1111'] as ImageProviderType[])(
+      'returns false for the self-hosted provider %s',
+      (providerType) => {
+        expect(requiresApiKey(providerType)).toBe(false)
+      },
+    )
+
+    it.each([
+      'nanogpt',
+      'openai',
+      'openrouter',
+      'chutes',
+      'google',
+      'zhipu',
+      // Its model list is open, its generation is not.
+      'pollinations',
+    ] as ImageProviderType[])('returns true for the hosted provider %s', (providerType) => {
+      expect(requiresApiKey(providerType)).toBe(true)
+    })
+
+    it('assumes an unknown provider needs a key', () => {
+      expect(requiresApiKey('unknown-provider')).toBe(true)
     })
   })
 

--- a/src/lib/services/ai/image/providers/registry.ts
+++ b/src/lib/services/ai/image/providers/registry.ts
@@ -48,6 +48,26 @@ const PROVIDER_FACTORIES: Record<ImageProviderType, ProviderFactory> = {
   a1111: createA1111Provider,
 }
 
+/**
+ * Whether a provider authenticates with an API key. Only the ones that run on the user's
+ * own machine do not. Exhaustive by type, so a new provider has to declare which it is.
+ *
+ * Pollinations counts as requiring one: the model list is served without it, but
+ * generation is not, and a profile that can list and cannot draw is the worse failure —
+ * it looks configured.
+ */
+const PROVIDER_REQUIRES_API_KEY: Record<ImageProviderType, boolean> = {
+  nanogpt: true,
+  openai: true,
+  openrouter: true,
+  chutes: true,
+  google: true,
+  zhipu: true,
+  pollinations: true,
+  comfyui: false,
+  a1111: false,
+}
+
 // ============================================================================
 // Model Cache
 // ============================================================================
@@ -66,10 +86,6 @@ function getCacheKey(providerType: ImageProviderType, apiKey?: string, baseUrl?:
   return `${providerType}:${keyHash}:${urlKey}`
 }
 
-export function clearModelsCache(): void {
-  modelCaches.clear()
-}
-
 // ============================================================================
 // Public API
 // ============================================================================
@@ -79,6 +95,11 @@ export function clearModelsCache(): void {
  */
 export function supportsImageGeneration(providerType: string): boolean {
   return providerType in PROVIDER_FACTORIES
+}
+
+/** Whether a profile of this provider needs an API key to be usable. */
+export function requiresApiKey(providerType: string): boolean {
+  return PROVIDER_REQUIRES_API_KEY[providerType as ImageProviderType] ?? true
 }
 
 /**

--- a/src/lib/services/ai/index.ts
+++ b/src/lib/services/ai/index.ts
@@ -26,7 +26,6 @@ import {
   emitImageAnalysisComplete,
   emitImageAnalysisFailed,
   emitImageQueued,
-  emitImageReady,
   emitBackgroundImageAnalysisStarted,
   emitBackgroundImageAnalysisComplete,
   emitBackgroundImageAnalysisFailed,
@@ -63,9 +62,9 @@ import {
   inlineImageService,
   isImageGenerationEnabled as isImageGenerationEnabledUtil,
   resolveStylePrompt,
+  runImageGeneration,
 } from './image'
 import type { InlineImageContext, ImageAnalysisContext } from './image'
-import { generateImage as registryGenerateImage } from './image/providers/registry'
 import {
   MemoryService,
   NarrativeService,
@@ -1141,10 +1140,7 @@ class AIService {
     referenceImageUrls?: string[],
   ): Promise<void> {
     try {
-      // Update status to generating
-      await database.updateEmbeddedImage(imageId, { status: 'generating' })
-
-      log('Generating analyzed image via SDK', {
+      log('Generating analyzed image', {
         imageId,
         profileId,
         model,
@@ -1152,24 +1148,17 @@ class AIService {
         hasReference: !!referenceImageUrls?.length,
       })
 
-      // Generate image using SDK
-      const result = await registryGenerateImage({
+      const base64 = await runImageGeneration({
+        imageId,
+        entryId,
+        prompt,
         profileId,
         model,
-        prompt,
         size,
         referenceImages: referenceImageUrls,
       })
 
-      if (!result.base64) {
-        throw new Error('No image data returned')
-      }
-
-      // Update record with image data
-      await database.updateEmbeddedImage(imageId, {
-        imageData: result.base64,
-        status: 'complete',
-      })
+      if (!base64) return
 
       // If this was a portrait generation, save to character
       if (scene.generatePortrait && scene.characters.length > 0) {
@@ -1179,28 +1168,17 @@ class AIService {
         )
         if (character) {
           await database.updateCharacter(character.id, {
-            portrait: result.base64,
+            portrait: base64,
           })
           log('Saved portrait to character', { characterId: character.id, name: charName })
         }
       }
 
       log('Analyzed image generated successfully', { imageId })
-      emitImageReady(imageId, entryId, true)
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error'
-      log('Analyzed image generation failed', { imageId, error: errorMessage })
-
-      try {
-        await database.updateEmbeddedImage(imageId, {
-          status: 'failed',
-          errorMessage,
-        })
-      } finally {
-        // Balances the `ImageQueued` emitted when this was scheduled, even if recording
-        // the failure is itself what failed.
-        emitImageReady(imageId, entryId, false)
-      }
+      // `runImageGeneration` records its own outcome and balances the queued count, so
+      // anything thrown past it comes from saving the portrait onto its character.
+      log('Saving the generated portrait failed', { imageId, error })
     }
   }
 

--- a/src/lib/services/ai/lorebook/LoreManagementService.ts
+++ b/src/lib/services/ai/lorebook/LoreManagementService.ts
@@ -23,6 +23,7 @@ import type { LoreManagementToolContext } from '../sdk/tools/lorebook'
 import {
   findDuplicateGroups,
   formatDuplicateGroup,
+  groupIsSettledBy,
   pairKeys,
   type DuplicateGroup,
 } from '$lib/services/duplicates'
@@ -189,11 +190,14 @@ export class LoreManagementService extends BaseAIService {
     // Create tool context with chapter querying
     const toolContext: LoreManagementToolContext = {
       entries: vaultEntries,
+      isAutonomous: true,
       onPendingChange: (change) => {
         // Auto-approve in autonomous mode
         change.status = 'approved'
-        ledger.apply(change)
-        log('Auto-approved change', { type: change.type, id: change.id })
+        const newIndex = ledger.apply(change)
+        log('Auto-approved change', { type: change.type, id: change.id, newIndex })
+        // Back to the tool, which reports it: the agent has no listing to find it in.
+        return newIndex
       },
       generateId: () => `lm-${++changeIdCounter}`,
       removedIndices,
@@ -209,14 +213,12 @@ export class LoreManagementService extends BaseAIService {
       // Without the obligation there is nothing to refuse over, so the predicate is not
       // installed: the worklist and `keep_separate` stay, they just stop being a gate.
       pendingDuplicates: this.requireDuplicateResolution
-        ? () => openDuplicateGroups().map(formatDuplicateGroup)
+        ? () => openDuplicateGroups().map((group) => formatDuplicateGroup(group, removedIndices))
         : undefined,
       onKeepSeparate: (indices, reason) => {
         const named = new Set(indices)
-        // Every index of a group must be named. Closing on a single shared index dismissed
-        // neighbouring groups the agent had never looked at.
         const closing = duplicateGroups.filter(
-          (group) => !dismissedGroups.has(group) && group.indices.every((i) => named.has(i)),
+          (group) => !dismissedGroups.has(group) && groupIsSettledBy(group, named, removedIndices),
         )
         for (const group of closing) dismissedGroups.add(group)
         // Persisted, not just dismissed for this session: the next run would otherwise
@@ -242,7 +244,9 @@ export class LoreManagementService extends BaseAIService {
         )
         .join('\n') || 'No entries yet.'
 
-    const duplicateSummary = duplicateGroups.map(formatDuplicateGroup).join('\n')
+    const duplicateSummary = duplicateGroups
+      .map((group) => formatDuplicateGroup(group, removedIndices))
+      .join('\n')
 
     // Left out entirely rather than printed empty: an empty heading is text the model
     // reads to learn nothing, and there is nothing after the last chapter more often than not.

--- a/src/lib/services/ai/lorebook/sessionChanges.ts
+++ b/src/lib/services/ai/lorebook/sessionChanges.ts
@@ -109,23 +109,33 @@ export class LoreSessionLedger {
     }
   }
 
-  apply(change: LorebookEntryPendingChangeSchema): void {
+  /**
+   * Apply the change, and for the two that append, return the index it landed at.
+   *
+   * The caller hands that index back to the agent in the tool result: the entry it just
+   * created or merged is addressable from that moment, and knowing where means it never
+   * has to re-read the list to find out what its own work did.
+   */
+  apply(change: LorebookEntryPendingChangeSchema): number | undefined {
     switch (change.type) {
       case 'create':
         return this.create(change)
       case 'update':
-        return this.update(change)
+        this.update(change)
+        return undefined
       case 'delete':
-        return this.delete(change)
+        this.delete(change)
+        return undefined
       case 'merge':
         return this.merge(change)
     }
   }
 
-  private create(change: LorebookEntryPendingChangeSchema): void {
-    if (!change.entry) return
+  private create(change: LorebookEntryPendingChangeSchema): number | undefined {
+    if (!change.entry) return undefined
     this.slots.push({ kind: 'created', entry: this.entryFromVault(change.entry) })
     this.vaultEntries.push(change.entry)
+    return this.slots.length - 1
   }
 
   private update(change: LorebookEntryPendingChangeSchema): void {
@@ -179,12 +189,12 @@ export class LoreSessionLedger {
     this.removedIndices.add(change.index)
   }
 
-  private merge(change: LorebookEntryPendingChangeSchema): void {
-    if (!change.entry) return
+  private merge(change: LorebookEntryPendingChangeSchema): number | undefined {
+    if (!change.entry) return undefined
     const indices = [...new Set(change.indices ?? [])].filter(
       (i) => this.slots[i] && this.slots[i].kind !== 'gone',
     )
-    if (indices.length < 2) return
+    if (indices.length < 2) return undefined
 
     // The rows this merge consumes. A member created earlier in the session has no row of
     // its own: it is folded in by simply never being created.
@@ -210,6 +220,7 @@ export class LoreSessionLedger {
         : { kind: 'created', entry: merged },
     )
     this.vaultEntries.push(change.entry)
+    return this.slots.length - 1
   }
 
   /**

--- a/src/lib/services/ai/retrieval/tier3Selection.ts
+++ b/src/lib/services/ai/retrieval/tier3Selection.ts
@@ -208,7 +208,7 @@ export async function runTier3Selection({
 
   const ctx = await ContextBuilder.forPack(storyId)
   ctx.add({
-    recentContent: recentContent(filteredRecent, recentEntriesCount, AS_PROSE, true),
+    recentContent: recentContent(filteredRecent, recentEntriesCount, AS_PROSE, { roles: true }),
     userInput,
     entrySummaries,
   })

--- a/src/lib/services/ai/sdk/middleware/promptSchema.test.ts
+++ b/src/lib/services/ai/sdk/middleware/promptSchema.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import type { JSONSchema7 } from 'json-schema'
+import { schemaToTypeScriptBlock } from './promptSchema'
+
+/** The shape the middleware actually receives: whatever Zod emits for the service schema. */
+function asJsonSchema(schema: z.ZodType): JSONSchema7 {
+  return z.toJSONSchema(schema, { io: 'output' }) as JSONSchema7
+}
+
+describe('schemaToTypeScriptBlock', () => {
+  it('renders a nullable string as a union, not as unknown', () => {
+    // Zod spells `.nullable()` as `anyOf: [string, null]`. Read as a plain `type`, that is
+    // no type at all, and the model was handed `unknown` for the field it had to fill.
+    const schema = asJsonSchema(z.object({ title: z.string().nullable() }))
+
+    expect(schemaToTypeScriptBlock(schema)).toContain('title: string | null;')
+  })
+
+  it('keeps the description alongside the union', () => {
+    const schema = asJsonSchema(
+      z.object({ locationName: z.string().nullable().describe('Where the scene is').optional() }),
+    )
+
+    expect(schemaToTypeScriptBlock(schema)).toContain(
+      'locationName?: string | null; // Where the scene is',
+    )
+  })
+
+  it('renders a nullable enum without losing its members', () => {
+    const schema = asJsonSchema(z.object({ status: z.enum(['open', 'shut']).nullable() }))
+    const block = schemaToTypeScriptBlock(schema)
+
+    expect(block).toContain('"open"')
+    expect(block).toContain('"shut"')
+    expect(block).toContain('| null')
+  })
+
+  it('still renders plain types', () => {
+    const schema = asJsonSchema(
+      z.object({ names: z.array(z.string()), count: z.number(), on: z.boolean() }),
+    )
+    const block = schemaToTypeScriptBlock(schema)
+
+    expect(block).toContain('names: string[];')
+    expect(block).toContain('count: number;')
+    expect(block).toContain('on: boolean;')
+  })
+
+  it('marks optional properties and names the interface', () => {
+    const schema = asJsonSchema(z.object({ a: z.string(), b: z.string().optional() }))
+    const block = schemaToTypeScriptBlock(schema, 'Response')
+
+    expect(block.startsWith('interface Response {')).toBe(true)
+    expect(block).toContain('a: string;')
+    expect(block).toContain('b?: string;')
+  })
+})

--- a/src/lib/services/ai/sdk/middleware/promptSchema.ts
+++ b/src/lib/services/ai/sdk/middleware/promptSchema.ts
@@ -20,6 +20,17 @@ function jsonSchemaToTypeScript(schema: JSONSchema7, indent = 0): string {
   const pad = '  '.repeat(indent)
   const padInner = '  '.repeat(indent + 1)
 
+  // Zod spells `.nullable()` as `anyOf: [T, null]`, not as a type array. Everything below
+  // keys off `type`, which is absent here, so without this branch every nullable field
+  // reaches the model as `unknown`.
+  const union = (schema.anyOf ?? schema.oneOf) as JSONSchema7[] | undefined
+  if (union?.length) {
+    const parts = union.map((variant) =>
+      variant.type === 'null' ? 'null' : jsonSchemaToTypeScript(variant, indent),
+    )
+    return [...new Set(parts)].join(' | ')
+  }
+
   const nullable = Array.isArray(schema.type) && schema.type.includes('null')
   const primaryType = Array.isArray(schema.type)
     ? schema.type.find((t: string) => t !== 'null')
@@ -74,7 +85,7 @@ function jsonSchemaToTypeScript(schema: JSONSchema7, indent = 0): string {
   }
 }
 
-function schemaToTypeScriptBlock(schema: JSONSchema7, name = 'Response'): string {
+export function schemaToTypeScriptBlock(schema: JSONSchema7, name = 'Response'): string {
   const typeBody = jsonSchemaToTypeScript(schema, 0)
   if (schema.type === 'object' && schema.properties) {
     return `interface ${name} ${typeBody}`

--- a/src/lib/services/ai/sdk/schemas/classifier.ts
+++ b/src/lib/services/ai/sdk/schemas/classifier.ts
@@ -84,12 +84,19 @@ export const newCharacterSchema = z.object({
 // Location Schemas
 // ============================================================================
 
+/**
+ * No `current` here: `scene.currentLocationName` is the only thing that moves the scene.
+ * Both existed and both were applied, in an order the model could not see, so a response
+ * naming two different places silently kept whichever ran last.
+ */
 export const locationUpdateSchema = z.object({
   name: z.string().describe('Exact name of existing location'),
   changes: z.object({
-    visited: z.boolean().describe('true if protagonist has been here').optional(),
-    current: z.boolean().describe('true if this is the current scene location').optional(),
-    description: z.string().describe('Complete replacement description').optional(),
+    visited: z.boolean().describe('true if the protagonist has been here').optional(),
+    description: z
+      .string()
+      .describe('Replaces the whole description; only for a location whose current text is shown')
+      .optional(),
     descriptionAddition: z.string().describe('New details learned about location').optional(),
   }),
 })
@@ -97,8 +104,7 @@ export const locationUpdateSchema = z.object({
 export const newLocationSchema = z.object({
   name: z.string().describe("Location's proper name"),
   description: z.string().describe('One sentence description').optional(),
-  visited: z.boolean().describe('true if protagonist has been here').optional(),
-  current: z.boolean().describe('true if this is the current scene location').optional(),
+  visited: z.boolean().describe('true if the protagonist has been here').optional(),
 })
 
 // ============================================================================
@@ -177,7 +183,9 @@ export const sceneSchema = z.object({
     .optional(),
   presentCharacterNames: z
     .array(z.string())
-    .describe('Names of characters physically present')
+    .describe(
+      'Every other character in the scene at the end of the passage, named exactly as the character list spells them. Anyone left out is treated as away',
+    )
     .default([]),
   timeProgression: z
     .enum(['none', 'minutes', 'hours', 'days'])

--- a/src/lib/services/ai/sdk/tools/lorebook.test.ts
+++ b/src/lib/services/ai/sdk/tools/lorebook.test.ts
@@ -4,6 +4,7 @@ import {
   createLoreManagementTools,
   createInteractiveVaultLorebookTools,
   type LoreManagementToolContext,
+  type LorebookEntryToolContext,
 } from './lorebook'
 
 const context: LoreManagementToolContext = {
@@ -33,7 +34,6 @@ describe('createLoreManagementTools', () => {
     >
 
     for (const name of [
-      'list_entries',
       'read_entry',
       'create_entry',
       'update_entry',
@@ -50,13 +50,40 @@ describe('createLoreManagementTools', () => {
     // could only create.
     const tools = createLoreManagementTools({ ...context, entries: [entry('Kaelen')] })
 
-    const listed = (await tools.list_entries.execute?.({} as never, {} as never)) as {
-      returnedCount: number
+    const read = (await tools.read_entry.execute?.({ index: 0 } as never, {} as never)) as {
+      found: boolean
       error?: string
     }
 
-    expect(listed.error).toBeUndefined()
-    expect(listed.returnedCount).toBe(1)
+    expect(read.error).toBeUndefined()
+    expect(read.found).toBe(true)
+  })
+
+  it('offers no list_entries: the prompt already carries every entry with its index', () => {
+    const tools = createLoreManagementTools(context) as unknown as Record<string, unknown>
+
+    expect(tools.list_entries).toBeUndefined()
+    // read_entry stays — it reads one entry, it does not restate the list.
+    expect(tools.read_entry).toBeDefined()
+  })
+
+  it('reports where a merge landed, which is how the agent tracks the index space', async () => {
+    // Without it the only way to find out was a listing, and the listing is capped.
+    const tools = createLoreManagementTools({
+      ...context,
+      entries: [entry('Kaelen'), entry('Kaelen the Bold')],
+      // As the lore manager runs it: applied on the spot, so there is an index to report.
+      isAutonomous: true,
+      onPendingChange: () => 2,
+    })
+
+    const merged = (await tools.merge_entries.execute?.(
+      { indices: [0, 1], mergedEntry: entry('Kaelen') } as never,
+      {} as never,
+    )) as { newIndex?: number; message: string }
+
+    expect(merged.newIndex).toBe(2)
+    expect(merged.message).toContain('index 2')
   })
 
   it('offers no list_chapters: the prompt already carries every summary in full', () => {
@@ -178,54 +205,6 @@ describe('lore management guards', () => {
     )) as { success: boolean }
 
     expect(result.success).toBe(true)
-  })
-
-  it('hides a removed entry from the list but keeps the indices of the rest', async () => {
-    const tools = createLoreManagementTools({
-      ...context,
-      entries: [entry('Kaelen'), entry('Mara'), entry('Tovin')],
-      removedIndices: new Set([1]),
-    })
-
-    const result = (await tools.list_entries.execute?.({} as never, {} as never)) as {
-      entries: { index: number; name: string }[]
-    }
-
-    expect(result.entries.map((e) => e.index)).toEqual([0, 2])
-  })
-
-  it('narrows the listing by query, over names, aliases, keywords and descriptions', async () => {
-    const tools = createLoreManagementTools({
-      ...context,
-      entries: [
-        entry('Kaelen'),
-        { ...entry('Mara'), description: 'Serves Kaelen at the forge.' },
-        entry('Tovin', ['Kaelen the Younger']),
-        entry('Rusthaven'),
-      ],
-    })
-
-    const result = (await tools.list_entries.execute?.(
-      { query: 'Kaelen' } as never,
-      {} as never,
-    )) as { entries: { index: number }[] }
-
-    expect(result.entries.map((e) => e.index)).toEqual([0, 1, 2])
-  })
-
-  it('caps the listing and says there is more', async () => {
-    const tools = createLoreManagementTools({
-      ...context,
-      entries: Array.from({ length: 30 }, (_, i) => entry(`Entry ${i}`)),
-    })
-
-    const result = (await tools.list_entries.execute?.({ limit: 5 } as never, {} as never)) as {
-      availableTotal: number
-      returnedCount: number
-      hasMore: boolean
-    }
-
-    expect(result).toMatchObject({ availableTotal: 30, returnedCount: 5, hasMore: true })
   })
 
   it('refuses to act on a removed index rather than acting on its neighbour', async () => {
@@ -396,6 +375,64 @@ describe('finish_lore_management', () => {
     )) as { completed: boolean }
 
     expect(result.completed).toBe(true)
+  })
+})
+
+describe('list_entries, on the vault assistant that still has it', () => {
+  // The factory's return type is the union of "vault only" and "vault plus entry tools",
+  // so the entry half is reached the way the tests below already reach it.
+  const vaultTools = (entryContext: LorebookEntryToolContext) =>
+    createInteractiveVaultLorebookTools(
+      { lorebooks: () => [], generateId: () => 'c1' },
+      entryContext,
+    ) as unknown as Record<string, { execute?: (input: never, options: never) => Promise<unknown> }>
+
+  it('hides a removed entry from the list but keeps the indices of the rest', async () => {
+    const tools = vaultTools({
+      ...context,
+      entries: [entry('Kaelen'), entry('Mara'), entry('Tovin')],
+      removedIndices: new Set([1]),
+    })
+
+    const result = (await tools.list_entries.execute?.({} as never, {} as never)) as {
+      entries: { index: number; name: string }[]
+    }
+
+    expect(result.entries.map((e) => e.index)).toEqual([0, 2])
+  })
+
+  it('narrows the listing by query, over names, aliases, keywords and descriptions', async () => {
+    const tools = vaultTools({
+      ...context,
+      entries: [
+        entry('Kaelen'),
+        { ...entry('Mara'), description: 'Serves Kaelen at the forge.' },
+        entry('Tovin', ['Kaelen the Younger']),
+        entry('Rusthaven'),
+      ],
+    })
+
+    const result = (await tools.list_entries.execute?.(
+      { query: 'Kaelen' } as never,
+      {} as never,
+    )) as { entries: { index: number }[] }
+
+    expect(result.entries.map((e) => e.index)).toEqual([0, 1, 2])
+  })
+
+  it('caps the listing and says there is more', async () => {
+    const tools = vaultTools({
+      ...context,
+      entries: Array.from({ length: 30 }, (_, i) => entry(`Entry ${i}`)),
+    })
+
+    const result = (await tools.list_entries.execute?.({ limit: 5 } as never, {} as never)) as {
+      availableTotal: number
+      returnedCount: number
+      hasMore: boolean
+    }
+
+    expect(result).toMatchObject({ availableTotal: 30, returnedCount: 5, hasMore: true })
   })
 })
 

--- a/src/lib/services/ai/sdk/tools/lorebook.ts
+++ b/src/lib/services/ai/sdk/tools/lorebook.ts
@@ -30,8 +30,14 @@ export interface LorebookEntryToolContext {
   entries: VaultLorebookEntry[]
   /** The ID of the lorebook these entries belong to, if bound */
   activeLorebookId?: string
-  /** Callback to register a pending change */
-  onPendingChange: (change: LorebookEntryPendingChangeSchema) => void
+  /**
+   * Callback to register a pending change.
+   *
+   * A caller that applies the change straight away answers with the index a create or a
+   * merge landed at, which the tool hands back to the model. One that queues it for a
+   * human returns nothing: there is no index until someone approves it.
+   */
+  onPendingChange: (change: LorebookEntryPendingChangeSchema) => number | void
   /** Generate unique ID for pending changes */
   generateId: () => string
   /**
@@ -53,6 +59,10 @@ export interface LorebookEntryToolContext {
    * character every run; off for the vault, where a human reads the change first.
    */
   preventDuplicateNames?: boolean
+  /**
+   * When true, tool descriptions and messages omit pending/approval phrases intended for human review.
+   */
+  isAutonomous?: boolean
 }
 
 /**
@@ -86,6 +96,7 @@ function createLorebookEntryTools(context: LorebookEntryToolContext) {
     getLorebookEntries,
     removedIndices,
     preventDuplicateNames,
+    isAutonomous,
   } = context
 
   /** Removed slots belong to the bound `entries` only; another lorebook's indices are its own. */
@@ -252,7 +263,9 @@ function createLorebookEntryTools(context: LorebookEntryToolContext) {
      * Returns a pending change for approval workflow.
      */
     create_entry: tool({
-      description: 'Create a new lorebook entry. The change will be pending until approved.',
+      description: isAutonomous
+        ? 'Create a new lorebook entry.'
+        : 'Create a new lorebook entry. The change will be pending until approved.',
       inputSchema: z.object({
         lorebookId: z
           .string()
@@ -344,13 +357,16 @@ function createLorebookEntryTools(context: LorebookEntryToolContext) {
           status: 'pending',
         }
 
-        onPendingChange(pendingChange)
+        const newIndex = onPendingChange(pendingChange)
 
         const note = describeDropped(cleanedAliases.dropped, cleanedKeywords.dropped)
         return {
           success: true,
           pendingChange,
-          message: `Created pending entry "${name}" (${type}). Awaiting approval.`,
+          ...(typeof newIndex === 'number' ? { newIndex } : {}),
+          message: isAutonomous
+            ? `Created entry "${name}" (${type})${typeof newIndex === 'number' ? ` at index ${newIndex}` : ''}.`
+            : `Created pending entry "${name}" (${type}). Awaiting approval.`,
           ...(note ? { note } : {}),
         }
       },
@@ -361,8 +377,9 @@ function createLorebookEntryTools(context: LorebookEntryToolContext) {
      * Returns a pending change for approval workflow.
      */
     update_entry: tool({
-      description:
-        'Update an existing lorebook entry by index. Only include fields you want to change. The change will be pending until approved.',
+      description: isAutonomous
+        ? 'Update an existing lorebook entry by index. Only include fields you want to change.'
+        : 'Update an existing lorebook entry by index. Only include fields you want to change. The change will be pending until approved.',
       inputSchema: z.object({
         lorebookId: z.string().optional().describe('ID of the lorebook containing the entry'),
         index: z.number().describe('Index of the entry to update'),
@@ -446,7 +463,9 @@ function createLorebookEntryTools(context: LorebookEntryToolContext) {
         return {
           success: true,
           pendingChange,
-          message: `Created pending update for "${previous.name}". Awaiting approval.`,
+          message: isAutonomous
+            ? `Updated entry "${previous.name}".`
+            : `Created pending update for "${previous.name}". Awaiting approval.`,
           ...(note ? { note } : {}),
         }
       },
@@ -457,7 +476,9 @@ function createLorebookEntryTools(context: LorebookEntryToolContext) {
      * Returns a pending change for approval workflow.
      */
     delete_entry: tool({
-      description: 'Delete a lorebook entry by index. The change will be pending until approved.',
+      description: isAutonomous
+        ? 'Delete a lorebook entry by index.'
+        : 'Delete a lorebook entry by index. The change will be pending until approved.',
       inputSchema: z.object({
         lorebookId: z.string().optional().describe('ID of the lorebook containing the entry'),
         index: z.number().describe('Index of the entry to delete'),
@@ -507,7 +528,9 @@ function createLorebookEntryTools(context: LorebookEntryToolContext) {
         return {
           success: true,
           pendingChange,
-          message: `Created pending deletion for "${previous.name}"${reason ? ` (${reason})` : ''}. Awaiting approval.`,
+          message: isAutonomous
+            ? `Deleted entry "${previous.name}"${reason ? ` (${reason})` : ''}.`
+            : `Created pending deletion for "${previous.name}"${reason ? ` (${reason})` : ''}. Awaiting approval.`,
         }
       },
     }),
@@ -517,8 +540,9 @@ function createLorebookEntryTools(context: LorebookEntryToolContext) {
      * Returns a pending change for approval workflow.
      */
     merge_entries: tool({
-      description:
-        'Merge multiple lorebook entries into a single entry. Useful for consolidating duplicate or related entries. The change will be pending until approval.',
+      description: isAutonomous
+        ? 'Merge multiple lorebook entries into a single entry. Useful for consolidating duplicate or related entries. You MUST provide at least 2 distinct valid entry indices in the `indices` array. Never pass a single index.'
+        : 'Merge multiple lorebook entries into a single entry. Useful for consolidating duplicate or related entries. You MUST provide at least 2 distinct valid entry indices in the `indices` array. Never pass a single index. The change will be pending until approval.',
       inputSchema: z.object({
         lorebookId: z.string().optional().describe('ID of the lorebook containing the entries'),
         indices: z.array(z.number()).min(2).describe('Indices of entries to merge (at least 2)'),
@@ -552,16 +576,16 @@ function createLorebookEntryTools(context: LorebookEntryToolContext) {
           }
         }
 
-        // Check for duplicates
+        // Check for duplicates and minimum distinct indices
         const uniqueIndices = [...new Set(indices)]
-        if (uniqueIndices.length !== indices.length) {
+        if (uniqueIndices.length < 2) {
           return {
             success: false,
-            error: 'Duplicate indices provided',
+            error: `merge_entries requires at least 2 distinct valid entry indices to merge. Provided: [${indices.join(', ')}]. To update a single entry, use update_entry instead of merge_entries.`,
           }
         }
 
-        const previousEntries = indices.map((i) => targetEntries[i])
+        const previousEntries = uniqueIndices.map((i) => targetEntries[i])
         const changeId = generateId()
 
         const pendingChange: LorebookEntryPendingChangeSchema = {
@@ -575,13 +599,16 @@ function createLorebookEntryTools(context: LorebookEntryToolContext) {
           status: 'pending',
         }
 
-        onPendingChange(pendingChange)
+        const newIndex = onPendingChange(pendingChange)
 
         const names = previousEntries.map((e) => e.name).join(', ')
         return {
           success: true,
           pendingChange,
-          message: `Created pending merge of [${names}] into "${mergedEntry.name}". Awaiting approval.`,
+          ...(typeof newIndex === 'number' ? { newIndex } : {}),
+          message: isAutonomous
+            ? `Merged [${names}] into "${mergedEntry.name}"${typeof newIndex === 'number' ? `, now at index ${newIndex}. Indices [${uniqueIndices.join(', ')}] are gone` : ''}.`
+            : `Created pending merge of [${names}] into "${mergedEntry.name}". Awaiting approval.`,
         }
       },
     }),
@@ -750,8 +777,10 @@ function createStoryTools(context: StoryToolContext) {
             // Kept: a refusal on the last step still ends the run, and this is its summary.
             summary: args.summary,
             remainingDuplicates: remaining,
-            message:
-              'Not finished yet. These possible duplicates have not been dealt with. For each one: merge_entries if they are the same subject, keep_separate if they are not. Then call finish_lore_management again.',
+            // Naming the instructions is the point: the duplicate list up there is the
+            // state the session started from, and a model that goes back to it redoes
+            // every group it has already closed.
+            message: `Not finished yet. ${remaining.length} of the duplicate groups ${remaining.length === 1 ? 'is' : 'are'} still open, and ${remaining.length === 1 ? 'it is' : 'they are'} listed here — this list, not the one in your instructions, which is the state you started from. Every group missing from it is already closed; do not revisit those. For each one here: merge_entries if they are the same subject, keep_separate if they are not. Then call finish_lore_management again.`,
           }
         }
 
@@ -787,6 +816,11 @@ function withoutFields<T extends { inputSchema: unknown }>(tool: T, ...fields: s
   return { ...tool, inputSchema: schema.omit(mask) } as T
 }
 
+/** Re-word a shared tool for one agent, where the common description names what it cannot see. */
+function withDescription<T extends object>(tool: T, description: string): T {
+  return { ...tool, description } as T
+}
+
 /**
  * `lorebookId` names something that does not exist here.
  *
@@ -797,21 +831,35 @@ function withoutFields<T extends { inputSchema: unknown }>(tool: T, ...fields: s
  */
 const LOREBOOK_ID = 'lorebookId'
 
+/**
+ * `list_entries` is not among this agent's tools.
+ *
+ * Its prompt already carries every entry with the index the tools take, so the only thing
+ * the tool could add was the list *after* the session had changed it — and capped at
+ * `MAX_LIST_ENTRIES` it answered that with a fifth of a large lorebook and no way to page,
+ * which reads as "the rest is gone". `create_entry` and `merge_entries` report the index
+ * their result landed at instead, so the agent follows the index space from its own
+ * results. Same reasoning as the absent `list_chapters`, in `createStoryTools`.
+ */
+type LoreManagementEntryTools = Exclude<keyof LorebookEntryTools, 'list_entries'>
+
 export function createLoreManagementTools(context: LoreManagementToolContext) {
   const { create_entry, update_entry, ...entryTools } = createLorebookEntryTools(context)
 
   // `satisfies` is the guard: every entry tool has to be named here, so a tool added to the
   // factory later cannot quietly reach this agent with its `lorebookId` still attached.
   const entry = {
-    list_entries: withoutFields(entryTools.list_entries, LOREBOOK_ID),
-    read_entry: withoutFields(entryTools.read_entry, LOREBOOK_ID),
+    read_entry: withDescription(
+      withoutFields(entryTools.read_entry, LOREBOOK_ID),
+      'Read the full details of one lorebook entry by its index, as listed in your instructions. Use it when the one-line summary there is not enough to judge a merge or an update.',
+    ),
     delete_entry: withoutFields(entryTools.delete_entry, LOREBOOK_ID),
     merge_entries: withoutFields(entryTools.merge_entries, LOREBOOK_ID),
     // `always` is a budget decision past every retrieval threshold, and this agent runs
     // unattended and cannot see the budget. The vault assistant keeps it: a user reads it.
     create_entry: withoutFields(create_entry, LOREBOOK_ID, 'injectionMode'),
     update_entry: withoutFields(update_entry, LOREBOOK_ID, 'injectionMode'),
-  } satisfies Record<keyof LorebookEntryTools, unknown>
+  } satisfies Record<LoreManagementEntryTools, unknown>
 
   return {
     ...entry,

--- a/src/lib/services/ai/utils/TTSService.ts
+++ b/src/lib/services/ai/utils/TTSService.ts
@@ -27,6 +27,7 @@ export interface TTSSettings {
   removeAllHtmlContent: boolean
   htmlTagsToRemoveContent: string
   provider: 'openai' | 'google' | 'microsoft'
+  responseFormat: 'mp3' | 'wav'
   volume: number
   volumeOverride: boolean
   providerVoices: Record<string, string>
@@ -835,7 +836,7 @@ export class OpenAICompatibleTTSProvider extends TTSProvider {
         model: this.settings.model,
         input: text,
         voice: voice,
-        response_format: 'mp3',
+        response_format: this.settings.responseFormat,
       }),
     })
 

--- a/src/lib/services/ai/wizard/ScenarioService.ts
+++ b/src/lib/services/ai/wizard/ScenarioService.ts
@@ -5,7 +5,15 @@
  */
 
 import { settings } from '$lib/stores/settings.svelte'
-import type { StoryMode, POV, TargetLength, Character, Location, Item } from '$lib/types'
+import type {
+  StoryMode,
+  POV,
+  TargetLength,
+  Character,
+  Location,
+  Item,
+  ImageGenerationMode,
+} from '$lib/types'
 import { ContextBuilder } from '$lib/services/context'
 import { createLogger } from '$lib/log'
 import {
@@ -44,7 +52,7 @@ export interface WizardData {
     tense: Tense
     tone: string
     visualProseMode?: boolean
-    imageGenerationMode?: 'none' | 'agentic' | 'inline'
+    imageGenerationMode?: ImageGenerationMode
     backgroundImagesEnabled?: boolean
     referenceMode?: boolean
     targetLength?: TargetLength
@@ -794,7 +802,7 @@ class ScenarioService {
       themes?: string[]
       visualProseMode?: boolean
       inlineImageMode?: boolean
-      imageGenerationMode?: 'none' | 'agentic' | 'inline'
+      imageGenerationMode?: ImageGenerationMode
       backgroundImagesEnabled?: boolean
       referenceMode?: boolean
       targetLength?: TargetLength

--- a/src/lib/services/database.ts
+++ b/src/lib/services/database.ts
@@ -1,4 +1,5 @@
 import Database from '@tauri-apps/plugin-sql'
+import { invoke } from '@tauri-apps/api/core'
 import type {
   Story,
   StoryEntry,
@@ -37,6 +38,21 @@ import type {
   EnumOption,
 } from '$lib/services/packs/types'
 import { hashContent } from '$lib/services/packs/hash'
+
+/**
+ * A runtime variable's slot in an entity's metadata JSON.
+ *
+ * The key is quoted rather than spliced bare: SQLite reads an unquoted path segment up to
+ * the next `.` or `[`, so an id carrying either would address a different slot and the
+ * UPDATE would match nothing — silently, since a path that finds no key is not an error.
+ */
+function runtimeVarPath(defId: string, field?: string): string {
+  const key = `$."runtimeVars"."${defId.replace(/"/g, '""')}"`
+  return field ? `${key}."${field}"` : key
+}
+
+/** Entity tables that can carry runtime-variable values in their metadata JSON. */
+const RUNTIME_VAR_ENTITY_TABLES = ['characters', 'locations', 'items', 'story_beats'] as const
 
 /**
  * Migrate visual descriptors from old string array format to new structured object format.
@@ -156,20 +172,19 @@ class DatabaseService {
   }
 
   /**
-   * Run a callback inside a BEGIN/COMMIT transaction.
-   * Automatically rolls back on error.
+   * Run statements atomically, on one connection, through the Rust side.
+   *
+   * Returns the rows affected by each, in order. The whole batch rolls back on the first
+   * error, and the rejection carries the failing statement's message.
    */
-  async withTransaction<T>(fn: () => Promise<T>): Promise<T> {
-    const db = await this.getDb()
-    await db.execute('BEGIN')
-    try {
-      const result = await fn()
-      await db.execute('COMMIT')
-      return result
-    } catch (error) {
-      await db.execute('ROLLBACK')
-      throw error
-    }
+  async transaction(statements: { sql: string; params?: unknown[] }[]): Promise<number[]> {
+    if (statements.length === 0) return []
+    // The command opens the file itself with `create_if_missing(false)`, so the plugin has
+    // to have been through load and migrations first.
+    await this.getDb()
+    return invoke<number[]>('db_transaction', {
+      statements: statements.map(({ sql, params }) => ({ sql, params: params ?? [] })),
+    })
   }
 
   /**
@@ -2320,6 +2335,22 @@ class DatabaseService {
   }
 
   /**
+   * The `<pic>` tags of an entry that already have a record, and nothing else.
+   *
+   * The question is only "which of these tags is already covered", so it does not go
+   * through `getEmbeddedImagesForEntry`: that reads `*`, and the base64 of every image in
+   * the entry is what `getEmbeddedImageMetaForStory` below exists to keep off the bridge.
+   */
+  async getEmbeddedImageSourceTextsForEntry(entryId: string): Promise<string[]> {
+    const db = await this.getDb()
+    const results = await db.select<{ source_text: string | null }[]>(
+      'SELECT source_text FROM embedded_images WHERE entry_id = ?',
+      [entryId],
+    )
+    return results.map((r) => r.source_text ?? '').filter(Boolean)
+  }
+
+  /**
    * Like getEmbeddedImagesForStory but WITHOUT the base64 `image_data` column.
    *
    * Used on hot paths (message send, retry backup) that only need metadata. Avoids
@@ -3696,15 +3727,16 @@ class DatabaseService {
     const db = await this.getDb()
     const now = Date.now()
     const branch = this.keptSeparateBranch(branchId)
-    await this.withTransaction(async () => {
-      for (const pairKey of pairKeys) {
-        await db.execute(
-          `INSERT OR IGNORE INTO kept_separate (story_id, branch_id, pool, pair_key, created_at)
-           VALUES (?, ?, ?, ?, ?)`,
-          [storyId, branch, pool, pairKey, now],
-        )
-      }
-    })
+    // A single INSERT is atomic on its own, which is the most this layer can get.
+    const chunkSize = 100
+    for (let start = 0; start < pairKeys.length; start += chunkSize) {
+      const chunk = pairKeys.slice(start, start + chunkSize)
+      await db.execute(
+        `INSERT OR IGNORE INTO kept_separate (story_id, branch_id, pool, pair_key, created_at)
+         VALUES ${chunk.map(() => '(?, ?, ?, ?, ?)').join(', ')}`,
+        chunk.flatMap((pairKey) => [storyId, branch, pool, pairKey, now]),
+      )
+    }
   }
 
   /** Forget every dismissal for a story branch, so the full worklist comes back. */
@@ -3954,9 +3986,108 @@ class DatabaseService {
     )
   }
 
-  async deleteRuntimeVariable(id: string): Promise<void> {
-    const db = await this.getDb()
-    await db.execute('DELETE FROM pack_runtime_variables WHERE id = ?', [id])
+  /**
+   * The stories on a pack, as a subquery rather than a list of ids.
+   *
+   * Reading them first and then writing is a round trip the transaction cannot cover: a
+   * story assigned to the pack in between keeps a variable the pack no longer has.
+   */
+  private static readonly STORIES_ON_PACK = 'SELECT id FROM stories WHERE pack_id = ?'
+
+  /**
+   * The statements that take a runtime variable's values out of every entity that carries
+   * them, across the stories on this pack.
+   */
+  private clearRuntimeVarStatements(
+    packId: string,
+    defId: string,
+  ): { sql: string; params: unknown[] }[] {
+    const jsonPath = runtimeVarPath(defId)
+
+    return RUNTIME_VAR_ENTITY_TABLES.map((table) => ({
+      sql: `UPDATE ${table} SET metadata = json_remove(metadata, ?) WHERE story_id IN (${DatabaseService.STORIES_ON_PACK}) AND json_extract(metadata, ?) IS NOT NULL`,
+      params: [jsonPath, packId, jsonPath],
+    }))
+  }
+
+  /** The same, for a rename. */
+  private renameRuntimeVarStatements(
+    packId: string,
+    defId: string,
+    newVariableName: string,
+  ): { sql: string; params: unknown[] }[] {
+    const jsonPath = runtimeVarPath(defId)
+    const varNamePath = runtimeVarPath(defId, 'variableName')
+
+    return RUNTIME_VAR_ENTITY_TABLES.map((table) => ({
+      sql: `UPDATE ${table} SET metadata = json_set(metadata, ?, ?) WHERE story_id IN (${DatabaseService.STORIES_ON_PACK}) AND json_extract(metadata, ?) IS NOT NULL`,
+      params: [varNamePath, newVariableName, packId, jsonPath],
+    }))
+  }
+
+  /**
+   * Delete a runtime variable and the values entities hold for it, atomically.
+   *
+   * Half of this landing is a definition without its values or values without their
+   * definition, which the editor cannot show and the user cannot clean up.
+   */
+  async deleteRuntimeVariableEverywhere(packId: string, id: string): Promise<void> {
+    await this.transaction([
+      { sql: 'DELETE FROM pack_runtime_variables WHERE id = ?', params: [id] },
+      ...this.clearRuntimeVarStatements(packId, id),
+    ])
+  }
+
+  /** Rename a runtime variable and every stored copy of its name, atomically. */
+  async renameRuntimeVariableEverywhere(
+    packId: string,
+    id: string,
+    newVariableName: string,
+  ): Promise<void> {
+    await this.transaction([
+      {
+        sql: 'UPDATE pack_runtime_variables SET variable_name = ? WHERE id = ?',
+        params: [newVariableName, id],
+      },
+      ...this.renameRuntimeVarStatements(packId, id, newVariableName),
+    ])
+  }
+
+  /**
+   * Change a runtime variable's type, dropping the values typed under the old one.
+   *
+   * The constraints go with the type, so they are cleared in the same statement rather
+   * than left describing a range the new type has no use for.
+   */
+  async changeRuntimeVariableTypeEverywhere(
+    packId: string,
+    id: string,
+    variableType: RuntimeVariableType,
+  ): Promise<void> {
+    await this.transaction([
+      {
+        sql: 'UPDATE pack_runtime_variables SET variable_type = ?, default_value = NULL, min_value = NULL, max_value = NULL, enum_options = NULL WHERE id = ?',
+        params: [variableType, id],
+      },
+      ...this.clearRuntimeVarStatements(packId, id),
+    ])
+  }
+
+  /** Write two sort orders as one, so a reorder cannot leave both rows on the same slot. */
+  async swapRuntimeVariableOrder(
+    first: { id: string; sortOrder: number },
+    second: { id: string; sortOrder: number },
+  ): Promise<void> {
+    await this.transaction([
+      {
+        sql: 'UPDATE pack_runtime_variables SET sort_order = ? WHERE id = ?',
+        params: [first.sortOrder, first.id],
+      },
+      {
+        sql: 'UPDATE pack_runtime_variables SET sort_order = ? WHERE id = ?',
+        params: [second.sortOrder, second.id],
+      },
+    ])
   }
 
   // ===== Runtime Variable Entity Value Operations =====
@@ -3973,12 +4104,11 @@ class DatabaseService {
 
     const db = await this.getDb()
     const placeholders = storyIds.map(() => '?').join(', ')
-    const jsonPath = `$.runtimeVars.${defId}`
+    const jsonPath = runtimeVarPath(defId)
 
-    const tables = ['characters', 'locations', 'items', 'story_beats']
     let total = 0
 
-    for (const table of tables) {
+    for (const table of RUNTIME_VAR_ENTITY_TABLES) {
       const results = await db.select<any[]>(
         `SELECT COUNT(*) as cnt FROM ${table} WHERE story_id IN (${placeholders}) AND json_extract(metadata, ?) IS NOT NULL`,
         [...storyIds, jsonPath],
@@ -3987,45 +4117,6 @@ class DatabaseService {
     }
 
     return total
-  }
-
-  async clearRuntimeVarFromEntities(packId: string, defId: string): Promise<void> {
-    const storyIds = await this.getStoriesUsingPack(packId)
-    if (storyIds.length === 0) return
-
-    const db = await this.getDb()
-    const placeholders = storyIds.map(() => '?').join(', ')
-    const jsonPath = `$.runtimeVars.${defId}`
-
-    const tables = ['characters', 'locations', 'items', 'story_beats']
-    for (const table of tables) {
-      await db.execute(
-        `UPDATE ${table} SET metadata = json_remove(metadata, ?) WHERE story_id IN (${placeholders}) AND json_extract(metadata, ?) IS NOT NULL`,
-        [jsonPath, ...storyIds, jsonPath],
-      )
-    }
-  }
-
-  async renameRuntimeVarInEntities(
-    packId: string,
-    defId: string,
-    newVariableName: string,
-  ): Promise<void> {
-    const storyIds = await this.getStoriesUsingPack(packId)
-    if (storyIds.length === 0) return
-
-    const db = await this.getDb()
-    const placeholders = storyIds.map(() => '?').join(', ')
-    const jsonPath = `$.runtimeVars.${defId}`
-    const varNamePath = `$.runtimeVars.${defId}.variableName`
-
-    const tables = ['characters', 'locations', 'items', 'story_beats']
-    for (const table of tables) {
-      await db.execute(
-        `UPDATE ${table} SET metadata = json_set(metadata, ?, ?) WHERE story_id IN (${placeholders}) AND json_extract(metadata, ?) IS NOT NULL`,
-        [varNamePath, newVariableName, ...storyIds, jsonPath],
-      )
-    }
   }
 
   // ===== Story-Pack Assignment =====

--- a/src/lib/services/database.ts
+++ b/src/lib/services/database.ts
@@ -45,9 +45,16 @@ import { hashContent } from '$lib/services/packs/hash'
  * The key is quoted rather than spliced bare: SQLite reads an unquoted path segment up to
  * the next `.` or `[`, so an id carrying either would address a different slot and the
  * UPDATE would match nothing — silently, since a path that finds no key is not an error.
+ *
+ * A quote or a backslash inside the segment has no escape at all in SQLite's path grammar,
+ * so ids carrying one are refused here. Every id is a `crypto.randomUUID()`, which cannot
+ * contain either; the check is what keeps that true if the ids ever change shape.
  */
 function runtimeVarPath(defId: string, field?: string): string {
-  const key = `$."runtimeVars"."${defId.replace(/"/g, '""')}"`
+  if (/["\\]/.test(defId)) {
+    throw new Error(`runtime variable id cannot be addressed in a JSON path: ${defId}`)
+  }
+  const key = `$."runtimeVars"."${defId}"`
   return field ? `${key}."${field}"` : key
 }
 
@@ -183,7 +190,18 @@ class DatabaseService {
     // to have been through load and migrations first.
     await this.getDb()
     return invoke<number[]>('db_transaction', {
-      statements: statements.map(({ sql, params }) => ({ sql, params: params ?? [] })),
+      statements: statements.map(({ sql, params }) => ({
+        sql,
+        // `undefined` and `NaN` both serialize to JSON null on the way over, where the
+        // command can no longer tell them from a deliberate NULL and writes one. Caught
+        // here, while the caller's mistake is still visible as one.
+        params: (params ?? []).map((param) => {
+          if (param === undefined || (typeof param === 'number' && Number.isNaN(param))) {
+            throw new Error(`transaction parameter is ${String(param)}: ${sql}`)
+          }
+          return param
+        }),
+      })),
     })
   }
 
@@ -3724,19 +3742,21 @@ class DatabaseService {
     pairKeys: string[],
   ): Promise<void> {
     if (pairKeys.length === 0) return
-    const db = await this.getDb()
     const now = Date.now()
     const branch = this.keptSeparateBranch(branchId)
-    // A single INSERT is atomic on its own, which is the most this layer can get.
+    // Chunked to keep each statement under SQLite's bound-parameter ceiling, then run as one
+    // transaction: a dismissal set that lands by halves leaves the rest back on the worklist.
     const chunkSize = 100
+    const statements = []
     for (let start = 0; start < pairKeys.length; start += chunkSize) {
       const chunk = pairKeys.slice(start, start + chunkSize)
-      await db.execute(
-        `INSERT OR IGNORE INTO kept_separate (story_id, branch_id, pool, pair_key, created_at)
+      statements.push({
+        sql: `INSERT OR IGNORE INTO kept_separate (story_id, branch_id, pool, pair_key, created_at)
          VALUES ${chunk.map(() => '(?, ?, ?, ?, ?)').join(', ')}`,
-        chunk.flatMap((pairKey) => [storyId, branch, pool, pairKey, now]),
-      )
+        params: chunk.flatMap((pairKey) => [storyId, branch, pool, pairKey, now]),
+      })
     }
+    await this.transaction(statements)
   }
 
   /** Forget every dismissal for a story branch, so the full worklist comes back. */

--- a/src/lib/services/duplicates/index.ts
+++ b/src/lib/services/duplicates/index.ts
@@ -147,6 +147,7 @@ export function findEntityDuplicates(
 export {
   findDuplicateGroups,
   formatDuplicateGroup,
+  groupIsSettledBy,
   normalizeName,
   editDistance,
   type DuplicateGroup,

--- a/src/lib/services/duplicates/names.test.ts
+++ b/src/lib/services/duplicates/names.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { editDistance, findDuplicateGroups, normalizeName } from './names'
+import {
+  editDistance,
+  findDuplicateGroups,
+  formatDuplicateGroup,
+  groupIsSettledBy,
+  normalizeName,
+  type DuplicateGroup,
+} from './names'
 
 const character = (name: string, aliases: string[] = []) => ({ name, aliases, type: 'character' })
 
@@ -90,9 +97,43 @@ describe('findDuplicateGroups', () => {
     expect(findDuplicateGroups([character('Mara'), character('Sara')])).toEqual([])
   })
 
-  it('does not pair a short name with every longer one containing it', () => {
-    // "Ren" inside "Renwald" is the substring-noise case, and it is below the fuzzy floor.
-    expect(findDuplicateGroups([character('Ren'), character('Ren Wald')])).toEqual([])
+  it('pairs a short name that is a whole word of a longer one', () => {
+    // Short, but not substring noise: "Ren" is a whole token of "Ren Wald". Whether the
+    // two are one subject is the question the worklist exists to ask.
+    expect(findDuplicateGroups([character('Ren'), character('Ren Wald')])[0].reason).toBe(
+      'contained',
+    )
+  })
+
+  it('does not pair a name that is merely a substring of another', () => {
+    // The substring-noise case the token comparison rules out by shape: "Ren" is inside
+    // "Renwald" but is not a word of it.
+    expect(findDuplicateGroups([character('Ren'), character('Renwald')])).toEqual([])
+  })
+
+  it('compares aliases the same way it compares names', () => {
+    // Only the primary names used to be compared past the exact-key check, so an alias
+    // that had drifted or grown a title was invisible.
+    expect(
+      findDuplicateGroups([character('Kaelen'), character('Aldric', ['Kaelan the Bold'])])[0]
+        .reason,
+    ).toBe('contained')
+
+    expect(
+      findDuplicateGroups([character('Kaelen'), character('Aldric', ['Kaelan'])])[0].reason,
+    ).toBe('similar')
+  })
+
+  it('allows a contained token to have drifted too', () => {
+    expect(findDuplicateGroups([character('Kaelen'), character('Kaelan the Bold')])[0].reason).toBe(
+      'contained',
+    )
+  })
+
+  it('spends each token of the longer name once', () => {
+    // Both tokens of "Maria Marie" reach for the one "Maria" over there — the first
+    // exactly, the second by drift. Letting them share it makes containment mean nothing.
+    expect(findDuplicateGroups([character('Maria Marie'), character('Maria de Luna')])).toEqual([])
   })
 
   it('compares fuzzily only within a type, but exact names across types', () => {
@@ -118,5 +159,41 @@ describe('findDuplicateGroups', () => {
     ])
     expect(groups[0].indices).toEqual([1, 2])
     expect(groups[0].names).toEqual(['The Citadel', 'Citadel'])
+  })
+})
+
+describe('formatDuplicateGroup', () => {
+  const group: DuplicateGroup = {
+    indices: [3, 7, 9],
+    names: ['Kaelen', 'Kaelan', 'Kaelen the Bold'],
+    reason: 'similar',
+  }
+
+  it('drops the members a merge or a delete already took', () => {
+    expect(formatDuplicateGroup(group, new Set([7]))).toBe(
+      '[3] Kaelen | [9] Kaelen the Bold — near-identical spelling',
+    )
+  })
+})
+
+describe('groupIsSettledBy', () => {
+  const group: DuplicateGroup = {
+    indices: [3, 7, 9, 11],
+    names: ['Kaelen', 'Kaelan', 'Kaelen the Bold', 'Kaelin'],
+    reason: 'similar',
+  }
+
+  it('refuses a partial answer, which would dismiss neighbouring groups untouched', () => {
+    expect(groupIsSettledBy(group, new Set([3, 7]), new Set())).toBe(false)
+  })
+
+  it('settles on the full membership', () => {
+    expect(groupIsSettledBy(group, new Set([3, 7, 9, 11]), new Set())).toBe(true)
+  })
+
+  it('settles on what is left once a merge has consumed the rest', () => {
+    // The listing hides 3 and 7, so those are the only indices the agent can name back.
+    // Demanding them anyway left the group impossible to close for the rest of the run.
+    expect(groupIsSettledBy(group, new Set([9, 11]), new Set([3, 7]))).toBe(true)
   })
 })

--- a/src/lib/services/duplicates/names.ts
+++ b/src/lib/services/duplicates/names.ts
@@ -36,13 +36,6 @@ export interface DuplicateGroup {
 export type DuplicateReason = 'same-name' | 'shared-alias' | 'contained' | 'similar'
 
 /**
- * Containment and similarity on a two- or three-letter name are noise: every short string
- * is inside some longer one. Exact-name and alias matches have no such floor — they are
- * exact.
- */
-const MIN_FUZZY_LENGTH = 4
-
-/**
  * How far apart two names may be spelled and still be the same name.
  *
  * One edit is plausible drift on a name long enough for it — "Kaelen"/"Kaelan" — and on a
@@ -146,11 +139,44 @@ function isSpellingDrift(a: string, b: string): boolean {
 }
 
 interface Normalized {
-  name: string
   type: string
-  tokens: string[]
-  /** Every name this entry answers to. Precomputed: every pair is compared. */
-  keys: Set<string>
+  /** Every name this entry answers to, the entry's own first. Precomputed: every pair is compared. */
+  keys: string[]
+  keySet: Set<string>
+  /** The tokens of each key, in the same order. */
+  tokens: string[][]
+}
+
+/**
+ * Whether one name is the other with more words around it, which is what makes "Kaelen"
+ * and "Kaelen the Bold" one candidate.
+ *
+ * Whole tokens on both sides, so this is boundary-aware by construction: "Ren" is a token
+ * of "Ren Wald" and is not a token of "Renwald". That is why there is no length floor here
+ * — a floor would only rule out the short *whole* names this is meant to catch, while the
+ * substring noise it was aimed at ("Ren" inside "Renwald") cannot arise in the first place.
+ *
+ * A token may also match by the drift allowed at its length, so a name that was both
+ * extended and misspelled is still caught.
+ *
+ * Each longer token answers for one shorter token and no more. Without that, a name whose
+ * own tokens repeat — or near-repeat, once drift is allowed — is "contained" in a longer
+ * name that carries the word once, which is not what containment means.
+ */
+function isContained(a: string[], b: string[]): boolean {
+  const [shorter, longer] = a.length <= b.length ? [a, b] : [b, a]
+  if (shorter.length === 0 || shorter.length >= longer.length) return false
+
+  const taken = new Array<boolean>(longer.length).fill(false)
+  return shorter.every((token) => {
+    // The exact hit first: the edit distance is the expensive half of this module and most
+    // tokens are carried over unchanged.
+    let at = longer.findIndex((other, i) => !taken[i] && other === token)
+    if (at === -1) at = longer.findIndex((other, i) => !taken[i] && isSpellingDrift(token, other))
+    if (at === -1) return false
+    taken[at] = true
+    return true
+  })
 }
 
 /**
@@ -158,36 +184,34 @@ interface Normalized {
  *
  * Order matters: the strongest reason wins, because it is what the agent is shown and a
  * "same-name" pair deserves less deliberation than a "contained" one.
+ *
+ * Containment and drift run over **every form against every form**, not just the two
+ * primary names: an alias is extended and misspelled exactly like a name, and comparing
+ * only the names missed "Kaelen" against an entry called "Kaelan the Bold".
  */
 function pairReason(a: Normalized, b: Normalized): DuplicateReason | null {
-  if (!a.name || !b.name) return null
+  if (a.keys.length === 0 || b.keys.length === 0) return null
 
-  if (a.name === b.name) return 'same-name'
+  if (a.keys[0] === b.keys[0]) return 'same-name'
 
-  for (const key of a.keys) {
-    if (b.keys.has(key)) return 'shared-alias'
+  for (const key of a.keySet) {
+    if (b.keySet.has(key)) return 'shared-alias'
   }
 
   // Beyond exact naming, only entries of the same kind are worth comparing: a location and
   // a character sharing a word are a namesake, not a duplicate.
   if (a.type !== b.type) return null
 
-  const [shorter, longer] = a.tokens.length <= b.tokens.length ? [a, b] : [b, a]
-  if (
-    shorter.tokens.length > 0 &&
-    shorter.tokens.length < longer.tokens.length &&
-    shorter.name.length >= MIN_FUZZY_LENGTH &&
-    shorter.tokens.every((token) => longer.tokens.includes(token))
-  ) {
-    return 'contained'
+  for (const aTokens of a.tokens) {
+    for (const bTokens of b.tokens) {
+      if (isContained(aTokens, bTokens)) return 'contained'
+    }
   }
 
-  if (
-    a.name.length >= MIN_FUZZY_LENGTH &&
-    b.name.length >= MIN_FUZZY_LENGTH &&
-    isSpellingDrift(a.name, b.name)
-  ) {
-    return 'similar'
+  for (const aKey of a.keys) {
+    for (const bKey of b.keys) {
+      if (isSpellingDrift(aKey, bKey)) return 'similar'
+    }
   }
 
   return null
@@ -210,11 +234,15 @@ export function findDuplicateGroups(entries: DuplicateCandidateInput[]): Duplica
   const normalized: Normalized[] = entries.map((entry) => {
     const name = normalizeName(entry.name)
     const aliases = (entry.aliases ?? []).map(normalizeName).filter(Boolean)
+    // An entry whose name folds to nothing is not compared at all: the empty string is
+    // equal to every other empty string, and two names this module cannot read are not
+    // two names it may declare the same.
+    const keys = name ? [...new Set([name, ...aliases])] : []
     return {
-      name,
       type: entry.type,
-      tokens: tokensOf(name),
-      keys: new Set([name, ...aliases].filter(Boolean)),
+      keys,
+      keySet: new Set(keys),
+      tokens: keys.map(tokensOf),
     }
   })
 
@@ -271,8 +299,37 @@ const REASON_LABELS: Record<DuplicateReason, string> = {
   similar: 'near-identical spelling',
 }
 
-/** One line per group, in the index form every lorebook tool takes. */
-export function formatDuplicateGroup(group: DuplicateGroup): string {
-  const members = group.indices.map((i, n) => `[${i}] ${group.names[n]}`).join(' | ')
+/**
+ * One line per group, in the index form every lorebook tool takes.
+ *
+ * `consumed` drops the members a merge or a delete has already taken. A group stays open
+ * while two of its members are left, and reprinting the dead indices alongside them offers
+ * the agent an index every tool will refuse. It is required rather than optional so that
+ * `groups.map(formatDuplicateGroup)` cannot compile: that hands the map's index across as
+ * the set.
+ */
+export function formatDuplicateGroup(group: DuplicateGroup, consumed: ReadonlySet<number>): string {
+  const members = group.indices
+    .map((index, n) => ({ index, name: group.names[n] }))
+    .filter(({ index }) => !consumed.has(index))
+    .map(({ index, name }) => `[${index}] ${name}`)
+    .join(' | ')
   return `${members} — ${REASON_LABELS[group.reason]}`
+}
+
+/**
+ * Whether naming `named` settles this group.
+ *
+ * Every member has to be accounted for: closing on one shared index dismissed neighbouring
+ * groups nobody had looked at. A `consumed` index counts as accounted for, and that half is
+ * why this lives next to `formatDuplicateGroup` — the listing hides those indices, so a rule
+ * that demanded them back would leave every group that survived a merge or a delete
+ * impossible to close, with the agent refused for an index it was never shown.
+ */
+export function groupIsSettledBy(
+  group: DuplicateGroup,
+  named: ReadonlySet<number>,
+  consumed: ReadonlySet<number>,
+): boolean {
+  return group.indices.every((i) => named.has(i) || consumed.has(i))
 }

--- a/src/lib/services/generation/GenerationPipeline.ts
+++ b/src/lib/services/generation/GenerationPipeline.ts
@@ -42,6 +42,7 @@ import {
   type BackgroundImageSettings,
 } from './phases/BackgroundImagePhase'
 import { mergeGenerators } from '$lib/utils/async'
+import { sameEntityName } from '$lib/utils/text'
 
 export interface PipelineDependencies
   extends
@@ -271,9 +272,15 @@ export class GenerationPipeline {
     classification: ClassificationPhaseResult | null,
     translation: TranslationResult2,
   ) {
+    // Matched the way presence is matched everywhere else: an exact-string compare here
+    // dropped the portrait reference for any name the model spelled differently.
+    //
+    // The protagonist is added rather than looked for. They are in every scene by
+    // definition, so whether the classifier remembered to name them says nothing — and
+    // leaving them out costs the image prompt its `isProtagonist` reference.
     const names = classification?.classificationResult?.scene?.presentCharacterNames ?? []
-    const presentCharacters: Character[] = ctx.worldState.characters.filter((c) =>
-      names.includes(c.name),
+    const presentCharacters: Character[] = ctx.worldState.characters.filter(
+      (c) => c.relationship === 'self' || names.some((name) => sameEntityName(c.name, name)),
     )
     return {
       storyId: ctx.story.id,

--- a/src/lib/services/generation/LoreManagementCoordinator.ts
+++ b/src/lib/services/generation/LoreManagementCoordinator.ts
@@ -47,6 +47,7 @@ export interface LoreManagementUICallbacks {
    * `onComplete` two seconds later — and this is the only record of what a run did.
    */
   onSummary?: (summary: string, changeCount: number) => void
+  onError?: (error: string) => void
   onComplete: () => void
 }
 
@@ -219,6 +220,8 @@ export class LoreManagementCoordinator {
       }
     } catch (error) {
       log('Lore management failed', error)
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      uiCallbacks?.onError?.(errorMessage)
 
       // Still clear the UI state: a failed run must not leave the lorebook read-only.
       finishUI()

--- a/src/lib/services/generation/characterPresence.test.ts
+++ b/src/lib/services/generation/characterPresence.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest'
+import type { Character } from '$lib/types'
+import { resolveCharacterPresence } from './characterPresence'
+
+function character(name: string, overrides: Partial<Character> = {}): Character {
+  return {
+    id: `id-${name}`,
+    storyId: 's1',
+    name,
+    description: null,
+    relationship: null,
+    traits: [],
+    visualDescriptors: {},
+    portrait: null,
+    status: 'active',
+    metadata: null,
+    branchId: null,
+    ...overrides,
+  }
+}
+
+const base = {
+  newNames: [],
+  explicitStatusNames: [],
+}
+
+describe('resolveCharacterPresence', () => {
+  it('marks an active character absent from the list as away', () => {
+    const changes = resolveCharacterPresence({
+      ...base,
+      characters: [character('Morvana'), character('Zella')],
+      presentNames: ['Morvana'],
+    })
+
+    expect(changes).toEqual([{ id: 'id-Zella', name: 'Zella', from: 'active', to: 'inactive' }])
+  })
+
+  it('brings a character who returns back into the scene', () => {
+    const changes = resolveCharacterPresence({
+      ...base,
+      characters: [character('Zella', { status: 'inactive' })],
+      presentNames: ['Zella'],
+    })
+
+    expect(changes).toEqual([{ id: 'id-Zella', name: 'Zella', from: 'inactive', to: 'active' }])
+  })
+
+  it('reports nothing for a character already in the right state', () => {
+    const changes = resolveCharacterPresence({
+      ...base,
+      characters: [character('Morvana'), character('Zella', { status: 'inactive' })],
+      presentNames: ['Morvana'],
+    })
+
+    expect(changes).toEqual([])
+  })
+
+  it('treats an empty list as no signal, not as an empty room', () => {
+    // The schema defaults the field to `[]`, so a model that skipped it is indistinguishable
+    // from one reporting nobody. Acting on it would empty the cast in a single turn.
+    const changes = resolveCharacterPresence({
+      ...base,
+      characters: [character('Morvana'), character('Zella')],
+      presentNames: [],
+    })
+
+    expect(changes).toEqual([])
+  })
+
+  it('changes nothing when the classification errored', () => {
+    // A salvaged response is missing whatever the model did not finish writing; absence
+    // from the list says nothing about the scene.
+    const changes = resolveCharacterPresence({
+      ...base,
+      characters: [character('Morvana'), character('Zella')],
+      presentNames: ['Morvana'],
+      hadError: true,
+    })
+
+    expect(changes).toEqual([])
+  })
+
+  it('never touches the protagonist', () => {
+    const changes = resolveCharacterPresence({
+      ...base,
+      characters: [character('Pento', { relationship: 'self' })],
+      presentNames: ['Morvana'],
+    })
+
+    expect(changes).toEqual([])
+  })
+
+  it('never resurrects or re-kills the dead', () => {
+    const changes = resolveCharacterPresence({
+      ...base,
+      characters: [character('Liana', { status: 'deceased' })],
+      presentNames: ['Liana'],
+    })
+
+    expect(changes).toEqual([])
+  })
+
+  it('yields to an explicit status update', () => {
+    const changes = resolveCharacterPresence({
+      ...base,
+      characters: [character('Scrim')],
+      presentNames: ['Morvana'],
+      explicitStatusNames: ['Scrim'],
+    })
+
+    expect(changes).toEqual([])
+  })
+
+  it('skips the reconciliation on an empty list, whatever this turn created', () => {
+    const changes = resolveCharacterPresence({
+      ...base,
+      characters: [character('Tarris')],
+      presentNames: [],
+      newNames: ['Tarris'],
+    })
+
+    // Still no signal: presentNames is empty, so the whole reconciliation is skipped.
+    expect(changes).toEqual([])
+  })
+
+  it('keeps a new character active when the list carries a signal', () => {
+    const changes = resolveCharacterPresence({
+      ...base,
+      characters: [character('Tarris'), character('Zella')],
+      presentNames: ['Morvana'],
+      newNames: ['Tarris'],
+    })
+
+    expect(changes).toEqual([{ id: 'id-Zella', name: 'Zella', from: 'active', to: 'inactive' }])
+  })
+
+  it('matches names through accents and punctuation, not through substrings', () => {
+    // `sameEntityName` folds "Vor'koth"/"Vorkoth"; it does not fold "Kaelen" into
+    // "Baron Kaelen", which would keep the wrong character in the scene.
+    const changes = resolveCharacterPresence({
+      ...base,
+      characters: [character("Vor'koth"), character('Baron Kaelen')],
+      presentNames: ['Vorkoth', 'Kaelen'],
+    })
+
+    expect(changes).toEqual([
+      { id: 'id-Baron Kaelen', name: 'Baron Kaelen', from: 'active', to: 'inactive' },
+    ])
+  })
+})

--- a/src/lib/services/generation/characterPresence.ts
+++ b/src/lib/services/generation/characterPresence.ts
@@ -1,0 +1,76 @@
+/**
+ * Character presence
+ *
+ * Turns the classifier's `scene.presentCharacterNames` into the status changes it implies.
+ *
+ * The model reports who is in the scene, never who left: asking a model to name thirty
+ * absent characters produces nothing, while asking it to name the three in front of it is
+ * the question the passage answers. Everyone else with an `active` status is therefore
+ * away, and the departure is inferred here rather than extracted.
+ *
+ * That inference is only as good as the list, so it is refused whenever the list cannot be
+ * trusted — see `resolveCharacterPresence`.
+ */
+
+import { sameEntityName } from '$lib/utils/text'
+import type { Character } from '$lib/types'
+
+export interface PresenceInput {
+  characters: Character[]
+  /** `scene.presentCharacterNames`, exactly as the classifier returned it. */
+  presentNames: string[]
+  /** Names of characters created by this same classification; present by construction. */
+  newNames: string[]
+  /** Names carrying an explicit `changes.status`, which decides for itself. */
+  explicitStatusNames: string[]
+  /** Set when the classification failed or was salvaged from a partial response. */
+  hadError?: boolean
+}
+
+export interface PresenceChange {
+  id: string
+  name: string
+  from: Character['status']
+  to: 'active' | 'inactive'
+}
+
+/**
+ * Which characters change status this turn, and to what.
+ *
+ * Returns nothing at all — not "everyone is away" — when the list carries no signal:
+ *
+ * - the classification errored or was salvaged, so absence from the list means the response
+ *   was truncated rather than the character was;
+ * - the list is empty. The schema defaults it to `[]`, so "the model said nobody" and "the
+ *   model did not answer" arrive identically, and a scene with nobody in it does not exist.
+ *
+ * `deceased` is never touched, the protagonist is never absent, and an explicit status in
+ * `characterUpdates` wins: the model saying someone died outranks the model not listing them.
+ */
+export function resolveCharacterPresence(input: PresenceInput): PresenceChange[] {
+  const { characters, presentNames, newNames, explicitStatusNames, hadError } = input
+
+  if (hadError) return []
+  if (presentNames.length === 0) return []
+
+  const inScene = [...presentNames, ...newNames]
+  const decided = explicitStatusNames
+
+  const changes: PresenceChange[] = []
+
+  for (const char of characters) {
+    if (char.relationship === 'self') continue
+    if (char.status === 'deceased') continue
+    if (decided.some((name) => sameEntityName(char.name, name))) continue
+
+    const present = inScene.some((name) => sameEntityName(char.name, name))
+
+    if (present && char.status !== 'active') {
+      changes.push({ id: char.id, name: char.name, from: char.status, to: 'active' })
+    } else if (!present && char.status === 'active') {
+      changes.push({ id: char.id, name: char.name, from: char.status, to: 'inactive' })
+    }
+  }
+
+  return changes
+}

--- a/src/lib/services/generation/index.ts
+++ b/src/lib/services/generation/index.ts
@@ -143,6 +143,10 @@ export type {
   SuggestionsRefreshResult,
 } from './SuggestionsRefreshService'
 
+// Character presence
+export { resolveCharacterPresence } from './characterPresence'
+export type { PresenceInput, PresenceChange } from './characterPresence'
+
 // Pipeline event handler
 export { handleEvent } from './PipelineEventHandler'
 export type { PipelineUICallbacks, PipelineEventState } from './PipelineEventHandler'

--- a/src/lib/services/generation/loreCallbacks.ts
+++ b/src/lib/services/generation/loreCallbacks.ts
@@ -118,6 +118,7 @@ export function buildLoreManagementUICallbacks(
       onStart: ui.startLoreManagement.bind(ui),
       onProgress: ui.updateLoreManagementProgress.bind(ui),
       onSummary: ui.setLoreManagementSummary.bind(ui),
+      onError: ui.setLoreManagementError.bind(ui),
       onComplete: ui.finishLoreManagement.bind(ui),
     }
   }
@@ -126,6 +127,14 @@ export function buildLoreManagementUICallbacks(
     onStart: () => target.onStatus('Updating lorebook...'),
     onProgress: (message) => target.onStatus(message),
     onSummary: ui.setLoreManagementSummary.bind(ui),
+    // The status line and not only the status line: the coordinator clears the UI right
+    // after this, and `onComplete` sets the status back to null in the same tick — so a
+    // failure written only there is erased before anyone reads it. The stored error
+    // outlives the run and is what the lorebook view shows.
+    onError: (err) => {
+      target.onStatus(`Lore management failed: ${err}`)
+      ui.setLoreManagementError(err)
+    },
     onComplete: () => target.onStatus(null),
   }
 }

--- a/src/lib/services/generation/mergeEntities.ts
+++ b/src/lib/services/generation/mergeEntities.ts
@@ -23,7 +23,7 @@
  */
 
 import type { Character, Entry, Item, Location } from '$lib/types'
-import { escapeRegex } from '$lib/utils/text'
+import { containsWholeUnit } from '$lib/utils/text'
 
 /** Where a field's value came from, which is what the preview shows next to it. */
 export type FieldOrigin =
@@ -302,27 +302,6 @@ export function planEntryMerge(primary: Entry, others: Entry[]): MergePlan {
 const APPEND_SEPARATOR = '\n\n'
 
 /**
- * Checks whether `needle` is contained in `haystack` as a whole-word / whole-unit text passage,
- * so sub-word occurrences ("Gatto" in "Cattedrale") are not false positives.
- */
-function containsAsWholeUnit(haystack: string, needle: string): boolean {
-  const normHay = haystack.toLowerCase().trim()
-  const normNeedle = needle.toLowerCase().trim()
-  if (!normNeedle) return false
-  if (normHay === normNeedle) return true
-
-  let patternStr = escapeRegex(normNeedle)
-  if (/^[\p{L}\p{N}]/u.test(normNeedle)) {
-    patternStr = '(?<![\\p{L}\\p{N}])' + patternStr
-  }
-  if (/[\p{L}\p{N}]$/u.test(normNeedle)) {
-    patternStr = patternStr + '(?![\\p{L}\\p{N}])'
-  }
-
-  return new RegExp(patternStr, 'u').test(normHay)
-}
-
-/**
  * Join the candidates, skipping any whose text the result already carries.
  *
  * Performs a bidirectional, boundary-aware check:
@@ -338,7 +317,7 @@ function appendCandidates(candidates: MergeCandidate[]): string {
     if (!text) continue
 
     // 1. If an existing part already covers this text as a whole unit, skip text.
-    if (parts.some((p) => containsAsWholeUnit(p, text))) {
+    if (parts.some((p) => containsWholeUnit(p, text))) {
       continue
     }
 
@@ -346,7 +325,7 @@ function appendCandidates(candidates: MergeCandidate[]): string {
     let replaced = false
     const newParts: string[] = []
     for (const p of parts) {
-      if (containsAsWholeUnit(text, p)) {
+      if (containsWholeUnit(text, p)) {
         if (!replaced) {
           newParts.push(text)
           replaced = true

--- a/src/lib/services/generation/phases/BackgroundImagePhase.ts
+++ b/src/lib/services/generation/phases/BackgroundImagePhase.ts
@@ -13,7 +13,7 @@ import type {
   AbortedEvent,
   ErrorEvent,
 } from '../types'
-import type { StoryEntry } from '$lib/types'
+import type { StoryEntry, ImageGenerationMode } from '$lib/types'
 
 /** Dependencies for image phase - injected to avoid tight coupling */
 export interface BackgroundImageDependencies {
@@ -30,7 +30,7 @@ export interface BackgroundImageDependencies {
 /** Settings needed for image phase decision making */
 export interface BackgroundImageSettings {
   backgroundImagesEnabled?: boolean
-  imageGenerationMode?: 'none' | 'agentic' | 'inline'
+  imageGenerationMode?: ImageGenerationMode
 }
 
 /** Input for the image phase */

--- a/src/lib/services/generation/phases/ImagePhase.ts
+++ b/src/lib/services/generation/phases/ImagePhase.ts
@@ -12,7 +12,7 @@ import type {
   ErrorEvent,
 } from '../types'
 import type { ImageGenerationContext } from '$lib/services/ai'
-import type { Character } from '$lib/types'
+import type { Character, ImageGenerationMode } from '$lib/types'
 
 /** Dependencies for image phase - injected to avoid tight coupling */
 export interface ImageDependencies {
@@ -25,7 +25,7 @@ export interface ImageDependencies {
 
 /** Settings needed for image phase decision making */
 export interface ImageSettings {
-  imageGenerationMode?: 'none' | 'agentic' | 'inline'
+  imageGenerationMode?: ImageGenerationMode
   referenceMode?: boolean
 }
 

--- a/src/lib/services/image/ImageEmbeddingService.ts
+++ b/src/lib/services/image/ImageEmbeddingService.ts
@@ -20,6 +20,7 @@ import {
   picTagRegex,
   renderSinglePicTag,
   type ImageReplacementInfo,
+  type PicTagRenderOptions,
 } from '$lib/utils/inlineImageParser'
 import { createFuzzyTextRegex } from '$lib/utils/text'
 
@@ -58,6 +59,51 @@ function buildAgenticMarkers(
   images: EmbeddedImage[],
   snapToDialogue: boolean,
 ): ImageMarker[] {
+  const snapped = snapToDialogue
+    ? snapMarkersToDialogue(content, rawMarkers(content, images))
+    : rawMarkers(content, images)
+  return [...snapped].sort((a, b) => b.start - a.start)
+}
+
+/**
+ * Raw-marker runs, keyed by the narration they were found in.
+ *
+ * Both readers — the renderer and the orphan gallery — ask the same question about the
+ * same entry, and the answer costs a fuzzy regex pass per image over the whole narration.
+ * Only the snapping differs between them, and that runs on the result. They are reached
+ * from different reactive contexts, so a single slot would be evicted by the next entry
+ * before the second reader arrives.
+ */
+const RAW_MARKER_CACHE_LIMIT = 32
+const rawMarkerCache = new Map<string, { signature: string; markers: ImageMarker[] }>()
+
+/**
+ * Keyed on the narration itself, so entries of the story being left never come up again.
+ * Called where the story or the branch changes, next to `clearTier3SelectionCache`.
+ */
+export function clearImageMarkerCache(): void {
+  rawMarkerCache.clear()
+}
+
+function markerSignature(images: EmbeddedImage[]): string {
+  return images.map((img) => `${img.id}:${img.status}:${img.sourceText}`).join('\u0000')
+}
+
+function rawMarkers(content: string, images: EmbeddedImage[]): ImageMarker[] {
+  const signature = markerSignature(images)
+  const cached = rawMarkerCache.get(content)
+  if (cached?.signature === signature) return cached.markers
+
+  const markers = findAgenticMarkers(content, images)
+  rawMarkerCache.set(content, { signature, markers })
+  if (rawMarkerCache.size > RAW_MARKER_CACHE_LIMIT) {
+    const oldest = rawMarkerCache.keys().next().value
+    if (oldest !== undefined) rawMarkerCache.delete(oldest)
+  }
+  return markers
+}
+
+function findAgenticMarkers(content: string, images: EmbeddedImage[]): ImageMarker[] {
   const displayable = getDisplayableAgenticImages(images)
   const sortedImages = [...displayable].sort((a, b) => b.sourceText.length - a.sourceText.length)
   const markers: ImageMarker[] = []
@@ -83,8 +129,7 @@ function buildAgenticMarkers(
     }
   }
 
-  const snapped = snapToDialogue ? snapMarkersToDialogue(content, markers) : markers
-  return snapped.sort((a, b) => b.start - a.start)
+  return markers
 }
 
 /**
@@ -166,6 +211,7 @@ function processUnified(
   render: (text: string) => string,
   renderMarkerText: (text: string) => string,
   snapToDialogue: boolean,
+  picOptions: PicTagRenderOptions,
 ): string {
   if (images.length === 0 && !content.includes('<pic')) {
     return render(content)
@@ -182,7 +228,7 @@ function processUnified(
     let picIndex = 0
     text = text.replace(picTagRegex(), (match) => {
       const placeholder = `PICPH${picIndex++}PICPH`
-      const html = renderSinglePicTag(match, imageMap, regeneratingIds)
+      const html = renderSinglePicTag(match, imageMap, { ...picOptions, regeneratingIds })
       placeholderMap.set(placeholder, html)
       return placeholder
     })
@@ -269,6 +315,7 @@ export function processStoryContent(
   content: string,
   images: EmbeddedImage[],
   regeneratingIds: Set<string> = new Set(),
+  picOptions: Omit<PicTagRenderOptions, 'regeneratingIds'> = {},
 ): string {
   return processUnified(
     content,
@@ -277,6 +324,7 @@ export function processStoryContent(
     parseStoryMarkdown,
     parseStoryMarkdownInline,
     true,
+    picOptions,
   )
 }
 
@@ -289,6 +337,7 @@ export function processVisualProseStoryContent(
   images: EmbeddedImage[],
   entryId: string,
   regeneratingIds: Set<string> = new Set(),
+  picOptions: Omit<PicTagRenderOptions, 'regeneratingIds'> = {},
 ): string {
   // Marker text stays raw here: in this mode it is already HTML, and running it
   // through a markdown renderer would mangle the tags it is made of.
@@ -299,33 +348,6 @@ export function processVisualProseStoryContent(
     (t) => sanitizeVisualProse(t, entryId),
     (t) => t,
     false,
+    picOptions,
   )
-}
-
-// Keep old functions as aliases for backward compatibility (used by StreamingEntry)
-export const processContentWithImages = processStoryContent
-export const processVisualProseWithImages = processVisualProseStoryContent
-export function processContentWithInlineImages(
-  content: string,
-  images: EmbeddedImage[],
-  regeneratingIds: Set<string> = new Set(),
-): string {
-  return processStoryContent(content, images, regeneratingIds)
-}
-export function processVisualProseWithInlineImages(
-  content: string,
-  images: EmbeddedImage[],
-  entryId: string,
-  regeneratingIds: Set<string> = new Set(),
-): string {
-  return processVisualProseStoryContent(content, images, entryId, regeneratingIds)
-}
-
-export const imageEmbeddingService = {
-  processStoryContent,
-  processVisualProseStoryContent,
-  processContentWithImages,
-  processVisualProseWithImages,
-  processContentWithInlineImages,
-  processVisualProseWithInlineImages,
 }

--- a/src/lib/services/image/ImageEmbeddingService.ts
+++ b/src/lib/services/image/ImageEmbeddingService.ts
@@ -92,7 +92,13 @@ function markerSignature(images: EmbeddedImage[]): string {
 function rawMarkers(content: string, images: EmbeddedImage[]): ImageMarker[] {
   const signature = markerSignature(images)
   const cached = rawMarkerCache.get(content)
-  if (cached?.signature === signature) return cached.markers
+  if (cached?.signature === signature) {
+    // Re-set to move the key to the end: eviction takes the first key, so without this a
+    // steadily re-read entry is dropped on age rather than on disuse.
+    rawMarkerCache.delete(content)
+    rawMarkerCache.set(content, cached)
+    return cached.markers
+  }
 
   const markers = findAgenticMarkers(content, images)
   rawMarkerCache.set(content, { signature, markers })

--- a/src/lib/services/image/index.ts
+++ b/src/lib/services/image/index.ts
@@ -5,12 +5,8 @@
  */
 
 export {
-  imageEmbeddingService,
   processStoryContent,
   processVisualProseStoryContent,
-  processContentWithImages,
-  processVisualProseWithImages,
-  processContentWithInlineImages,
-  processVisualProseWithInlineImages,
   getPlacedImageIds,
+  clearImageMarkerCache,
 } from './ImageEmbeddingService'

--- a/src/lib/services/prompts/templates/analysis.ts
+++ b/src/lib/services/prompts/templates/analysis.ts
@@ -38,24 +38,18 @@ Visual descriptors enable consistent character visualization. The goal is to bui
 - A traveler might have weathered features, travel-worn clothes, a pack
 Never leave a character without complete visual descriptors - invent plausible details to fill gaps.
 
-**For EXISTING characters - USE replaceVisualDescriptors:**
-When updating a character's appearance, use \`replaceVisualDescriptors\` to provide the COMPLETE, FINAL list of descriptors. This REPLACES all existing descriptors entirely. Look at their current "Appearance:" in the entity list and output a cleaned-up, consolidated version with any updates applied.
+**For EXISTING characters:** \`visualDescriptors\` REPLACES every category at once. Only send it for a character listed \`status: active\`. The others are listed without their \`appearance:\` because it is withheld, not because it is empty, and rewriting one you cannot see discards everything already recorded about how that character looks.
 
-When to use \`replaceVisualDescriptors\`:
-- ANY visual change (new outfit, new accessory, injury, etc.)
-- Existing descriptors are bloated/redundant (consolidate them!)
-- Character was missing descriptors (fill them in now)
+When to send it:
+- ANY visual change (new outfit, new accessory, injury)
+- The listed appearance is bloated or self-contradictory (consolidate it)
+- An active character is listed with no \`appearance:\` at all — they have none yet, so invent one now, on the same terms as a new character
 
-The replacement list should:
-- Include ALL categories: face, hair, eyes, build, clothing, accessories, distinguishing marks
-- Be ~5-10 concise descriptors (one phrase per feature)
-- Merge redundant entries (e.g., multiple "Face:" entries → one)
-- Update changed details (new clothes replace old clothes)
-- Keep unchanged details from the original
-
-Example: If character has bloated appearance with duplicate Face/Hair/Eyes entries, output a single clean \`replaceVisualDescriptors\` array with one entry per category.
-
-**Goal:** Descriptors should be CONCISE but COMPLETE - detailed enough to draw the character, but without redundancy. Always output ~5-10 descriptors, never 20+.
+Your version must:
+- Cover ALL categories: face, hair, eyes, build, clothing, accessories, distinguishing
+- Keep every unchanged detail from the listed appearance, where one is listed
+- Merge duplicates into one phrase per category
+- Stay concise: detailed enough to draw the character, never a paragraph per category
 
 ### Locations - ONLY extract if:
 - The scene takes place there or characters travel there
@@ -63,11 +57,23 @@ Example: If character has bloated appearance with duplicate Face/Hair/Eyes entri
 - Example: "The scene shifts to the Thornwood Tavern" = YES
 - Example: "Mountains visible in the distance" = NO
 
+### Current Location - \`currentLocationName\`:
+The name of the place the passage ENDS in. This is what moves the scene, so treat it as a move order:
+- Repeat the location marked \`current: true\` in the list whenever the scene has not moved. Leaving it out changes nothing, but a different name moves the story
+- A name that is not in the list creates a new location, so spell an existing one exactly as listed
+- Only somewhere the characters actually are — not a place they discuss, remember, or can see in the distance
+- \`null\` if the passage genuinely gives no place
+
+Its description is a **whole-value replacement**, so send \`description\` only for the location whose current text you can see above, and only when this passage genuinely changes what the place is. To add a detail without touching the rest, use \`descriptionAddition\`.
+
 ### Items - ONLY extract if:
 - A character explicitly acquires, picks up, or is given the item
 - The item has narrative significance (plot item, weapon, key, etc.)
 - Example: "She hands over an ancient amulet" = YES
 - Example: "There's a bottle on the shelf" = NO
+
+### Item Updates - what the listed state means:
+Anything not printed under an item is at its default: one of it, not equipped, in {{ protagonistName }}'s inventory. Send \`quantity\`, \`equipped\` or \`location\` only when the passage changes one of them.
 
 ### Story Beats - ONLY extract if:
 - A task, quest, or plot thread is introduced or resolved
@@ -84,13 +90,17 @@ Example: If character has bloated appearance with duplicate Face/Hair/Eyes entri
 - This prevents story beats from stacking up indefinitely
 - Example: If "Find the missing brother" was active and the brother is found, mark it completed
 
-### Character Status - who is in the scene right now:
-- \`active\` means present in the current scene. It does not mean important, and it does not mean alive
-- Set \`inactive\` for any character listed above as \`active\` who is no longer in the scene, and \`active\` again when they return
-- The text will rarely state that someone left, so do not wait to read it — compare the list against the scene yourself
-- Silence is not absence: a character who is in the scene but says nothing stays \`active\`
-- Example: the party leaves the tavern and the innkeeper stays behind = mark the innkeeper \`inactive\`
-- This prevents every character in the story from being reported to the narrator as present
+### Scene Presence - \`presentCharacterNames\`:
+This is the list of who is in the scene at the END of the passage. It is the only place you report presence, and everyone you leave out is treated as away — so it has to be complete.
+- Include every character physically there, whether or not they speak. Leave out {{ protagonistName }}, who is in every scene by definition
+- Silence is not absence: someone who is present but says nothing still belongs on the list
+- Leave out anyone who left, stayed behind, or is only being talked about
+- Copy names **exactly** as they appear in the character list; a name you spell differently is a different character
+- A character who returns simply reappears on the list — nothing else is needed
+- Never return an empty list while anyone is in the scene. An empty list means "no answer", not "an empty room"
+- Example: the party leaves the tavern and the innkeeper stays behind = the innkeeper is not on the list
+
+Use \`characterUpdates.status\` only for a change the scene itself states: \`deceased\` when a character dies. Leaving someone off \`presentCharacterNames\` already handles walking out of the room.
 
 ### Time Progression - ALWAYS assess how much time passed:
 Determine how much narrative time elapsed during this passage. Consider what activities occurred and how long they would realistically take.
@@ -100,7 +110,6 @@ Determine how much narrative time elapsed during this passage. Consider what act
 - Quick actions (drawing a weapon, opening a door, picking something up)
 - Immediate reactions or observations
 - Example: "She nodded and replied, 'I understand.'" = none
-- Example: "He drew his sword and faced the enemy." = none
 
 **"minutes"** - A short period passes (will add ~15 minutes):
 - Extended conversations or negotiations
@@ -109,7 +118,6 @@ Determine how much narrative time elapsed during this passage. Consider what act
 - Eating a quick meal, getting dressed
 - Walking a short distance within the same location
 - Example: "They discussed the plan in detail, weighing each option." = minutes
-- Example: "She searched the study, checking every drawer." = minutes
 
 **"hours"** - A moderate period passes (will add ~2 hours):
 - Traveling between locations (walking across town, riding to a nearby village)
@@ -117,7 +125,6 @@ Determine how much narrative time elapsed during this passage. Consider what act
 - Waiting for something or someone
 - A complex task requiring sustained effort
 - Example: "They rode through the forest until reaching the crossroads." = hours
-- Example: "He spent the afternoon studying the ancient texts." = hours
 
 **"days"** - Significant time passes (will add 1 day):
 - Sleeping, resting overnight, or waking up the next day
@@ -125,16 +132,17 @@ Determine how much narrative time elapsed during this passage. Consider what act
 - Explicit time skips ("days later", "the following week")
 - Extended recovery from injury or illness
 - Example: "She slept through the night and woke at dawn." = days
-- Example: "After three days of travel, they finally arrived." = days
 
 **When uncertain:** Lean toward incrementing time rather than "none" - stories feel more dynamic when time progresses. If any notable activity occurred beyond immediate dialogue/reactions, choose at least "minutes".
 
 ## Critical Rules
 1. When in doubt, DO NOT extract - false positives pollute the world state
 2. Only extract what ACTUALLY HAPPENED, not what might happen
-3. Use the exact names from the text, don't invent or embellish
-4. ALWAYS check if active story beats should be marked completed or failed
-5. ALWAYS assess timeProgression - prefer incrementing time over "none" when activities occur`,
+3. Never invent an entity, an event, or a name. Visual descriptors are the one exception: those you fill in
+4. Use names exactly as the text and the entity list spell them
+5. ALWAYS check if active story beats should be marked completed or failed
+6. ALWAYS assess timeProgression - prefer incrementing time over "none" when activities occur
+7. ALWAYS list who is in the scene in \`presentCharacterNames\` - it is never optional`,
   // Ordered by how often each block changes, not by how the task reads.
   //
   // With prefix KV caching, everything up to the first token that differs from the previous
@@ -155,7 +163,10 @@ Determine how much narrative time elapsed during this passage. Consider what act
 ## Setting
 {{ genre }}
 Mode: {{ mode }}
-
+{% if settingDescription != blank %}{{ settingDescription }}
+{% endif %}{% if tone != blank %}Tone: {{ tone }}
+{% endif %}{% if themes != blank %}Themes: {{ themes }}
+{% endif %}
 ## Already Known Entities (check before adding duplicates)
 A name is the whole of its bullet line. Anything indented under it is that entity's current
 state, never part of its name. When you refer to an entity that is already listed, copy its
@@ -171,14 +182,13 @@ appended to it creates a second copy of the same character.
 ### Items
 {{ existingItems }}
 
-## Active Story Beats (update these when resolved!)
+{% if hasStoryBeats %}## Active Story Beats (update these when resolved!)
 {{ existingBeats }}
 
-{% if customVariableInstructions != blank %}
+{% endif %}{% if customVariableInstructions != blank %}
 {{ customVariableInstructions }}
 {% endif %}
 ## Context
-Already tracking: {{ entityCounts }}
 {{ currentTimeInfo }}
 {{ chatHistoryBlock }}
 ## {{ inputLabel }}
@@ -190,12 +200,12 @@ Already tracking: {{ entityCounts }}
 """
 
 ## Your Task
-1. Check if any EXISTING entities need updates (status change, new info learned, etc.)
-2. **IMPORTANT**: Check if any active story beats have been COMPLETED or FAILED in this passage - mark them accordingly to keep the list clean
-3. Identify any NEW significant entities introduced (apply the extraction rules strictly)
-4. Determine the current scene state
+1. Check if any EXISTING entities need updates (new info learned, a death, an appearance that changed)
+{% if hasStoryBeats %}2. **IMPORTANT**: Check if any active story beats have been COMPLETED or FAILED in this passage - mark them accordingly to keep the list clean
+{% endif %}3. Identify any NEW significant entities introduced (apply the extraction rules strictly)
+4. Set \`presentCharacterNames\`, \`currentLocationName\` and \`timeProgression\`
 
-Empty arrays are fine - don't invent entities that aren't clearly in the text.`,
+Empty arrays are fine everywhere except \`presentCharacterNames\` - don't invent entities that aren't clearly in the text.`,
 }
 
 const styleReviewerPromptTemplate: PromptTemplate = {
@@ -212,7 +222,7 @@ Identify overused phrases, sentence patterns, structural repetition, and stylist
 
 ### Phrase-Level Repetition
 - Repeated descriptive phrases (e.g., "eyes widening", "heart pounding")
-- Overused sentence openers (e.g., "You see", "There is")
+- Overused sentence openers (e.g., "There is", "It was")
 - Cliche expressions and purple prose patterns
 - Repetitive dialogue tags or action beats
 - Word echoes within close proximity

--- a/src/lib/services/prompts/templates/memory.ts
+++ b/src/lib/services/prompts/templates/memory.ts
@@ -140,11 +140,12 @@ An entry is pulled into the narrator's prompt when its **name**, one of its **al
 
 ## Tools
 
-- **The two lists below are complete.** Every chapter is there with its full summary — there is no tool that lists chapters, and there is nothing else to see. Every lorebook entry is there with the index the tools take; \`read_entry\` gives you one entry's full text, and \`list_entries\` is only worth calling *after* you have merged or deleted something, to see the list as it then stands.
+- **The two lists below are complete.** Every chapter is there with its full summary, and every lorebook entry is there with the index the tools take. There is no tool that lists either of them: what you have is all there is, and \`read_entry\` gives you one entry's full text when its one-line summary is not enough.
+- **Your own results tell you where things moved.** A merge reports the index its result landed at and which indices it consumed; a creation reports its index too. An index you have already merged or deleted is refused by every tool, and that refusal is not a reason to look for the entry elsewhere — it means that work is done.
 {% if hasChapters %}- Use query_chapter when a summary is not enough, and ask a specific question ("What did [character] reveal?", never "Give me the full content"). Each call reads a whole chapter with a second model, there are a few per session, and asking the same question twice returns the first answer rather than reading again.
 {% else %}- There are no chapters, so query_chapter has nothing to read. Do not spend steps on it.
 {% endif %}
-When every duplicate group is closed and your changes are made, call finish_lore_management with a summary.`,
+**Consolidating is the first step, not the whole job.**{% if hasStoryMaterial %} Once the groups are closed, go back over the chapter summaries and the recent story: entries the events have outdated are step 2, a subject that matters and has no entry at all is step 3. That is what those two lists are in front of you for, and a session that only merged duplicates has done a third of its work.{% endif %} Call finish_lore_management with a summary of what you changed when all of it is done.`,
   // Stable material first, volatile material last: with prefix KV caching everything up to
   // the first differing token is reused. The chapter summaries change only when a chapter
   // is written, the entry list only when the lorebook changes, and the duplicate worklist

--- a/src/lib/services/prompts/templates/narrative.ts
+++ b/src/lib/services/prompts/templates/narrative.ts
@@ -81,8 +81,8 @@ When [LOREBOOK CONTEXT] is provided, treat it as canonical:
 - Purple prose: overwrought metaphors, consecutive similes, excessive adjectives
 - Epithets: "the dark-haired woman"—use names or pronouns after introduction
 - Banned words: orbs (for eyes), tresses, alabaster, porcelain, delve, visceral, palpable
-- Telling emotions: "You felt angry"—show through physical sensation instead
-- Ending with direct questions like "What do you do?"
+- Telling emotions outright: "felt angry", "was terrified"—show through physical sensation instead
+- Ending by asking the player what they do next
 - Recapping previous events at the start of responses
 - Explanation chains: NPCs spelling out "A, therefore B, therefore C"
 - Formal hedging: "Protocol dictates," "It would suggest," "My assessment remains"

--- a/src/lib/services/prompts/templates/wizard.ts
+++ b/src/lib/services/prompts/templates/wizard.ts
@@ -129,7 +129,7 @@ const openingGenerationAdventurePromptTemplate: PromptTemplate = {
 1. **NEVER write what {{ protagonistName }} does** - no actions, movements, or gestures
 2. **NEVER write what {{ protagonistName }} says** - no dialogue or speech
 3. **NEVER write what {{ protagonistName }} thinks or feels** - no internal states, emotions, or reactions
-4. **NEVER write what {{ protagonistName }} perceives** - avoid "you see", "you notice", "you hear" constructions
+4. **NEVER write what {{ protagonistName }} perceives** - no seeing, noticing or hearing attributed to them, in any person
 5. **Only describe the environment, NPCs, and situation** - let {{ protagonistName }} decide how to engage
 </critical_constraints>
 
@@ -143,7 +143,7 @@ Write ONLY:
 
 Do NOT write:
 - "{{ protagonistName }} walks into..." / "{{ protagonistName }} looks at..." / "{{ protagonistName }} feels..."
-- "You notice..." / "You see..." / "You sense..."
+- The same in second person, whatever pronoun the point of view uses
 - Any action, perception, or internal state belonging to {{ protagonistName }}
 </what_to_write>
 
@@ -173,7 +173,7 @@ End by presenting a situation that naturally invites {{ protagonistName }} to ac
 - An object of interest within reach
 - A choice point or moment of tension
 
-NO questions. NO "What do you do?" Just the pregnant moment.
+NO questions. Never ask the player what they do. Just the pregnant moment.
 </ending>
 
 <prohibited_patterns>
@@ -296,7 +296,7 @@ const openingRefinementAdventurePromptTemplate: PromptTemplate = {
 1. **NEVER write what {{ protagonistName }} does** - no actions, movements, or gestures
 2. **NEVER write what {{ protagonistName }} says** - no dialogue or speech
 3. **NEVER write what {{ protagonistName }} thinks or feels** - no internal states, emotions, or reactions
-4. **NEVER write what {{ protagonistName }} perceives** - avoid "you see", "you notice", "you hear" constructions
+4. **NEVER write what {{ protagonistName }} perceives** - no seeing, noticing or hearing attributed to them, in any person
 5. **Only describe the environment, NPCs, and situation** - let {{ protagonistName }} decide how to engage
 </critical_constraints>
 
@@ -334,7 +334,7 @@ End by presenting a situation that naturally invites {{ protagonistName }} to ac
 - An object of interest within reach
 - A choice point or moment of tension
 
-NO questions. NO "What do you do?" Just the pregnant moment.
+NO questions. Never ask the player what they do. Just the pregnant moment.
 </ending>
 
 <prohibited_patterns>

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -202,6 +202,10 @@ export function getDefaultAdvancedRequestSettings(): AdvancedRequestSettings {
 }
 
 // Classifier service settings (World State Classifier - extracts entities from narrative)
+/** The window the classifier reads, in whole story entries. Shared with the slider. */
+export const CLASSIFIER_WINDOW_MIN = 2
+export const CLASSIFIER_WINDOW_MAX = 15
+
 export interface ClassifierSettings {
   presetId?: string
   profileId: string | null // API profile to use (null = use default profile)
@@ -210,11 +214,23 @@ export interface ClassifierSettings {
   maxTokens: number
   reasoningEffort: ReasoningEffort
   manualBody: string
-  chatHistoryTruncation: number // Max words per chat history entry (0 = no truncation, up to 500)
+  recentEntriesWindow: number // Recent story entries sent whole as context, 2-15
 }
 
 export function getDefaultClassifierSettings(): ClassifierSettings {
   return getDefaultClassifierSettingsForProvider('openrouter')
+}
+
+/** A stored window outside the slider's range, back inside it. */
+function clampClassifierWindow(loaded: ClassifierSettings): ClassifierSettings {
+  const window = Math.round(loaded.recentEntriesWindow)
+  if (!Number.isFinite(window)) {
+    return { ...loaded, recentEntriesWindow: getDefaultClassifierSettings().recentEntriesWindow }
+  }
+  return {
+    ...loaded,
+    recentEntriesWindow: Math.min(Math.max(window, CLASSIFIER_WINDOW_MIN), CLASSIFIER_WINDOW_MAX),
+  }
 }
 
 export function getDefaultClassifierSettingsForProvider(
@@ -229,7 +245,7 @@ export function getDefaultClassifierSettingsForProvider(
     maxTokens: 8192,
     reasoningEffort: preset.reasoningEffort,
     manualBody: '',
-    chatHistoryTruncation: 0,
+    recentEntriesWindow: 7,
   }
 }
 
@@ -674,6 +690,14 @@ export interface TTSServiceSettings {
   removeAllHtmlContent: boolean // Removes content within all HTML tags (default: false)
   htmlTagsToRemoveContent: string // Specific HTML tags to remove content from (default: span, div)
   provider: 'openai' | 'google' | 'microsoft' // TTS Provider (default: 'openai')
+  /**
+   * Audio container asked of an OpenAI-compatible endpoint.
+   *
+   * MP3 by default, because it is the OpenAI default and roughly a fifth of the bytes.
+   * A local runtime built without an MP3 encoder answers it with a 400 and serves WAV
+   * instead — hence the choice rather than a constant. Other providers do not read this.
+   */
+  responseFormat: 'mp3' | 'wav'
   volume: number // TTS volume 0.0-1.0 (default: 1.0)
   volumeOverride: boolean // Enable volume override (default: false)
   providerVoices: Record<string, string> // Provider-specific voices
@@ -702,6 +726,7 @@ export function getDefaultTTSSettings(): TTSServiceSettings {
     removeAllHtmlContent: false,
     htmlTagsToRemoveContent: 'span, div',
     provider: 'openai',
+    responseFormat: 'mp3',
     volume: 1.0,
     volumeOverride: false,
     providerVoices: { openai: 'alloy', google: 'en', microsoft: '' },
@@ -725,6 +750,7 @@ export function getDefaultTTSSettingsForProvider(_provider: ProviderType): TTSSe
     removeAllHtmlContent: false,
     htmlTagsToRemoveContent: 'span, div',
     provider: 'openai',
+    responseFormat: 'mp3',
     volume: 1.0,
     volumeOverride: false,
     providerVoices: { openai: 'alloy', google: 'en', microsoft: '' },
@@ -778,10 +804,6 @@ export function getDefaultCharacterCardImportSettingsForProvider(
 
 // Combined system services settings
 // Service-specific settings (only extra fields, not generation config)
-export interface ClassifierSpecificSettings {
-  chatHistoryTruncation: number
-}
-
 export interface LorebookClassifierSpecificSettings {
   batchSize: number
   maxConcurrent: number
@@ -860,7 +882,6 @@ export interface TTSSpecificSettings {
 export type CharacterCardImportSpecificSettings = object
 
 export interface ServiceSpecificSettings {
-  classifier: ClassifierSpecificSettings
   lorebookClassifier: LorebookClassifierSpecificSettings
   suggestions: SuggestionsSpecificSettings
   actionChoices: ActionChoicesSpecificSettings
@@ -891,7 +912,6 @@ export function getDefaultExperimentalFeatures(): ExperimentalFeatures {
 
 export function getDefaultServiceSpecificSettings(): ServiceSpecificSettings {
   return {
-    classifier: getDefaultClassifierSpecificSettings(),
     lorebookClassifier: getDefaultLorebookClassifierSpecificSettings(),
     suggestions: getDefaultSuggestionsSpecificSettings(),
     actionChoices: getDefaultActionChoicesSpecificSettings(),
@@ -905,12 +925,6 @@ export function getDefaultServiceSpecificSettings(): ServiceSpecificSettings {
     characterCardImport: getDefaultCharacterCardImportSpecificSettings(),
     contextWindow: getDefaultContextWindowSettings(),
     lorebookLimits: getDefaultLorebookLimitsSettings(),
-  }
-}
-
-export function getDefaultClassifierSpecificSettings(): ClassifierSpecificSettings {
-  return {
-    chatHistoryTruncation: 0,
   }
 }
 
@@ -1656,7 +1670,6 @@ class SettingsStore {
         try {
           const loaded = JSON.parse(serviceSpecificJson)
           this.serviceSpecificSettings = {
-            classifier: { ...getDefaultClassifierSpecificSettings(), ...loaded.classifier },
             lorebookClassifier: {
               ...getDefaultLorebookClassifierSpecificSettings(),
               ...loaded.lorebookClassifier,
@@ -1713,7 +1726,9 @@ class SettingsStore {
             this.getDefaultProviderType(),
           )
           this.systemServicesSettings = {
-            classifier: { ...defaults.classifier, ...loaded.classifier },
+            // `recentEntriesWindow` reaches `recentContent`, where a zero returns the empty
+            // string rather than an error: the classifier would lose its history in silence.
+            classifier: clampClassifierWindow({ ...defaults.classifier, ...loaded.classifier }),
             lorebookClassifier: { ...defaults.lorebookClassifier, ...loaded.lorebookClassifier },
             memory: { ...defaults.memory, ...loaded.memory },
             suggestions: { ...defaults.suggestions, ...loaded.suggestions },
@@ -1875,9 +1890,17 @@ class SettingsStore {
     await database.setSetting('max_tokens', tokens.toString())
   }
 
+  /**
+   * Clamped here rather than only in the form: this value is also the wait before an image
+   * is called stuck, so a zero would offer the retry on every image the moment it queues.
+   */
   async setLlmTimeout(timeoutMs: number) {
-    this.apiSettings.llmTimeoutMs = timeoutMs
-    await database.setSetting('llm_timeout_ms', timeoutMs.toString())
+    // `Math.max(NaN, …)` is NaN, and it would reach both the live setting and the stored
+    // string — where it survives as "NaN" until someone moves the slider.
+    const requested = Number.isFinite(timeoutMs) ? timeoutMs : LLM_TIMEOUT_DEFAULT
+    const clamped = Math.min(Math.max(requested, LLM_TIMEOUT_MIN), LLM_TIMEOUT_MAX)
+    this.apiSettings.llmTimeoutMs = clamped
+    await database.setSetting('llm_timeout_ms', clamped.toString())
   }
 
   /**

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -223,10 +223,12 @@ export function getDefaultClassifierSettings(): ClassifierSettings {
 
 /** A stored window outside the slider's range, back inside it. */
 function clampClassifierWindow(loaded: ClassifierSettings): ClassifierSettings {
-  const window = Math.round(loaded.recentEntriesWindow)
-  if (!Number.isFinite(window)) {
+  // Checked before rounding: `Math.round(null)` is 0, which is finite and would clamp to the
+  // slider's minimum instead of restoring the default.
+  if (!Number.isFinite(loaded.recentEntriesWindow)) {
     return { ...loaded, recentEntriesWindow: getDefaultClassifierSettings().recentEntriesWindow }
   }
+  const window = Math.round(loaded.recentEntriesWindow)
   return {
     ...loaded,
     recentEntriesWindow: Math.min(Math.max(window, CLASSIFIER_WINDOW_MIN), CLASSIFIER_WINDOW_MAX),
@@ -575,6 +577,10 @@ export interface EntryRetrievalSettings {
   reasoningEffort: ReasoningEffort
   manualBody: string
 }
+
+/** The window Tier 2/Tier 3 retrieval scans, in whole story entries. Shared with the slider. */
+export const ENTRY_RETRIEVAL_WINDOW_MIN = 2
+export const ENTRY_RETRIEVAL_WINDOW_MAX = 15
 
 export function getDefaultEntryRetrievalSettings(): EntryRetrievalSettings {
   return getDefaultEntryRetrievalSettingsForProvider('openrouter')

--- a/src/lib/stores/story.svelte.ts
+++ b/src/lib/stores/story.svelte.ts
@@ -20,6 +20,7 @@ import type {
   LocationBeforeState,
   ItemBeforeState,
   StoryBeatBeforeState,
+  ImageGenerationMode,
 } from '$lib/types'
 import { database } from '$lib/services/database'
 import { rollbackService } from '$lib/services/rollbackService'
@@ -49,12 +50,14 @@ import {
   ChapterBatchService,
   buildLoreManagementCallbacks,
   buildLoreManagementUICallbacks,
+  resolveCharacterPresence,
   type WorldState,
 } from '$lib/services/generation'
 import { createLogger } from '$lib/log'
 import { sameEntityName } from '$lib/utils/text'
 import { grammarService } from '$lib/services/grammar'
 import { clearTier3SelectionCache } from '$lib/services/ai'
+import { clearImageMarkerCache } from '$lib/services/image'
 
 const log = createLogger('StoryStore')
 
@@ -518,6 +521,7 @@ class StoryStore {
     this.invalidateChapterCache()
     grammarService.clearEntityWords()
     clearTier3SelectionCache()
+    clearImageMarkerCache()
   }
 
   // Close the current story and reset state
@@ -551,6 +555,7 @@ class StoryStore {
 
     // Whatever the previous story left cached is about a pool this one does not have.
     clearTier3SelectionCache()
+    clearImageMarkerCache()
 
     this.currentStory = story
     this.currentBgImage = await database.getBackgroundForBranch(storyId, story.currentBranchId)
@@ -2354,7 +2359,8 @@ class StoryStore {
             name: newLocData?.name ?? update.name,
             description: newLocData?.description ?? null,
             visited: newLocData?.visited ?? false,
-            current: newLocData?.current ?? false,
+            // Only `scene.currentLocationName` moves the scene.
+            current: false,
             connections: [],
             metadata: locMetadata,
             branchId: this.currentStory?.currentBranchId ?? null,
@@ -2393,49 +2399,6 @@ class StoryStore {
           // COW: ensure entity is owned by current branch before updating
           const { entity: ownedLoc, wasCowed: locWasCowed } = await this.cowLocation(existing)
 
-          if (update.changes.current === true) {
-            changes.visited = true
-            if (this.isCowBranch()) {
-              // COW-aware: targeted updates instead of blanket clear
-              const prevCurrent = this.locations.find((l) => l.current && l.id !== ownedLoc.id)
-              if (prevCurrent) {
-                const { entity: ownedPrev, wasCowed: prevWasCowed } =
-                  await this.cowLocation(prevCurrent)
-                await database.updateLocation(ownedPrev.id, { current: false })
-                this.locations = this.locations.map((l) =>
-                  l.id === ownedPrev.id ? { ...l, current: false } : l,
-                )
-                if (prevWasCowed && trackingEnabled) {
-                  createdLocationIds.push(ownedPrev.id)
-                  const prevIdx = locationsBefore.findIndex((lb) => lb.id === prevCurrent.id)
-                  if (prevIdx !== -1) locationsBefore.splice(prevIdx, 1)
-                }
-              }
-              await database.updateLocation(ownedLoc.id, { ...changes, current: true })
-              this.locations = this.locations.map((l) =>
-                l.id === ownedLoc.id ? { ...l, ...changes, current: true, visited: true } : l,
-              )
-            } else {
-              await database.setCurrentLocation(storyId, ownedLoc.id)
-              if (Object.keys(changes).length > 0) {
-                await database.updateLocation(ownedLoc.id, changes)
-              }
-              this.locations = this.locations.map((l) => {
-                if (l.id === ownedLoc.id) {
-                  return { ...l, ...changes, current: true, visited: true }
-                }
-                return { ...l, current: false }
-              })
-            }
-            if (locWasCowed && trackingEnabled) {
-              createdLocationIds.push(ownedLoc.id)
-              const idx = locationsBefore.findIndex((lb) => lb.id === existing.id)
-              if (idx !== -1) locationsBefore.splice(idx, 1)
-            }
-            return
-          }
-
-          if (update.changes.current === false) changes.current = false
           if (Object.keys(changes).length === 0) {
             // Even if no changes, track COW if it happened
             if (locWasCowed && trackingEnabled) {
@@ -2715,10 +2678,6 @@ class StoryStore {
           if (newLoc.visited !== undefined && newLoc.visited !== existing.visited) {
             changes.visited = newLoc.visited
           }
-          if (newLoc.current && !existing.current) {
-            changes.current = true
-            changes.visited = true
-          }
           // Merge inline runtime variable values into metadata if present
           const newLocInlineVars = extractInlineCustomVars(
             newLoc as unknown as Record<string, unknown>,
@@ -2735,25 +2694,6 @@ class StoryStore {
           }
         } else if (!existing) {
           log('Adding new location:', newLoc.name)
-          // If this is the current location, unset others first
-          if (newLoc.current) {
-            if (this.isCowBranch()) {
-              // COW-aware: targeted unset of previous current
-              const prevCurrent = this.locations.find((l) => l.current)
-              if (prevCurrent) {
-                const { entity: ownedPrev } = await this.cowLocation(prevCurrent)
-                await database.updateLocation(ownedPrev.id, { current: false })
-                this.locations = this.locations.map((l) =>
-                  l.id === ownedPrev.id ? { ...l, current: false } : l,
-                )
-              }
-            } else {
-              this.locations = this.locations.map((l) => ({ ...l, current: false }))
-              for (const l of this.locations) {
-                await database.updateLocation(l.id, { current: false })
-              }
-            }
-          }
           const locMetadata: Record<string, unknown> = { source: 'classifier' }
           const newLocInlineVars = extractInlineCustomVars(
             newLoc as unknown as Record<string, unknown>,
@@ -2768,7 +2708,8 @@ class StoryStore {
             name: newLoc.name,
             description: newLoc.description ?? null,
             visited: newLoc.visited ?? false,
-            current: newLoc.current ?? false,
+            // Only `scene.currentLocationName` moves the scene, and it runs before this.
+            current: false,
             connections: [],
             metadata: locMetadata,
             branchId: this.currentStory?.currentBranchId ?? null,
@@ -2844,6 +2785,53 @@ class StoryStore {
       })
     }
 
+    // Reconcile who is in the scene. Last, so the characters this classification created
+    // are already in `this.characters` and the explicit updates above have had their say.
+    const presenceChanges = resolveCharacterPresence({
+      characters: this.characters,
+      presentNames: result.scene.presentCharacterNames ?? [],
+      newNames: result.entryUpdates.newCharacters.map((c) => c.name),
+      explicitStatusNames: result.entryUpdates.characterUpdates
+        .filter((u) => u.changes.status !== undefined)
+        .map((u) => u.name),
+      hadError: !!result._error,
+    })
+
+    for (const change of presenceChanges) {
+      const char = this.characters.find((c) => c.id === change.id)
+      if (!char) continue
+
+      await this.wrapUpdate(
+        change.to === 'active' ? 'Character enters scene' : 'Character leaves scene',
+        char.name,
+        async () => {
+          if (trackingEnabled && !charactersBefore.some((cb) => cb.id === char.id)) {
+            charactersBefore.push({
+              id: char.id,
+              name: char.name,
+              status: char.status,
+              relationship: char.relationship,
+              traits: [...char.traits],
+              visualDescriptors: { ...char.visualDescriptors },
+              metadata: char.metadata ? { ...char.metadata } : null,
+            })
+          }
+
+          const { entity: ownedChar, wasCowed } = await this.cowCharacter(char)
+          await database.updateCharacter(ownedChar.id, { status: change.to })
+          this.characters = this.characters.map((c) =>
+            c.id === ownedChar.id ? { ...c, status: change.to } : c,
+          )
+
+          if (wasCowed && trackingEnabled) {
+            createdCharacterIds.push(ownedChar.id)
+            const idx = charactersBefore.findIndex((cb) => cb.id === char.id)
+            if (idx !== -1) charactersBefore.splice(idx, 1)
+          }
+        },
+      )
+    }
+
     // Apply time progression from scene data
     if (result.scene.timeProgression && result.scene.timeProgression !== 'none') {
       await this.applyTimeProgression(result.scene.timeProgression)
@@ -2912,12 +2900,17 @@ class StoryStore {
       result.entryUpdates.characterUpdates.length > 0 ||
       result.entryUpdates.locationUpdates.length > 0 ||
       result.entryUpdates.itemUpdates.length > 0 ||
-      result.entryUpdates.storyBeatUpdates.length > 0
+      result.entryUpdates.storyBeatUpdates.length > 0 ||
+      // Presence is inferred from `scene`, not from `entryUpdates`, so a turn whose only
+      // effect is someone walking out wrote statuses and announced nothing.
+      presenceChanges.length > 0
 
     if (hasChanges) {
       emitStateUpdated({
         characters:
-          result.entryUpdates.newCharacters.length + result.entryUpdates.characterUpdates.length,
+          result.entryUpdates.newCharacters.length +
+          result.entryUpdates.characterUpdates.length +
+          presenceChanges.length,
         locations:
           result.entryUpdates.newLocations.length + result.entryUpdates.locationUpdates.length,
         items: result.entryUpdates.newItems.length + result.entryUpdates.itemUpdates.length,
@@ -3908,6 +3901,7 @@ class StoryStore {
     // verdict. The key covers this on its own now; clearing keeps the cache from
     // depending on that alone, as it already does on story switch.
     clearTier3SelectionCache()
+    clearImageMarkerCache()
 
     // Announce once entries and caches are correct. Emitted before the
     // background/suggestion restores below so a failure in either can't
@@ -4494,7 +4488,7 @@ class StoryStore {
       tone?: string
       themes?: string[]
       visualProseMode?: boolean
-      imageGenerationMode?: 'none' | 'agentic' | 'inline'
+      imageGenerationMode?: ImageGenerationMode
       backgroundImagesEnabled?: boolean
       referenceMode?: boolean
     }

--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -143,7 +143,15 @@ class UIStore {
   isStreaming = $state(false)
   private htmlRenderer: StreamingHtmlRenderer | null = null
   private visualProseEntryId: string | null = null
-  private tokenCountInterval: ReturnType<typeof setInterval> | null = null
+  /**
+   * When the streaming token count was last recomputed.
+   *
+   * Counting is a full BPE pass over everything received so far, so a timer re-tokenizes
+   * the whole response several times a second for as long as it runs — and keeps doing it
+   * while the stream is stalled. Throttling the appends instead keeps the same cadence on
+   * screen and does the work only when there is new text.
+   */
+  private lastTokenCountAt = 0
 
   // Scroll break state - persists until user sends a new message
   userScrolledUp = $state(false)
@@ -284,6 +292,7 @@ class UIStore {
    */
   lastLoreManagementSummary = $state<string | null>(null)
   lastLoreManagementChanges = $state<number>(0)
+  loreManagementError = $state<string | null>(null)
 
   // Lorebook activation tracking for stickiness
   // Maps entry ID -> last activation position (story entry index)
@@ -487,12 +496,7 @@ class UIStore {
 
   // Streaming methods
   startStreaming(visualProseMode = false, entryId?: string) {
-    // Ensure any existing interval is cleared to prevent leaks
-    if (this.tokenCountInterval) {
-      clearInterval(this.tokenCountInterval)
-      this.tokenCountInterval = null
-    }
-
+    this.lastTokenCountAt = 0
     this.isStreaming = true
     this.streamingContent = ''
     this.streamingReasoning = ''
@@ -505,10 +509,14 @@ class UIStore {
       this.htmlRenderer = null
       this.visualProseEntryId = null
     }
-    // Start periodic token counting (every 500ms to avoid performance issues)
-    this.tokenCountInterval = setInterval(() => {
-      this.updateStreamingTokenCount()
-    }, 500)
+  }
+
+  /** Recount at most twice a second, and only when a chunk has just landed. */
+  private countStreamingTokensThrottled() {
+    const now = Date.now()
+    if (now - this.lastTokenCountAt < 500) return
+    this.lastTokenCountAt = now
+    this.updateStreamingTokenCount()
   }
 
   private updateStreamingTokenCount() {
@@ -525,18 +533,15 @@ class UIStore {
     } else {
       this.streamingContent += content
     }
+    this.countStreamingTokensThrottled()
   }
 
   appendReasoningContent(content: string) {
     this.streamingReasoning += content
+    this.countStreamingTokensThrottled()
   }
 
   endStreaming(): string {
-    // Clear token count interval
-    if (this.tokenCountInterval) {
-      clearInterval(this.tokenCountInterval)
-      this.tokenCountInterval = null
-    }
     // Final token count update
     this.updateStreamingTokenCount()
 
@@ -1489,6 +1494,7 @@ class UIStore {
     this.loreManagementActive = true
     this.loreManagementProgress = 'Analyzing story content...'
     this.loreManagementChanges = 0
+    this.loreManagementError = null
     // The previous run's account stops being true the moment a new one starts writing.
     this.lastLoreManagementSummary = null
     // Close any open modals/edit modes since user can't edit during lore management
@@ -1508,6 +1514,14 @@ class UIStore {
   setLoreManagementSummary(summary: string, changeCount: number) {
     this.lastLoreManagementSummary = summary
     this.lastLoreManagementChanges = changeCount
+  }
+
+  setLoreManagementError(error: string | null) {
+    this.loreManagementError = error
+  }
+
+  clearLoreManagementError() {
+    this.loreManagementError = null
   }
 
   finishLoreManagement() {

--- a/src/lib/stores/wizard/narrativeStore.svelte.ts
+++ b/src/lib/stores/wizard/narrativeStore.svelte.ts
@@ -7,7 +7,7 @@ import {
 import { aiService } from '$lib/services/ai'
 import { TranslationService } from '$lib/services/ai/utils/TranslationService'
 import { settings } from '$lib/stores/settings.svelte'
-import type { StoryMode, POV, TargetLength, VaultLorebook } from '$lib/types'
+import type { StoryMode, POV, TargetLength, VaultLorebook, ImageGenerationMode } from '$lib/types'
 import type { ImportedLorebookItem } from '$lib/components/wizard/wizardTypes'
 import type { GeneratedOpening } from '$lib/services/ai/sdk'
 
@@ -28,7 +28,7 @@ export class NarrativeStore {
   selectedTense = $state<Tense>('present')
   tone = $state('immersive and engaging')
   visualProseMode = $state(false)
-  imageGenerationMode = $state<'none' | 'agentic' | 'inline'>('none')
+  imageGenerationMode = $state<ImageGenerationMode>('none')
   backgroundImagesEnabled = $state(false)
   referenceMode = $state(false)
   targetLength = $state<TargetLength>('dynamic')

--- a/src/lib/stores/wizard/stImportWizard.svelte.ts
+++ b/src/lib/stores/wizard/stImportWizard.svelte.ts
@@ -11,7 +11,14 @@ import { CharacterCardImport } from '$lib/services/characterCardImport'
 import { LorebookImportExport } from '$lib/services/lorebookImportExport'
 import { replaceUserPlaceholders } from '$lib/components/wizard/wizardTypes'
 import type { ImportedLorebookItem } from '$lib/components/wizard/wizardTypes'
-import type { StoryMode, POV, VaultCharacter, VaultLorebook, VaultLorebookEntry } from '$lib/types'
+import type {
+  StoryMode,
+  POV,
+  VaultCharacter,
+  VaultLorebook,
+  VaultLorebookEntry,
+  ImageGenerationMode,
+} from '$lib/types'
 import type {
   ExpandedSetting,
   GeneratedCharacter,
@@ -121,7 +128,7 @@ export class STImportWizardStore {
   selectedTense = $state<Tense>('present')
   tone = $state('immersive and engaging')
   visualProseMode = $state(false)
-  imageGenerationMode = $state<'none' | 'agentic' | 'inline'>('none')
+  imageGenerationMode = $state<ImageGenerationMode>('none')
   backgroundImagesEnabled = $state(false)
   referenceMode = $state(false)
   importChatAsEntries = $state(false) // true = import chat, false = fresh start with card opening

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -113,6 +113,9 @@ export interface MemoryConfig {
 /** Target narration length for a turn. Drives `{{ lengthInstruction }}` in the prompt. */
 export type TargetLength = 'short' | 'medium' | 'long' | 'dynamic'
 
+/** How a story generates images: not at all, on the model's initiative, or embedded in the prose. */
+export type ImageGenerationMode = 'none' | 'agentic' | 'inline'
+
 export interface StorySettings {
   model?: string
   temperature?: number
@@ -122,7 +125,7 @@ export interface StorySettings {
   tone?: string
   themes?: string[]
   visualProseMode?: boolean // Enable HTML/CSS visual output mode
-  imageGenerationMode?: 'none' | 'agentic' | 'inline' // Image generation strategy
+  imageGenerationMode?: ImageGenerationMode
   backgroundImagesEnabled?: boolean
   referenceMode?: boolean
   targetLength?: TargetLength

--- a/src/lib/utils/inlineImageParser.test.ts
+++ b/src/lib/utils/inlineImageParser.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest'
 import {
   extractPicTags,
   hasIncompletePicTag,
-  hasPicTags,
   stripPicTags,
   replacePicTagsWithPlaceholders,
   renderSinglePicTag,
@@ -153,13 +152,7 @@ describe('hasIncompletePicTag', () => {
   })
 })
 
-describe('hasPicTags / stripPicTags', () => {
-  it('detects both tag forms', () => {
-    expect(hasPicTags(SELF_CLOSING)).toBe(true)
-    expect(hasPicTags(PAIRED)).toBe(true)
-    expect(hasPicTags('no markup here')).toBe(false)
-  })
-
+describe('stripPicTags', () => {
   it('removes every tag and leaves the prose', () => {
     expect(stripPicTags(`One. ${SELF_CLOSING} Two. ${PAIRED} Three.`)).toBe('One.  Two.  Three.')
   })
@@ -187,12 +180,11 @@ describe('replacePicTagsWithPlaceholders', () => {
   })
 
   it('handles a prompt containing ">" in every rule, not just the parser', () => {
-    // All four used to share `[^>]*?` and all four used to miss this tag together, so a
-    // raw `<pic ...>` string reached rendered narration while `hasPicTags` and
-    // `stripPicTags` both reported there was nothing to strip.
+    // Every rule used to share `[^>]*?` and they all missed this tag together, so a raw
+    // `<pic ...>` string reached rendered narration while `stripPicTags` reported there
+    // was nothing to strip.
     const withAngle = '<pic prompt="a sign reading 10 > 9 above the door" />'
 
-    expect(hasPicTags(withAngle)).toBe(true)
     expect(stripPicTags(withAngle)).toBe('')
     expect(replacePicTagsWithPlaceholders(withAngle)).not.toContain('<pic')
     expect(extractPicTags(withAngle)).toHaveLength(1)
@@ -208,8 +200,35 @@ describe('replacePicTagsWithPlaceholders', () => {
 })
 
 describe('renderSinglePicTag', () => {
-  it('renders nothing when the tag has no image record', () => {
-    expect(renderSinglePicTag(SELF_CLOSING, new Map())).toBe('')
+  it('offers to recreate a tag whose image record is missing', () => {
+    const html = renderSinglePicTag(SELF_CLOSING, new Map())
+
+    expect(html).toContain('Image record missing')
+    expect(html).toContain('data-action="create-missing"')
+  })
+
+  it('offers a retry on an image that has been waiting too long', () => {
+    const map = imageMap(SELF_CLOSING, { status: 'generating' })
+    const id = map.get(SELF_CLOSING)!.id
+
+    expect(renderSinglePicTag(SELF_CLOSING, map)).not.toContain('data-action="regenerate"')
+    expect(renderSinglePicTag(SELF_CLOSING, map, { stuckIds: new Set([id]) })).toContain(
+      'data-action="regenerate"',
+    )
+  })
+
+  it('reports a missing record with no prompt, but offers nothing to generate from it', () => {
+    const html = renderSinglePicTag('<pic prompt="" />', new Map())
+
+    expect(html).toContain('Image record missing')
+    expect(html).not.toContain('data-action="create-missing"')
+  })
+
+  it('waits out the grace period before calling a missing record lost', () => {
+    const html = renderSinglePicTag(SELF_CLOSING, new Map(), { offerMissingRecovery: false })
+
+    expect(html).not.toContain('data-action="create-missing"')
+    expect(html).toContain('In queue...')
   })
 
   it('renders the finished image inline', () => {
@@ -221,11 +240,9 @@ describe('renderSinglePicTag', () => {
   })
 
   it('overlays the previous image while it is being regenerated', () => {
-    const html = renderSinglePicTag(
-      SELF_CLOSING,
-      imageMap(SELF_CLOSING, { status: 'complete' }),
-      new Set(['img-1']),
-    )
+    const html = renderSinglePicTag(SELF_CLOSING, imageMap(SELF_CLOSING, { status: 'complete' }), {
+      regeneratingIds: new Set(['img-1']),
+    })
 
     expect(html).toContain('regenerating')
     // The old image stays visible underneath rather than the frame going blank.
@@ -303,7 +320,7 @@ describe('PIC_TAG — malformed input', () => {
     const content = `<pic prompt="never closed ${'word '.repeat(4000)}`
 
     expect(extractPicTags(content)).toEqual([])
-    expect(hasPicTags(content)).toBe(false)
+    expect(stripPicTags(content)).toBe(content)
   })
 
   it('stays linear on a long run of paired quotes', () => {

--- a/src/lib/utils/inlineImageParser.test.ts
+++ b/src/lib/utils/inlineImageParser.test.ts
@@ -231,6 +231,31 @@ describe('renderSinglePicTag', () => {
     expect(html).toContain('In queue...')
   })
 
+  it('reports a tag past the per-message limit instead of offering a recovery', () => {
+    const html = renderSinglePicTag(SELF_CLOSING, new Map(), { overBudget: true })
+
+    expect(html).toContain('Past the per-message image limit')
+    expect(html).not.toContain('data-action="create-missing"')
+    expect(html).not.toContain('In queue...')
+  })
+
+  it('prefers the limit notice over the recovery offer', () => {
+    const html = renderSinglePicTag(SELF_CLOSING, new Map(), {
+      overBudget: true,
+      offerMissingRecovery: true,
+    })
+
+    expect(html).not.toContain('Image record missing')
+  })
+
+  it('leaves a recorded image alone when the entry is over budget', () => {
+    const html = renderSinglePicTag(SELF_CLOSING, imageMap(SELF_CLOSING, { status: 'complete' }), {
+      overBudget: true,
+    })
+
+    expect(html).not.toContain('Past the per-message image limit')
+  })
+
   it('renders the finished image inline', () => {
     const html = renderSinglePicTag(SELF_CLOSING, imageMap(SELF_CLOSING, { status: 'complete' }))
 

--- a/src/lib/utils/inlineImageParser.ts
+++ b/src/lib/utils/inlineImageParser.ts
@@ -203,6 +203,15 @@ function errorWithInfo(errorMsg: string, shortPrompt: string, imageId: string): 
  * from it, and the placeholder still has to appear: silently rendering it as the empty
  * string is how the markup went missing from the narration in the first place.
  */
+/** A tag past the per-message budget: no record, and none is coming. */
+function overBudgetInfo(shortPrompt: string): string {
+  return `<div class="placeholder-error-icon">${errorIconSvg}</div>
+    <div class="placeholder-info">
+      <span class="placeholder-status error">Past the per-message image limit</span>
+      <span class="placeholder-prompt">${escapeHtml(shortPrompt)}</span>
+    </div>`
+}
+
 function missingRecordInfo(prompt: string, shortPrompt: string): string {
   const action = prompt
     ? `\n    <button class="inline-image-btn create-missing-btn" data-action="create-missing" data-prompt="${escapeHtml(prompt)}" title="Recreate this image">Generate</button>`
@@ -245,6 +254,11 @@ export interface PicTagRenderOptions {
    * so taking it then would create a second record for every tag about to be flushed.
    */
   offerMissingRecovery?: boolean
+  /**
+   * The entry has spent its per-message image budget, so a tag without a record was skipped
+   * rather than lost. Reported as a limit: the rescan would refuse to recreate it.
+   */
+  overBudget?: boolean
 }
 
 /**
@@ -256,7 +270,7 @@ export function renderSinglePicTag(
   imageMap: Map<string, ImageReplacementInfo>,
   options: PicTagRenderOptions = {},
 ): string {
-  const { regeneratingIds, stuckIds, offerMissingRecovery = true } = options
+  const { regeneratingIds, stuckIds, offerMissingRecovery = true, overBudget = false } = options
   const attrMatch = match.match(picTagRegex('i'))
   const attrs = attrMatch ? attrMatch[1] : ''
   const prompt = readAttribute(attrs, 'prompt') ?? ''
@@ -264,6 +278,9 @@ export function renderSinglePicTag(
 
   const imageInfo = imageMap.get(match)
   if (!imageInfo) {
+    if (overBudget) {
+      return buildPlaceholder('failed', '', prompt, overBudgetInfo(shortPrompt))
+    }
     return offerMissingRecovery
       ? buildPlaceholder('failed', '', prompt, missingRecordInfo(prompt, shortPrompt))
       : buildPlaceholder(

--- a/src/lib/utils/inlineImageParser.ts
+++ b/src/lib/utils/inlineImageParser.ts
@@ -12,8 +12,8 @@
  *
  * - A prompt containing `>` ("a sign reading 10 > 9") ends the match early, so *no* rule
  *   fires. The consequence is not a missing image but the literal `<pic ...>` string
- *   surviving into rendered narration, with `hasPicTags` and `stripPicTags` both agreeing
- *   there is nothing there to strip.
+ *   surviving into rendered narration, with `stripPicTags` agreeing there is nothing
+ *   there to strip.
  * - It cannot tell a quote that closes an attribute from one inside its value.
  *
  * Matching quoted runs explicitly fixes both: `"[^"]*"` and `'[^']*'` consume a whole
@@ -139,7 +139,7 @@ export function hasIncompletePicTag(content: string): { incomplete: boolean; saf
 /**
  * Escape HTML special characters for safe attribute values.
  */
-function escapeHtml(str: string): string {
+export function escapeHtml(str: string): string {
   return str
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
@@ -168,7 +168,10 @@ function buildPlaceholder(
   innerContent: string,
 ): string {
   const shimmer = status !== 'failed' ? '<div class="placeholder-shimmer"></div>' : ''
-  return `<div class="inline-image-placeholder ${status}" data-image-id="${imageId}" data-prompt="${escapeHtml(prompt)}">
+  // No id while streaming and none for a missing record: the attribute is a click target,
+  // and an empty one resolves to no image at all.
+  const idAttribute = imageId ? ` data-image-id="${imageId}"` : ''
+  return `<div class="inline-image-placeholder ${status}"${idAttribute} data-prompt="${escapeHtml(prompt)}">
     ${shimmer}
     <div class="placeholder-content">${innerContent}</div>
   </div>`
@@ -191,6 +194,26 @@ function errorWithInfo(errorMsg: string, shortPrompt: string, imageId: string): 
     ${retryButton(imageId)}`
 }
 
+/**
+ * A tag whose image record is gone: the generation never reached the database, or the
+ * record was removed under it. Offering the rescan is the difference between a narration
+ * that lost a paragraph's worth of markup for no stated reason and one the reader can fix.
+ *
+ * A tag with no prompt gets the notice without the button. There is nothing to generate
+ * from it, and the placeholder still has to appear: silently rendering it as the empty
+ * string is how the markup went missing from the narration in the first place.
+ */
+function missingRecordInfo(prompt: string, shortPrompt: string): string {
+  const action = prompt
+    ? `\n    <button class="inline-image-btn create-missing-btn" data-action="create-missing" data-prompt="${escapeHtml(prompt)}" title="Recreate this image">Generate</button>`
+    : ''
+  return `<div class="placeholder-error-icon">${errorIconSvg}</div>
+    <div class="placeholder-info">
+      <span class="placeholder-status error">Image record missing</span>
+      <span class="placeholder-prompt">${escapeHtml(shortPrompt)}</span>
+    </div>${action}`
+}
+
 // ─── Completed image renderers ───
 
 function renderCompleteImage(imageId: string, prompt: string, imageData: string): string {
@@ -209,27 +232,49 @@ function renderRegeneratingImage(imageId: string, prompt: string, imageData: str
   </div>`
 }
 
+export interface PicTagRenderOptions {
+  /** Image IDs currently being regenerated. */
+  regeneratingIds?: Set<string>
+  /** Image IDs waiting long enough to offer a retry. */
+  stuckIds?: Set<string>
+  /**
+   * Offer to recreate a tag that has no image record.
+   *
+   * Off for the moments after an entry is saved, where its records are still being
+   * written and a missing one is the normal state: the recovery rescans the whole entry,
+   * so taking it then would create a second record for every tag about to be flushed.
+   */
+  offerMissingRecovery?: boolean
+}
+
 /**
  * Render HTML for a single <pic> tag match.
  * Handles all image states: complete, regenerating, generating, failed, pending, unknown.
- *
- * @param match - The full <pic> tag match string
- * @param imageMap - Map of original tag text to image info
- * @param regeneratingIds - Optional set of image IDs currently being regenerated
- * @returns HTML string for the image (or empty string if no image record found)
  */
 export function renderSinglePicTag(
   match: string,
   imageMap: Map<string, ImageReplacementInfo>,
-  regeneratingIds?: Set<string>,
+  options: PicTagRenderOptions = {},
 ): string {
+  const { regeneratingIds, stuckIds, offerMissingRecovery = true } = options
   const attrMatch = match.match(picTagRegex('i'))
   const attrs = attrMatch ? attrMatch[1] : ''
   const prompt = readAttribute(attrs, 'prompt') ?? ''
   const shortPrompt = prompt.length > 60 ? prompt.slice(0, 60) + '...' : prompt
 
   const imageInfo = imageMap.get(match)
-  if (!imageInfo) return ''
+  if (!imageInfo) {
+    return offerMissingRecovery
+      ? buildPlaceholder('failed', '', prompt, missingRecordInfo(prompt, shortPrompt))
+      : buildPlaceholder(
+          'pending',
+          '',
+          prompt,
+          loaderWithInfo('In queue...', shortPrompt, 'pending'),
+        )
+  }
+
+  const stuck = stuckIds?.has(imageInfo.id) ?? false
 
   if (imageInfo.status === 'complete' && imageInfo.imageData) {
     return (regeneratingIds?.has(imageInfo.id) ?? false)
@@ -242,7 +287,7 @@ export function renderSinglePicTag(
       'generating',
       imageInfo.id,
       prompt,
-      loaderWithInfo('Generating image...', shortPrompt),
+      loaderWithInfo('Generating image...', shortPrompt) + (stuck ? retryButton(imageInfo.id) : ''),
     )
   }
 
@@ -261,7 +306,8 @@ export function renderSinglePicTag(
     'pending',
     imageInfo.id,
     prompt,
-    loaderWithInfo('In queue...', shortPrompt, 'pending'),
+    loaderWithInfo('In queue...', shortPrompt, 'pending') +
+      (stuck ? retryButton(imageInfo.id) : ''),
   )
 }
 
@@ -294,16 +340,6 @@ export interface ImageReplacementInfo {
   status: 'pending' | 'generating' | 'complete' | 'failed'
   id: string
   errorMessage?: string
-}
-
-/**
- * Check if content contains any <pic> tags.
- *
- * @param content - The content to check
- * @returns True if at least one <pic> tag is found
- */
-export function hasPicTags(content: string): boolean {
-  return picTagRegex('i').test(content)
 }
 
 /**

--- a/src/lib/utils/recentContent.test.ts
+++ b/src/lib/utils/recentContent.test.ts
@@ -57,19 +57,21 @@ describe('recentContent', () => {
     expect(recentContent(entries, 3, AS_HAYSTACK)).toBe('two three four')
   })
 
-  describe('withRoles', () => {
+  describe('roles', () => {
     const typed = (type: StoryEntry['type']): StoryEntry => ({ ...entry('said', 0), type })
 
     it('labels who produced each entry', () => {
       // The fixture alternates by index: 'three' is index 2, so it is the player's.
-      expect(recentContent(entries, 2, AS_PROSE, true)).toBe(
+      expect(recentContent(entries, 2, AS_PROSE, { roles: true })).toBe(
         '[Player Action]: three\n\n[Narrator]: four',
       )
     })
 
     it('never puts an internal type identifier in the prompt', () => {
       // Nothing creates these today; they survive in stories saved by older versions.
-      const labelled = recentContent([typed('system'), typed('retry')], 2, AS_PROSE, true)
+      const labelled = recentContent([typed('system'), typed('retry')], 2, AS_PROSE, {
+        roles: true,
+      })
 
       expect(labelled).not.toContain('[system]')
       expect(labelled).not.toContain('[retry]')
@@ -77,11 +79,44 @@ describe('recentContent', () => {
     })
 
     it('calls a retry a narration, because that is what the model is being shown', () => {
-      expect(recentContent([typed('retry')], 1, AS_PROSE, true)).toBe('[Narrator]: said')
+      expect(recentContent([typed('retry')], 1, AS_PROSE, { roles: true })).toBe('[Narrator]: said')
     })
 
-    it('leaves the content untouched in the unlabelled form', () => {
-      expect(recentContent(entries, 2, AS_PROSE, false)).toBe('three\n\nfour')
+    it('leaves the content untouched with no options', () => {
+      expect(recentContent(entries, 2, AS_PROSE)).toBe('three\n\nfour')
+    })
+  })
+
+  describe('time', () => {
+    const stamped = (content: string, hours: number): StoryEntry => ({
+      ...entry(content, 1),
+      metadata: { timeStart: { years: 0, days: 10, hours, minutes: 5 } },
+    })
+
+    it('stamps the in-story clock the entry began at', () => {
+      expect(recentContent([stamped('a', 17)], 1, AS_PROSE, { roles: true, time: true })).toBe(
+        '[Narrator] (at Y0D10 17:05): a',
+      )
+    })
+
+    it('pads hours and minutes to two digits, and opens the line without the role', () => {
+      expect(recentContent([stamped('a', 9)], 1, AS_PROSE, { time: true })).toBe(
+        '(at Y0D10 09:05): a',
+      )
+    })
+
+    it('leaves entries that carry no time unstamped', () => {
+      expect(recentContent(entries, 1, AS_PROSE, { roles: true, time: true })).toBe(
+        '[Narrator]: four',
+      )
+    })
+  })
+
+  describe('transform', () => {
+    it('rewrites each entry before it is labelled', () => {
+      expect(
+        recentContent(entries, 2, AS_PROSE, { roles: true, transform: (c) => c.toUpperCase() }),
+      ).toBe('[Player Action]: THREE\n\n[Narrator]: FOUR')
     })
   })
 })

--- a/src/lib/utils/recentContent.ts
+++ b/src/lib/utils/recentContent.ts
@@ -3,24 +3,26 @@ import type { StoryEntry } from '$lib/types'
 /**
  * The last `count` story entries, flattened into one string.
  *
- * Six call sites built this by hand, and the separator is the reason it looks like a
- * pointless wrapper until you compare them:
+ * The separator says what the result is for, and every call site states it:
  *
- * - `' '` when the result is a **haystack**, fed to `entityNameMatches` to find out which
- *   entities are mentioned. The separator only has to stop the last word of one entry
- *   fusing with the first word of the next.
- * - `'\n\n'` when the result is **prose in a prompt**, read by a model. Paragraph breaks
- *   are the difference between a scene and a wall of text.
- *
- * Passing it explicitly makes that choice visible at every call site, which repeating the
- * three-line chain did not: the two spellings sat in different files and read as an
- * inconsistency rather than a decision.
+ * - `' '` for a **haystack**, fed to `entityNameMatches`. It only has to stop the last word
+ *   of one entry fusing with the first of the next.
+ * - `'\n\n'` for **prose in a prompt**, read by a model.
  */
+export interface RecentContentOptions {
+  /** Prefix each entry with who produced it. */
+  roles?: boolean
+  /** Stamp each entry with the in-story time it began, when it carries one. */
+  time?: boolean
+  /** Applied to each entry's content before it is labelled and joined. */
+  transform?: (content: string) => string
+}
+
 export function recentContent(
   entries: StoryEntry[],
   count: number,
   separator: ' ' | '\n\n',
-  withRoles = false,
+  options: RecentContentOptions = {},
 ): string {
   // `slice(-0)` is `slice(0)` -- the whole array, not none of it. Every caller today is
   // bounded by a slider with a minimum of 2, or passes `entries.length`, so this never
@@ -28,12 +30,28 @@ export function recentContent(
   // which is the worst possible direction for an off-by-nothing to go.
   if (count <= 0) return ''
 
-  const sliced = entries.slice(-count)
-  if (!withRoles) {
-    return sliced.map((e) => e.content).join(separator)
-  }
+  const { roles = false, time = false, transform } = options
 
-  return sliced.map((e) => `${roleLabel(e.type)}: ${e.content}`).join(separator)
+  return entries
+    .slice(-count)
+    .map((e) => {
+      const content = transform ? transform(e.content) : e.content
+      // Joined rather than concatenated: the time alone must not open the line on a space.
+      const prefix = [roles ? roleLabel(e.type) : '', time ? entryTime(e) : '']
+        .filter(Boolean)
+        .join(' ')
+      return prefix ? `${prefix}: ${content}` : content
+    })
+    .join(separator)
+}
+
+/** The in-story clock an entry started at, as a parenthetical, or nothing if it has none. */
+function entryTime(entry: StoryEntry): string {
+  const t = entry.metadata?.timeStart
+  if (!t) return ''
+  const hh = String(t.hours).padStart(2, '0')
+  const mm = String(t.minutes).padStart(2, '0')
+  return `(at Y${t.years}D${t.days} ${hh}:${mm})`
 }
 
 /**

--- a/src/lib/utils/stripNarratorMarkup.test.ts
+++ b/src/lib/utils/stripNarratorMarkup.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { stripNarratorMarkup } from './text'
+
+describe('stripNarratorMarkup', () => {
+  it('unwraps a heading rather than dropping it', () => {
+    // The heading carries the hour and the place — the two scene fields the classifier fills.
+    expect(stripNarratorMarkup('### Late Morning | The Grotto\n\nShe freezes.')).toBe(
+      'Late Morning | The Grotto\n\nShe freezes.',
+    )
+  })
+
+  it('unwraps a heading that is also bold', () => {
+    expect(stripNarratorMarkup('### **Mid-Morning | The Grotto Pool**')).toBe(
+      'Mid-Morning | The Grotto Pool',
+    )
+  })
+
+  it('drops horizontal rules, which carry no text', () => {
+    expect(stripNarratorMarkup('One.\n\n***\n\nTwo.\n\n---\n\nThree.\n\n___\n\nFour.')).toBe(
+      'One.\n\nTwo.\n\nThree.\n\nFour.',
+    )
+  })
+
+  it('unwraps a bold-only line', () => {
+    expect(stripNarratorMarkup('One.\n\n**The Assessment**\n\nTwo.')).toBe(
+      'One.\n\nThe Assessment\n\nTwo.',
+    )
+  })
+
+  it('leaves bold inside a sentence alone', () => {
+    expect(stripNarratorMarkup('She said **no** to the Empress.')).toBe(
+      'She said **no** to the Empress.',
+    )
+  })
+
+  it('collapses the gaps a dropped rule leaves behind', () => {
+    expect(stripNarratorMarkup('# Title\n\n***\n\nProse.')).toBe('Title\n\nProse.')
+  })
+
+  it('leaves ordinary prose untouched', () => {
+    const prose = 'Morvana snorts.\n\n"Boring," she says.'
+    expect(stripNarratorMarkup(prose)).toBe(prose)
+  })
+
+  it('leaves a bullet alone, which is not a rule', () => {
+    expect(stripNarratorMarkup('- a bullet')).toBe('- a bullet')
+  })
+})

--- a/src/lib/utils/stripNarratorMarkup.test.ts
+++ b/src/lib/utils/stripNarratorMarkup.test.ts
@@ -45,4 +45,15 @@ describe('stripNarratorMarkup', () => {
   it('leaves a bullet alone, which is not a rule', () => {
     expect(stripNarratorMarkup('- a bullet')).toBe('- a bullet')
   })
+
+  it('keeps both spans on a line carrying two of them', () => {
+    const line = '**Morning** at **the pool**'
+    expect(stripNarratorMarkup(line)).toBe(line)
+  })
+
+  it('still unwraps a line that is one span end to end', () => {
+    expect(stripNarratorMarkup('**Late Morning | The Grotto Pool**')).toBe(
+      'Late Morning | The Grotto Pool',
+    )
+  })
 })

--- a/src/lib/utils/text.test.ts
+++ b/src/lib/utils/text.test.ts
@@ -440,4 +440,14 @@ describe('createFuzzyTextRegex', () => {
     const cjkRegex = createFuzzyTextRegex('古い *龍*')
     expect(cjkRegex.test('古い 龍が目を覚ました')).toBe(true)
   })
+
+  it('builds a usable pattern for text carrying an apostrophe', () => {
+    const regex = createFuzzyTextRegex("Yuka's breath hitches")
+    expect(regex.test('and Yuka’s breath hitches once')).toBe(true)
+  })
+
+  it('matches a quoted line of dialogue', () => {
+    const regex = createFuzzyTextRegex('"Who are you?" she asked')
+    expect(regex.test('“Who are you?” she asked, stepping back')).toBe(true)
+  })
 })

--- a/src/lib/utils/text.ts
+++ b/src/lib/utils/text.ts
@@ -39,6 +39,30 @@ export function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
+/**
+ * Whether `needle` occurs in `haystack` as a whole unit — bounded by anything that is not a
+ * letter or a digit, so "Gatto" is not found inside "Cattedrale".
+ *
+ * Both sides are lowercased here; no caller has to do it first. Scripts written without
+ * spaces have no boundary to anchor on, so `entityNameMatches` answers for those before it
+ * gets here.
+ */
+export function containsWholeUnit(haystack: string, needle: string): boolean {
+  const text = haystack.toLowerCase()
+  const unit = needle.toLowerCase().trim()
+  if (!unit) return false
+  if (text.trim() === unit) return true
+
+  let pattern = escapeRegex(unit)
+  if (/^[\p{L}\p{N}]/u.test(unit)) {
+    pattern = '(?<![\\p{L}\\p{N}])' + pattern
+  }
+  if (/[\p{L}\p{N}]$/u.test(unit)) {
+    pattern = pattern + '(?![\\p{L}\\p{N}])'
+  }
+  return new RegExp(pattern, 'u').test(text)
+}
+
 export interface EntityNameMatchOptions {
   /**
    * Also match when a word in `searchText` merely *starts with* the name ("ren" ->
@@ -105,14 +129,7 @@ export function entityNameMatches(
     return haystack.includes(normalizedName)
   }
 
-  let patternStr = escapeRegex(normalizedName)
-  if (/^[\p{L}\p{N}]/u.test(normalizedName)) {
-    patternStr = '(?<![\\p{L}\\p{N}])' + patternStr
-  }
-  if (/[\p{L}\p{N}]$/u.test(normalizedName)) {
-    patternStr = patternStr + '(?![\\p{L}\\p{N}])'
-  }
-  if (new RegExp(patternStr, 'iu').test(haystack)) {
+  if (containsWholeUnit(haystack, normalizedName)) {
     return true
   }
 
@@ -531,10 +548,12 @@ export function createFuzzyTextRegex(text: string): RegExp {
     return new RegExp(escapeRegex(text), 'giu')
   }
 
-  // 3. Escape words and handle variants
-  const patternParts = words.map((word) => {
-    return escapeRegex(word).replace(/'/g, "[\\'’‘‚]").replace(/"/g, '[\\"“”„‟]')
-  })
+  // 3. Escape words and handle variants. Only the apostrophe needs a class of its own:
+  // the split above keeps it inside a word, while every other quotation mark is a
+  // separator and is already covered by the fuzzy separator below. It is not
+  // backslash-escaped inside the class — `\'` is an invalid identity escape under the
+  // `u` flag, which made the constructor throw for every text carrying an apostrophe.
+  const patternParts = words.map((word) => escapeRegex(word).replace(/'/g, "['’‘‚]"))
 
   // 4. Join with a "super-fuzzy" separator
   // We strictly forbid newlines that are part of a paragraph break (\\n\\n), on either side,
@@ -656,4 +675,21 @@ export function sameEntityName(a: string, b: string): boolean {
   const folded = foldName(a)
   if (!folded) return false
   return folded === foldName(b)
+}
+
+/**
+ * Strip the narrator's layout markers from a passage, keeping every word.
+ *
+ * The markers are for a reader; a model asked what happened in the passage only has to
+ * parse them. The text under them is not decoration — a heading like
+ * `### Late Morning | The Grotto Pool` carries the hour and the place, which is exactly
+ * what the scene fields are for. Only a horizontal rule goes entirely, having no text.
+ */
+export function stripNarratorMarkup(content: string): string {
+  return content
+    .replace(/^[ \t]*([*\-_])(?:[ \t]*\1){2,}[ \t]*$/gm, '')
+    .replace(/^#{1,6}[ \t]+(.*)$/gm, '$1')
+    .replace(/^[ \t]*\*\*(.+?)\*\*[ \t]*$/gm, '$1')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
 }

--- a/src/lib/utils/text.ts
+++ b/src/lib/utils/text.ts
@@ -686,10 +686,15 @@ export function sameEntityName(a: string, b: string): boolean {
  * what the scene fields are for. Only a horizontal rule goes entirely, having no text.
  */
 export function stripNarratorMarkup(content: string): string {
-  return content
-    .replace(/^[ \t]*([*\-_])(?:[ \t]*\1){2,}[ \t]*$/gm, '')
-    .replace(/^#{1,6}[ \t]+(.*)$/gm, '$1')
-    .replace(/^[ \t]*\*\*(.+?)\*\*[ \t]*$/gm, '$1')
-    .replace(/\n{3,}/g, '\n\n')
-    .trim()
+  return (
+    content
+      .replace(/^[ \t]*([*\-_])(?:[ \t]*\1){2,}[ \t]*$/gm, '')
+      .replace(/^#{1,6}[ \t]+(.*)$/gm, '$1')
+      // One span covering the whole line, so a line carrying two of them keeps both intact
+      // rather than surrendering its inner markers to a match that spans from the first
+      // opener to the last closer.
+      .replace(/^[ \t]*\*\*((?:(?!\*\*).)+)\*\*[ \t]*$/gm, '$1')
+      .replace(/\n{3,}/g, '\n\n')
+      .trim()
+  )
 }


### PR DESCRIPTION
Fixes found while chasing image markers that had stopped appearing, and the things that investigation walked past. Rebased on current `master`. No schema changes.

## Fixes

- **Markers vanished.** #437 added the `u` flag to `createFuzzyTextRegex`, where the pattern's `\'` is an invalid identity escape. The constructor threw for any sourceText carrying an apostrophe — and since the throw happens while building markers, it took *every* marker in the entry with it.
- **`withTransaction` was corrupting the connection pool.** `tauri-plugin-sql` runs each statement on an arbitrary pooled connection, so `BEGIN` and `COMMIT` never met: the writes self-committed, and the connection holding the orphaned `BEGIN` kept a write lock that turned every later write into `database is locked`. Replaced by a `db_transaction` Rust command that owns one connection, rolls back on the first error, and reports the rows each statement affected.
- **A `<pic>` tag with no image record rendered as the empty string**, silently deleting it from the narration. It now shows a placeholder offering a rescan, which skips the tags that already have a record instead of duplicating them.
- **The tracker's flush could miss the last tag**, whose generation was started but not yet registered when the entry was saved — generated, never recorded, and so deleted at render time.
- **Concurrent reads of an entry's images could install a stale snapshot**, and the inline display removed every other entry's.
- **A departure was never recorded.** Nothing marked a character away, so `[PRESENT]` grew to the whole cast.

## Behaviour

- **Presence is inferred, not extracted.** The classifier reports who is in the scene at the end of the passage; everyone else active is away. Refused when the response errored or the list is empty, which cannot be told apart from "no answer". The narrator gets `[CHARACTERS PRESENT]`, `[RECENTLY DEPARTED]` and `[KNOWN CHARACTERS]` as three sections rather than one, with appearance dropped for the departed.
- **Only `scene.currentLocationName` moves the scene.** `current` is gone from the location schemas: both paths existed, both applied, in an order the model could not see.
- **The classifier reads recent turns whole**, on a window configurable in Advanced (2–15, default 7), with the narrator's layout markers stripped. Replaces the per-entry word truncation, which cut off the end of a narration — where the scene it reports on lives. Locations and items are listed one per line, with state only where it differs from the default; appearance is sent only for characters in the scene.
- **Lore management has no `list_entries`.** The prompt already carries every entry, and it was capped at a fifth of a large lorebook with no way to page. `create_entry` and `merge_entries` report the index they landed at instead. Duplicate detection matches whole tokens and reads aliases, so "Kaelen" finds "Kaelan the Bold". The autonomous run drops the pending/approval vocabulary it never had a workflow for, and a failed run leaves an error the lorebook view shows with Retry and Dismiss.
- **TTS audio format is a setting** on the OpenAI-compatible provider, still MP3 by default: a local runtime built without an MP3 encoder answers MP3 with a 400 and wants WAV.
- **Image settings state what is unusable.** A mode without a configured profile can be turned off but not on, and API-key requirements are declared per provider in one table.

## Performance

- One 1s interval per story entry, forever, to flip one affordance — now one timeout per entry with work outstanding, on the nearest deadline.
- Streaming token counts were a full BPE pass every 500ms, growing with the response and running on while it stalled. Throttled to the appends.
- An image event refreshes that image instead of pulling every base64 in the entry back through the IPC bridge.
- Raw marker matching is memoized, so the orphan gallery and the renderer stop asking twice.

## Also

The retry no longer pretends to reproduce what it cannot — an img2img reference is not recoverable and a portrait retry rewrites the row, never the character's picture. Three copies of the generate/record/notify cycle collapsed into one, four dead exports removed, and the `alt` attribute escaped, since for an inline image it holds the `<pic>` tag.

`check`, 1157 tests and `lint` clean; `cargo check` and `clippy` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MP3/WAV selection for OpenAI-compatible text-to-speech services.
  * Added configurable recent-entry context for world-state classification.
  * Added image-generation availability checks for background, portrait, and reference images.
  * Added lore-management error banners with retry and dismiss actions.
  * Improved character presence tracking and duplicate-entry handling.

* **Bug Fixes**
  * Improved inline-image retries, recovery, rendering safety, and generation limits.
  * Improved atomic updates for runtime variables and database transactions.
  * Improved prompt formatting, text matching, and narrator-markup handling.

* **Tests**
  * Expanded coverage for image tracking, lore management, character presence, parsing, prompts, and text utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->