### PR TITLE
Wizard dismiss guard and textarea autosize

### DIFF
--- a/src/lib/components/memory/ChapterCard.svelte
+++ b/src/lib/components/memory/ChapterCard.svelte
@@ -177,7 +177,7 @@
     <!-- Summary -->
     <div class="px-3 py-3">
       {#if isEditing}
-        <Textarea bind:value={editedSummary} class="min-h-[80px] resize-y text-sm" rows={4} />
+        <Textarea bind:value={editedSummary} class="min-h-[80px] text-sm" rows={4} />
       {:else}
         <div class="bg-muted/30 text-muted-foreground rounded p-2 text-sm leading-relaxed">
           {chapter.summary}

--- a/src/lib/components/settings/ExperimentalSettings.svelte
+++ b/src/lib/components/settings/ExperimentalSettings.svelte
@@ -36,6 +36,7 @@
   import * as Dialog from '$lib/components/ui/dialog'
   import { database } from '$lib/services/database'
   import { isAndroid } from '$lib/utils/platform'
+  import { autosize } from '$lib/utils/autosize'
   import { ask, open } from '@tauri-apps/plugin-dialog'
   import { openFilters } from '$lib/utils/dialogFilters'
   import { invoke } from '@tauri-apps/api/core'
@@ -615,10 +616,11 @@
       <!-- Query Input -->
       <textarea
         bind:value={sqlQuery}
+        use:autosize={{ enabled: true, value: sqlQuery }}
         onkeydown={handleQueryKeydown}
         placeholder="SELECT * FROM stories LIMIT 10;"
         spellcheck={false}
-        class="bg-surface-950 border-surface-700 text-foreground placeholder:text-muted-foreground w-full rounded-md border p-3 font-mono text-xs leading-relaxed focus:ring-1 focus:ring-amber-500/50 focus:outline-none"
+        class="bg-surface-950 border-surface-700 text-foreground placeholder:text-muted-foreground max-h-[50dvh] w-full resize-none rounded-md border p-3 font-mono text-xs leading-relaxed focus:ring-1 focus:ring-amber-500/50 focus:outline-none"
         rows={4}></textarea>
 
       <!-- Actions -->

--- a/src/lib/components/settings/MainNarrative.svelte
+++ b/src/lib/components/settings/MainNarrative.svelte
@@ -146,7 +146,7 @@
         <Textarea
           bind:value={settings.apiSettings.manualBody}
           onblur={() => settings.setMainManualBody(settings.apiSettings.manualBody)}
-          class="min-h-[100px] w-full resize-y font-mono"
+          class="min-h-[100px] w-full font-mono"
           rows={4}
         />
         <p class="text-muted-foreground mt-1 text-xs">

--- a/src/lib/components/story/StoryEntry.svelte
+++ b/src/lib/components/story/StoryEntry.svelte
@@ -1406,7 +1406,7 @@
         <Textarea
           bind:value={editContent}
           onkeydown={handleKeydown}
-          class="min-h-25 w-full resize-y text-base"
+          class="min-h-25 w-full text-base"
           rows={4}
         />
         <div class="flex gap-2">

--- a/src/lib/components/ui/responsive-modal/responsive-modal.svelte
+++ b/src/lib/components/ui/responsive-modal/responsive-modal.svelte
@@ -10,11 +10,19 @@
   type Props = {
     open: boolean
     onOpenChange?: OnChangeFn<boolean>
+    /** Drawer-only: `false` stops the swipe-down gesture. The desktop dialog has no equivalent. */
+    dismissible?: boolean
     children: Snippet
     [key: string]: unknown
   }
 
-  let { open = $bindable(false), onOpenChange, children, ...props }: Props = $props()
+  let {
+    open = $bindable(false),
+    onOpenChange,
+    dismissible = true,
+    children,
+    ...props
+  }: Props = $props()
 
   const isMobile = createIsMobile()
   setResponsiveModalContext({ isMobile })
@@ -26,7 +34,7 @@
 </script>
 
 {#if isMobile.current}
-  <Drawer.Root bind:open onOpenChange={handleOpenChange} {...props}>
+  <Drawer.Root bind:open {dismissible} onOpenChange={handleOpenChange} {...props}>
     {@render children?.()}
   </Drawer.Root>
 {:else}

--- a/src/lib/components/ui/textarea/textarea.svelte
+++ b/src/lib/components/ui/textarea/textarea.svelte
@@ -2,20 +2,29 @@
   import type { WithElementRef, WithoutChildren } from 'bits-ui'
   import type { HTMLTextareaAttributes } from 'svelte/elements'
   import { cn } from '$lib/utils/cn.js'
+  import { autosize } from '$lib/utils/autosize'
+
+  type Props = WithoutChildren<WithElementRef<HTMLTextareaAttributes>> & {
+    /** Grow with the content up to `max-h`, instead of keeping the height a caller set. */
+    autosize?: boolean
+  }
 
   let {
     ref = $bindable(null),
     value = $bindable(),
+    autosize: autosizeEnabled = true,
     class: className,
     ...restProps
-  }: WithoutChildren<WithElementRef<HTMLTextareaAttributes>> = $props()
+  }: Props = $props()
 </script>
 
 <textarea
   bind:this={ref}
   class={cn(
     'border-input bg-background placeholder:text-muted-foreground focus-visible:border-ring flex min-h-[80px] w-full rounded-md border px-3 py-2 text-base focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+    autosizeEnabled && 'max-h-[50dvh] resize-none',
     className,
   )}
   bind:value
+  use:autosize={{ enabled: autosizeEnabled, value }}
   {...restProps}></textarea>

--- a/src/lib/components/vault/VaultScenarioFormFields.svelte
+++ b/src/lib/components/vault/VaultScenarioFormFields.svelte
@@ -172,7 +172,7 @@
                 bind:value={data.settingSeed}
                 oninput={handleInput}
                 rows={10}
-                class="min-h-[200px] resize-y font-mono text-sm leading-relaxed"
+                class="min-h-[200px] font-mono text-sm leading-relaxed"
                 placeholder="Detailed world setting..."
               />
               <div

--- a/src/lib/components/wizard/STImportWizard.svelte
+++ b/src/lib/components/wizard/STImportWizard.svelte
@@ -8,7 +8,7 @@
   import { MODAL_CLOSE_TRANSITION_MS } from '$lib/constants/layout'
   import { createIsMobile } from '$lib/hooks/is-mobile.svelte'
   import { Button } from '$lib/components/ui/button'
-  import { ChevronLeft, ChevronRight, Play } from '@lucide/svelte'
+  import { ChevronLeft, ChevronRight, Play, X } from '@lucide/svelte'
 
   import {
     StepUploadFiles,
@@ -20,6 +20,7 @@
   } from './st-import-steps'
   import Step6Portraits from './steps/Step6Portraits.svelte'
   import StepPackSelection from './steps/StepPackSelection.svelte'
+  import WizardExitConfirm from './WizardExitConfirm.svelte'
 
   interface Props {
     onClose: () => void
@@ -30,6 +31,7 @@
   const isMobile = createIsMobile()
 
   let isOpen = $state(true)
+  let showExitConfirm = $state(false)
 
   /**
    * A close driven from this side never reaches `vaul`'s restore, and `onClose()` unmounts
@@ -48,6 +50,23 @@
 
   const wizard = new STImportWizardStore(() => handleClose())
 
+  /**
+   * Past the first step the wizard holds uploads and choices that exist nowhere else, so a
+   * stray tap on the backdrop has to be confirmed instead of silently discarding them.
+   */
+  const guardDismiss = $derived(wizard.currentStep > 1 && !wizard.isCreatingStory)
+
+  /**
+   * A drawer swipe has no event to intercept, so it is switched off rather than confirmed;
+   * the header's close button is the deliberate way out on mobile.
+   */
+  const allowSwipeDismiss = $derived(!guardDismiss && !wizard.isCreatingStory)
+
+  function requestDismiss() {
+    if (guardDismiss) showExitConfirm = true
+    else handleClose()
+  }
+
   const imageGenerationEnabled = $derived(hasRequiredCredentials())
 
   const stepTitles = [
@@ -64,22 +83,41 @@
 
 <ResponsiveModal.Root
   open={isOpen}
+  dismissible={allowSwipeDismiss}
   onOpenChange={(open) => !open && !wizard.isCreatingStory && handleClose()}
 >
   <ResponsiveModal.Content
     class="flex h-full flex-col gap-0 p-0 sm:h-auto sm:max-h-[90vh] sm:max-w-3xl"
     interactOutsideBehavior={wizard.isCreatingStory ? 'ignore' : 'close'}
     escapeKeydownBehavior={wizard.isCreatingStory ? 'ignore' : 'close'}
+    onInteractOutside={(e: PointerEvent) => {
+      e.preventDefault()
+      requestDismiss()
+    }}
+    onEscapeKeydown={(e: KeyboardEvent) => {
+      e.preventDefault()
+      if (showExitConfirm) showExitConfirm = false
+      else requestDismiss()
+    }}
   >
     <!-- Header -->
-    <div class="flex flex-col border-b p-4 pb-4">
-      <div class="mb-4 flex items-center justify-between">
-        <div>
+    <div class="flex flex-col border-b p-4 pb-4" inert={showExitConfirm}>
+      <div class="mb-4 flex items-center justify-between gap-2">
+        <div class="min-w-0">
           <ResponsiveModal.Title class="text-xl">Import from SillyTavern</ResponsiveModal.Title>
           <ResponsiveModal.Description>
             Step {wizard.currentStep} of {wizard.totalSteps}: {stepTitles[wizard.currentStep - 1]}
           </ResponsiveModal.Description>
         </div>
+        <Button
+          variant="ghost"
+          class="text-muted-foreground hover:text-foreground h-9 w-9 shrink-0 p-0"
+          title="Close wizard"
+          disabled={wizard.isCreatingStory}
+          onclick={requestDismiss}
+        >
+          <X class="h-5 w-5" />
+        </Button>
       </div>
 
       <!-- Progress Bar -->
@@ -97,7 +135,7 @@
     </div>
 
     <!-- Content -->
-    <div class="min-h-0 flex-1 overflow-y-auto p-4">
+    <div class="min-h-0 flex-1 overflow-y-auto p-4" inert={showExitConfirm}>
       {#if wizard.currentStep === 1}
         <StepPackSelection
           availablePacks={wizard.availablePacks}
@@ -274,7 +312,7 @@
     </div>
 
     <!-- Footer Navigation -->
-    <div class="flex shrink-0 justify-between border-t p-4">
+    <div class="flex shrink-0 justify-between border-t p-4" inert={showExitConfirm}>
       {#if wizard.currentStep > 1}
         <Button
           variant="secondary"
@@ -315,5 +353,15 @@
         </Button>
       {/if}
     </div>
+
+    <WizardExitConfirm
+      open={showExitConfirm}
+      title="Discard this import?"
+      onCancel={() => (showExitConfirm = false)}
+      onDiscard={() => {
+        showExitConfirm = false
+        handleClose()
+      }}
+    />
   </ResponsiveModal.Content>
 </ResponsiveModal.Root>

--- a/src/lib/components/wizard/SetupWizard.svelte
+++ b/src/lib/components/wizard/SetupWizard.svelte
@@ -6,12 +6,14 @@
   import { MODAL_CLOSE_TRANSITION_MS } from '$lib/constants/layout'
   import { createIsMobile } from '$lib/hooks/is-mobile.svelte'
   import { Button } from '$lib/components/ui/button'
-  import { ChevronLeft, ChevronRight, Play } from '@lucide/svelte'
+  import { ChevronLeft, ChevronRight, Play, X } from '@lucide/svelte'
   import { ui } from '$lib/stores/ui.svelte'
   import { lorebookVault } from '$lib/stores/lorebookVault.svelte'
   import { characterVault } from '$lib/stores/characterVault.svelte'
   import { hasRequiredCredentials } from '$lib/services/ai/image'
   import type { VaultCharacter } from '$lib/types'
+
+  import WizardExitConfirm from './WizardExitConfirm.svelte'
 
   // Step components
   import {
@@ -35,6 +37,7 @@
   const isMobile = createIsMobile()
 
   let isOpen = $state(true)
+  let showExitConfirm = $state(false)
 
   /**
    * A close driven from this side never reaches `vaul`'s restore, and `onClose()` unmounts
@@ -53,6 +56,23 @@
 
   // Initialize Wizard Store
   const wizard = new WizardStore(() => handleClose())
+
+  /**
+   * Past the first step the wizard holds answers that exist nowhere else, so a stray tap on
+   * the backdrop has to be confirmed instead of silently discarding them.
+   */
+  const guardDismiss = $derived(wizard.currentStep > 1 && !wizard.isCreatingStory)
+
+  /**
+   * A drawer swipe has no event to intercept, so it is switched off rather than confirmed;
+   * the header's close button is the deliberate way out on mobile.
+   */
+  const allowSwipeDismiss = $derived(!guardDismiss && !wizard.isCreatingStory)
+
+  function requestDismiss() {
+    if (guardDismiss) showExitConfirm = true
+    else handleClose()
+  }
 
   // Auto-link embedded lorebook when selecting a vault character
   function autoLinkCharacterLorebook(char: VaultCharacter, isProtagonist = false) {
@@ -103,22 +123,41 @@
 
 <ResponsiveModal.Root
   open={isOpen}
+  dismissible={allowSwipeDismiss}
   onOpenChange={(open) => !open && !wizard.isCreatingStory && handleClose()}
 >
   <ResponsiveModal.Content
     class="flex h-full flex-col gap-0 p-0 sm:h-auto sm:max-h-[90vh] sm:max-w-3xl"
     interactOutsideBehavior={wizard.isCreatingStory ? 'ignore' : 'close'}
     escapeKeydownBehavior={wizard.isCreatingStory ? 'ignore' : 'close'}
+    onInteractOutside={(e: PointerEvent) => {
+      e.preventDefault()
+      requestDismiss()
+    }}
+    onEscapeKeydown={(e: KeyboardEvent) => {
+      e.preventDefault()
+      if (showExitConfirm) showExitConfirm = false
+      else requestDismiss()
+    }}
   >
     <!-- Header -->
-    <div class="flex flex-col border-b p-4 pb-4">
-      <div class="mb-4 flex items-center justify-between">
-        <div>
+    <div class="flex flex-col border-b p-4 pb-4" inert={showExitConfirm}>
+      <div class="mb-4 flex items-center justify-between gap-2">
+        <div class="min-w-0">
           <ResponsiveModal.Title class="text-xl">Create New Story</ResponsiveModal.Title>
           <ResponsiveModal.Description>
             Step {wizard.currentStep} of {wizard.totalSteps}: {stepTitles[wizard.currentStep - 1]}
           </ResponsiveModal.Description>
         </div>
+        <Button
+          variant="ghost"
+          class="text-muted-foreground hover:text-foreground h-9 w-9 shrink-0 p-0"
+          title="Close wizard"
+          disabled={wizard.isCreatingStory}
+          onclick={requestDismiss}
+        >
+          <X class="h-5 w-5" />
+        </Button>
       </div>
 
       <!-- Progress Bar -->
@@ -136,7 +175,7 @@
     </div>
 
     <!-- Content -->
-    <div class="min-h-0 flex-1 overflow-y-auto p-4">
+    <div class="min-h-0 flex-1 overflow-y-auto p-4" inert={showExitConfirm}>
       {#if wizard.currentStep === 1}
         <Step1Mode
           selectedMode={wizard.narrative.selectedMode}
@@ -448,7 +487,7 @@
     </div>
 
     <!-- Footer Navigation -->
-    <div class="flex shrink-0 justify-between border-t p-4">
+    <div class="flex shrink-0 justify-between border-t p-4" inert={showExitConfirm}>
       {#if wizard.currentStep > 1}
         <Button variant="secondary" class="gap-1 pl-2" onclick={() => wizard.prevStep()}>
           <ChevronLeft class="h-4 w-4" />
@@ -486,5 +525,14 @@
         </Button>
       {/if}
     </div>
+
+    <WizardExitConfirm
+      open={showExitConfirm}
+      onCancel={() => (showExitConfirm = false)}
+      onDiscard={() => {
+        showExitConfirm = false
+        handleClose()
+      }}
+    />
   </ResponsiveModal.Content>
 </ResponsiveModal.Root>

--- a/src/lib/components/wizard/WizardExitConfirm.svelte
+++ b/src/lib/components/wizard/WizardExitConfirm.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import { Button } from '$lib/components/ui/button'
+  import { TriangleAlert } from '@lucide/svelte'
+
+  interface Props {
+    open: boolean
+    title?: string
+    onCancel: () => void
+    onDiscard: () => void
+  }
+
+  let { open, title = 'Discard this story?', onCancel, onDiscard }: Props = $props()
+
+  const uid = $props.id()
+
+  let cancelButton = $state<HTMLElement | null>(null)
+
+  $effect(() => {
+    if (open) cancelButton?.focus()
+  })
+</script>
+
+<!--
+  Belongs inside the wizard's own dialog, not in a nested one: a second modal layer would
+  take over the dismissible and escape layers this prompt exists to intercept.
+-->
+{#if open}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="bg-background/80 absolute inset-0 z-50 flex items-center justify-center p-4 backdrop-blur-sm"
+    onclick={(e) => e.target === e.currentTarget && onCancel()}
+  >
+    <div
+      class="bg-card w-full max-w-sm rounded-lg border p-5 shadow-lg"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="{uid}-title"
+      aria-describedby="{uid}-description"
+    >
+      <div class="flex items-start gap-3">
+        <TriangleAlert class="mt-0.5 h-5 w-5 shrink-0 text-amber-500" />
+        <div class="min-w-0">
+          <h2 id="{uid}-title" class="font-semibold">{title}</h2>
+          <p id="{uid}-description" class="text-muted-foreground mt-1 text-sm">
+            Everything you have filled in so far will be lost.
+          </p>
+        </div>
+      </div>
+
+      <div class="mt-5 flex justify-end gap-2">
+        <Button bind:ref={cancelButton} variant="outline" onclick={onCancel}>Keep Editing</Button>
+        <Button variant="destructive" onclick={onDiscard}>Discard</Button>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/src/lib/components/wizard/steps/Step8Opening.svelte
+++ b/src/lib/components/wizard/steps/Step8Opening.svelte
@@ -222,7 +222,7 @@
             value={manualOpeningText}
             oninput={(e) => onManualOpeningChange(e.currentTarget.value)}
             placeholder="Write the opening scene of your story here... Describe the setting, introduce your character, set the mood. This will be the first entry in your adventure."
-            class="min-h-[140px] resize-y text-sm"
+            class="min-h-[140px] text-sm"
             rows={6}
             disabled={isGeneratingOpening || isRefiningOpening || generatedOpening !== null}
           />
@@ -355,7 +355,7 @@
           <Textarea
             value={openingDraft ?? ''}
             oninput={(e) => onDraftChange(e.currentTarget.value)}
-            class="min-h-[140px] resize-y text-sm"
+            class="min-h-[140px] text-sm"
             rows={6}
           />
           <div class="flex justify-end gap-2">

--- a/src/lib/utils/autosize.ts
+++ b/src/lib/utils/autosize.ts
@@ -1,0 +1,60 @@
+/**
+ * Svelte action that keeps a textarea exactly as tall as its content.
+ *
+ * The upper bound is the element's own `max-height`, so a caller caps the growth with a
+ * class rather than a parameter, and the textarea scrolls internally past that point.
+ */
+
+export interface AutosizeParams {
+  enabled: boolean
+  /** Re-measures whenever this changes, so a value set in code resizes too, not just typing. */
+  value: unknown
+}
+
+export function autosize(node: HTMLTextAreaElement, params: AutosizeParams) {
+  let enabled = params.enabled
+  let lastWidth = 0
+
+  function resize() {
+    if (!enabled) return
+    // A textarea in a closed accordion or an inactive tab measures 0; leave its height alone.
+    if (!node.offsetWidth && !node.offsetHeight) return
+
+    const style = getComputedStyle(node)
+    // `scrollHeight` excludes the border, which a border-box height still has to cover.
+    const border =
+      style.boxSizing === 'border-box'
+        ? parseFloat(style.borderTopWidth) + parseFloat(style.borderBottomWidth)
+        : 0
+
+    node.style.height = 'auto'
+    node.style.height = `${node.scrollHeight + border}px`
+  }
+
+  // Only width matters: it rewraps the text. Height changes are this action's own doing.
+  const observer = new ResizeObserver(() => {
+    if (node.offsetWidth === lastWidth) return
+    lastWidth = node.offsetWidth
+    resize()
+  })
+
+  node.addEventListener('input', resize)
+  observer.observe(node)
+  resize()
+
+  return {
+    update(next: AutosizeParams) {
+      const wasEnabled = enabled
+      enabled = next.enabled
+      if (!enabled) {
+        if (wasEnabled) node.style.height = ''
+        return
+      }
+      resize()
+    },
+    destroy() {
+      node.removeEventListener('input', resize)
+      observer.disconnect()
+    },
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic textarea sizing to fit entered content, with height limits and no manual resizing.
  * Added discard confirmation when exiting setup or import wizards after editing begins.
  * Added configurable dismissal behavior for responsive dialogs.
* **Bug Fixes**
  * Improved wizard safeguards to prevent accidental loss of in-progress answers.
  * Standardized textarea behavior across editing and configuration screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->