### PR TITLE
Slice M3.9 ctrl z action batched

### DIFF
--- a/docs/implementation/lessons-learned/README.md
+++ b/docs/implementation/lessons-learned/README.md
@@ -136,6 +136,10 @@ slice plans when relevant.
   — `embedding_stale` is a handoff signal, not a durable property, so a
   post-hoc E2E assertion on it tests drain scheduling; assert the initial
   write or the settled end state, never the handoff.
+- [The seeded branch tip moves at boot](./seed-tip-position-shifts-at-boot.md)
+  — boot recovery reverse-replays the fixture's dangling in-flight turn, so a
+  pre-launch `MAX(position)` sits above the tip the app boots with and shifts
+  every classifier window handle; anchor on the last `ai_reply`.
 - [A literal NUL in a plan file silently rewrites the code it specifies](./plan-file-nul-corruption.md)
   — `file .impl-plans/*.md` should never say `data`; reading tools disagree
   about a raw NUL and each renders a different separator.

--- a/docs/implementation/lessons-learned/seed-tip-position-shifts-at-boot.md
+++ b/docs/implementation/lessons-learned/seed-tip-position-shifts-at-boot.md
@@ -1,0 +1,52 @@
+# The seeded branch tip moves at boot, so a pre-launch position is not the app's
+
+The dev fixture leaves the hero branch on a **dangling in-flight turn** — a
+`user_action` whose reply never committed, plus its `pipeline_runs` marker.
+`runBootstrap` calls `recoverInFlightRuns` before hydrate, which reverse-replays
+that orphan away. The row is gone by the time the reader paints, and its
+`position` is handed to the next turn the spec commits.
+
+Every seed helper in `e2e/harness/seed.ts` runs against the DB **file, before
+launch**. So a helper that reads `MAX(position)` reads a tip the app will not
+boot with:
+
+```ts
+// Returns 72. After boot recovery the real tip is 71, and the spec's own
+// first user_action lands ON 72 — below the watermark this just parked.
+const tip = db
+  .prepare(`SELECT COALESCE(MAX(position), 0) AS p FROM story_entries WHERE branch_id = ?`)
+  .get(branchId).p
+```
+
+The failure is silent and looks like a product bug. Parking the classifier
+watermark one position high pushed the spec's first turn out of the pass window,
+so `unprocessedTurnCount` saw three rows where the cadence needed four and the
+pass simply never fired — no error, just a poll that timed out on an empty
+`happenings` table. Had the count still reached the cadence, the damage would
+have been worse: the window's `t1..tN` handles shift by one, so a fixture
+anchoring a fact to `t2` silently anchors it somewhere else.
+
+## How to apply
+
+Anchor a pre-launch position on a row boot recovery cannot remove — the last
+**settled** turn:
+
+```ts
+;`SELECT COALESCE(MAX(position), 0) AS p FROM story_entries
+  WHERE branch_id = ? AND kind = 'ai_reply'`
+```
+
+A dangling `user_action` is exactly what recovery reverses; a reply is only ever
+written by a turn that committed. Then assert the shape you assumed once the app
+is up — `expect(rows).toHaveLength(4)` on the rows above the parked position
+turns a future fixture change into a loud failure instead of a mis-mapped handle.
+
+## Why it generalises
+
+Any pre-launch seed write that encodes a **derived** fact about the fixture —
+a max position, an entry id, a row count, a watermark — is asserting that boot
+is a no-op. Boot is not a no-op: recovery reverse-replays orphans, the drain
+clears staleness flags (see
+[Staleness flags are cleared by the drain](./staleness-flags-are-cleared-by-the-drain.md)),
+and hydrate can prune. Seed absolute facts the fixture owns; derive anything
+positional after launch, or anchor it on a row that boot provably leaves alone.

--- a/docs/implementation/lessons-learned/seed-tip-position-shifts-at-boot.md
+++ b/docs/implementation/lessons-learned/seed-tip-position-shifts-at-boot.md
@@ -31,9 +31,9 @@ anchoring a fact to `t2` silently anchors it somewhere else.
 Anchor a pre-launch position on a row boot recovery cannot remove — the last
 **settled** turn:
 
-```ts
-;`SELECT COALESCE(MAX(position), 0) AS p FROM story_entries
-  WHERE branch_id = ? AND kind = 'ai_reply'`
+```sql
+SELECT COALESCE(MAX(position), 0) AS p FROM story_entries
+ WHERE branch_id = ? AND kind = 'ai_reply'
 ```
 
 A dangling `user_action` is exactly what recovery reverses; a reply is only ever

--- a/docs/implementation/milestones/03-memory-floor/slices/09-undo-batched.md
+++ b/docs/implementation/milestones/03-memory-floor/slices/09-undo-batched.md
@@ -126,14 +126,16 @@ positional window, and the watermark clamp. This slice therefore
 executed as a verification slice: the acceptance-criteria fixture
 matrix (`lib/actions/story-entries/undo-classifier.test.ts`) was
 built against the shipped machinery, and no fixture surfaced a
-defect. Because the tests were expected to pass on arrival, three
+defect. Because the tests were expected to pass on arrival, four
 mutation checks stand in for TDD's watch-it-fail step and are the
 evidence the assertions are not vacuous: relaxing the
 survival-anchor comparison to strict `>` spares a fact anchored
 exactly at B; dropping the `periodic_classifier` skip in
-head-selection retargets undo at the classifier group; and dropping
+head-selection retargets undo at the classifier group; dropping
 the `await` on the C3 drain lets the sweep finish before the
-classifier's terminal resolves.
+classifier's terminal resolves; and deleting the anchor predicate
+outright (a bare suffix sweep) takes the surviving turn's fact down
+with the undone turn, caught at the E2E layer.
 
 Resolved decisions:
 
@@ -147,6 +149,17 @@ Resolved decisions:
   directly; the awareness natural-key upsert absorbs, the duplicate
   happening row is tolerated (cleaned at M5 chapter-close dedup),
   and the watermark stays clamped after redo.
-- **E2E** — no new spec; `e2e/tests/reader-undo-redo.spec.ts`
-  already covers the user-facing flow, and the classifier interplay
-  is log-selection logic owned by the vitest matrix.
+- **E2E** — planned as "no new spec", reversed during execution.
+  The manual smoke this slice's Tests section calls for is not
+  practically runnable (it needs a classifier pass landed against a
+  real provider), so its substance moved into
+  `e2e/tests/reader-undo-redo.spec.ts` as a second describe: two
+  turns under a cadence tuned so one pass covers both, a fact
+  anchored to each turn via `sourceTurn`, then CTRL-Z. It is the
+  only place the survival anchor is proven on a log the app built
+  itself rather than one a fixture hand-wrote — the window, its
+  `t1..tN` handles, and `deltas.entry_id` all come from the real
+  reconciler. Building it required a new harness helper
+  (`parkClassifierWatermarkAtLastReply`) and surfaced a boot-order
+  trap now recorded in
+  [lessons-learned](../../../lessons-learned/seed-tip-position-shifts-at-boot.md).

--- a/docs/implementation/milestones/03-memory-floor/slices/09-undo-batched.md
+++ b/docs/implementation/milestones/03-memory-floor/slices/09-undo-batched.md
@@ -113,10 +113,40 @@ the reader keybinding behavior.
 
 ## Open questions
 
-- **Redo-stack shape for suffix units** — M2.5's stack stores
-  single groups; batched units need ordered multi-group frames.
-  Confirm the frame shape at planning (runtime-only, no schema).
+- **Redo-stack shape for suffix units** — resolved during slice
+  planning; see Implementation notes.
 
 ## Implementation notes
 
-_Populated at finish: notable deviations from the plan and resolved developer decisions._
+The Scope-in mechanics pre-landed before this slice started: Slice
+3.2 shipped the head-selection algorithm (`lib/undo`,
+classifier-skip plus turn/group classification) and Slice 3.3
+rewired `undoLastAction` through the C3 bracket, the survival-anchor
+positional window, and the watermark clamp. This slice therefore
+executed as a verification slice: the acceptance-criteria fixture
+matrix (`lib/actions/story-entries/undo-classifier.test.ts`) was
+built against the shipped machinery, and no fixture surfaced a
+defect. Because the tests were expected to pass on arrival, three
+mutation checks stand in for TDD's watch-it-fail step and are the
+evidence the assertions are not vacuous: relaxing the
+survival-anchor comparison to strict `>` spares a fact anchored
+exactly at B; dropping the `periodic_classifier` skip in
+head-selection retargets undo at the classifier group; and dropping
+the `await` on the C3 drain lets the sweep finish before the
+classifier's terminal resolves.
+
+Resolved decisions:
+
+- **Redo-stack shape for suffix units** — the shipped
+  `RedoGroup = RedoSnapshot[]` frame (one ordered frame per undo
+  unit, spanning multiple `action_id`s for suffix units, each
+  snapshot carrying the pruned delta row plus the pre-reversal row
+  content) is the resolution. Runtime-only, no schema.
+- **AC5 depth** — asserted at the write-path seam: after
+  undo → redo, a re-deriving pass drives `applyDeltaAction`
+  directly; the awareness natural-key upsert absorbs, the duplicate
+  happening row is tolerated (cleaned at M5 chapter-close dedup),
+  and the watermark stays clamped after redo.
+- **E2E** — no new spec; `e2e/tests/reader-undo-redo.spec.ts`
+  already covers the user-facing flow, and the classifier interplay
+  is log-selection logic owned by the vitest matrix.

--- a/e2e/harness/seed.ts
+++ b/e2e/harness/seed.ts
@@ -198,6 +198,38 @@ export function seedClassifierBacklog(
   }
 }
 
+/**
+ * Park the classifier watermark at the last settled turn and return that position, so
+ * the cadence counts only the turns a spec commits after launch. The fixture seeds
+ * `classifier_status = NULL`, which floors the window at 0 — a pass would otherwise
+ * claim the whole seeded branch and the spec could not say which turns it read.
+ *
+ * Anchors on the last `ai_reply`, not MAX(position): the fixture ends on a dangling
+ * in-flight turn that boot recovery reverse-replays away, so the seed-time maximum
+ * sits one position above the tip the app actually boots with — high enough to push
+ * the first committed turn out of the window and shift every handle. Runs before launch.
+ */
+export function parkClassifierWatermarkAtLastReply(dbPath: string, branchId: string): number {
+  const db = new DatabaseSync(dbPath)
+  try {
+    const row = db
+      .prepare(
+        `SELECT COALESCE(MAX(position), 0) AS p FROM story_entries
+          WHERE branch_id = ? AND kind = 'ai_reply'`,
+      )
+      .get(branchId) as { p: number }
+    db.prepare(
+      `UPDATE branches SET classifier_status = json_set(
+         COALESCE(classifier_status, '{}'), '$.state', 'idle', '$.retryCount', 0,
+         '$.lastSuccessAt', NULL, '$.lastError', NULL, '$.processedThrough', ?)
+       WHERE id = ?`,
+    ).run(row.p, branchId)
+    return row.p
+  } finally {
+    db.close()
+  }
+}
+
 /** Strip the `classifier` agent assignment so the pass fails pre-flight. Runs before launch. */
 export function unassignClassifierAgent(dbPath: string): void {
   const db = new DatabaseSync(dbPath)

--- a/e2e/harness/seed.ts
+++ b/e2e/harness/seed.ts
@@ -157,6 +157,15 @@ export function setClassifierCadence(dbPath: string, storyId: string, cadence: n
   }
 }
 
+function parkWatermark(db: DatabaseSync, branchId: string, processedThrough: number): void {
+  db.prepare(
+    `UPDATE branches SET classifier_status = json_set(
+       COALESCE(classifier_status, '{}'), '$.state', 'idle', '$.retryCount', 0,
+       '$.lastSuccessAt', NULL, '$.lastError', NULL, '$.processedThrough', ?)
+     WHERE id = ?`,
+  ).run(processedThrough, branchId)
+}
+
 /**
  * Append `count` filler turns and park the classifier watermark at `processedThrough`,
  * so the branch carries a backlog deeper than the reader's entry window. Each filler
@@ -187,43 +196,32 @@ export function seedClassifierBacklog(
         `FILLER-${position} nothing happens.`,
       )
     }
-    db.prepare(
-      `UPDATE branches SET classifier_status = json_set(
-         COALESCE(classifier_status, '{}'), '$.state', 'idle', '$.retryCount', 0,
-         '$.lastSuccessAt', NULL, '$.lastError', NULL, '$.processedThrough', ?)
-       WHERE id = ?`,
-    ).run(processedThrough, branchId)
+    parkWatermark(db, branchId, processedThrough)
   } finally {
     db.close()
   }
 }
 
 /**
- * Park the classifier watermark at the last settled turn and return that position, so
- * the cadence counts only the turns a spec commits after launch. The fixture seeds
- * `classifier_status = NULL`, which floors the window at 0 — a pass would otherwise
- * claim the whole seeded branch and the spec could not say which turns it read.
- *
- * Anchors on the last `ai_reply`, not MAX(position): the fixture ends on a dangling
- * in-flight turn that boot recovery reverse-replays away, so the seed-time maximum
- * sits one position above the tip the app actually boots with — high enough to push
- * the first committed turn out of the window and shift every handle. Runs before launch.
+ * Park the classifier watermark at the last `ai_reply` and return that position, so a pass
+ * covers only the turns a spec commits after launch — the fixture seeds
+ * `classifier_status = NULL`, which floors the window at 0. Anchors on the last reply rather
+ * than MAX(position) because the fixture ends on a dangling in-flight turn that boot recovery
+ * reverse-replays, putting the seed-time maximum above the tip the app boots with.
+ * Runs before launch.
  */
 export function parkClassifierWatermarkAtLastReply(dbPath: string, branchId: string): number {
   const db = new DatabaseSync(dbPath)
   try {
     const row = db
       .prepare(
-        `SELECT COALESCE(MAX(position), 0) AS p FROM story_entries
-          WHERE branch_id = ? AND kind = 'ai_reply'`,
+        `SELECT MAX(position) AS p FROM story_entries WHERE branch_id = ? AND kind = 'ai_reply'`,
       )
-      .get(branchId) as { p: number }
-    db.prepare(
-      `UPDATE branches SET classifier_status = json_set(
-         COALESCE(classifier_status, '{}'), '$.state', 'idle', '$.retryCount', 0,
-         '$.lastSuccessAt', NULL, '$.lastError', NULL, '$.processedThrough', ?)
-       WHERE id = ?`,
-    ).run(row.p, branchId)
+      .get(branchId) as { p: number | null }
+    if (row.p === null) {
+      throw new Error(`No ai_reply on branch ${branchId}: the watermark would floor at 0.`)
+    }
+    parkWatermark(db, branchId, row.p)
     return row.p
   } finally {
     db.close()

--- a/e2e/tests/reader-undo-redo.spec.ts
+++ b/e2e/tests/reader-undo-redo.spec.ts
@@ -4,7 +4,13 @@ import { queryApp } from '../harness/db'
 import { installEmbedderModel } from '../harness/embedder'
 import { launchApp, type LaunchedApp } from '../harness/launch'
 import { startMockLlm, type MockLlm } from '../harness/mock-llm'
-import { createSeededUserDataDir, removeUserDataDir, setProviderEndpoint } from '../harness/seed'
+import {
+  createSeededUserDataDir,
+  parkClassifierWatermarkAtLastReply,
+  removeUserDataDir,
+  setClassifierCadence,
+  setProviderEndpoint,
+} from '../harness/seed'
 import { home } from '../locators/home'
 import { reader } from '../locators/reader'
 
@@ -71,5 +77,176 @@ test.describe('reader — undo / redo a turn', () => {
     await reader.actionsTrigger(app.window).click()
     await reader.redoRow(app.window).click()
     await expect.poll(replyCount, { timeout: 15_000 }).toBe(1)
+  })
+})
+
+// The survival anchor only bites when a classifier delta sits ABOVE the undone
+// turn's create in log order while being anchored to an entry BELOW it. That
+// arrangement needs a real pass whose window spans two turns, so only a running
+// app produces it: the window is built from SQLite at pass time, the handles are
+// minted there, and the reconciler stamps deltas.entry_id from sourceTurn.
+// Unit fixtures hand-write that log; this proves the app actually creates it.
+const SURVIVE_REPLY_A = 'E2E-SURVIVE-A the courier waters the horse at dawn.'
+const SURVIVE_REPLY_B = 'E2E-SURVIVE-B the bridge groans underfoot.'
+const FACT_A = 'The courier waters the horse at dawn'
+const FACT_B = 'The bridge collapses behind the courier'
+
+test.describe('reader — undo of a turn covered by a two-turn classifier pass', () => {
+  let app: LaunchedApp
+  let mock: MockLlm
+  let userDataDir: string | undefined
+  // Watermark parked at the last settled turn: every position above it is this spec's.
+  let tip: number
+
+  test.beforeAll(async () => {
+    test.setTimeout(180_000)
+    const seeded = createSeededUserDataDir()
+    userDataDir = seeded.userDataDir
+    await installEmbedderModel(userDataDir)
+    mock = await startMockLlm()
+    // t1..t4 are the window's prose handles in ascending position: turn A's
+    // user_action, turn A's reply, turn B's user_action, turn B's reply. The
+    // delta's entry_id comes from sourceTurn (lib/classifier/plan.ts), so t2
+    // anchors a fact to the SURVIVING turn and t4 to the undone one.
+    mock.setStructured('periodic-classifier', {
+      happenings: [
+        { title: FACT_A, description: 'A quiet halt.', sourceTurn: 't2' },
+        { title: FACT_B, description: 'Timbers give way.', sourceTurn: 't4' },
+      ],
+      relationships: [],
+      statusFlips: [],
+      newCharacters: [],
+    })
+    setProviderEndpoint(seeded.dbPath, mock.url)
+    // unprocessedTurnCount counts entry ROWS, not turn pairs: two turns are four
+    // rows, so cadence 4 fires exactly one pass and only after turn B — the
+    // single pass whose window covers both turns.
+    setClassifierCadence(seeded.dbPath, 'story_hero', 4)
+    tip = parkClassifierWatermarkAtLastReply(seeded.dbPath, 'br_hero_main')
+    app = await launchApp({ userDataDir, cleanupUserData: true })
+  })
+
+  test.afterAll(async () => {
+    await app?.close()
+    await mock?.close()
+    removeUserDataDir(userDataDir)
+  })
+
+  async function branchId(): Promise<string> {
+    return (
+      await queryApp(app.window, `SELECT current_branch_id FROM stories WHERE id = 'story_hero'`)
+    )[0][0] as string
+  }
+
+  async function happeningCount(branch: string, title: string): Promise<number> {
+    return (
+      await queryApp(
+        app.window,
+        `SELECT COUNT(*) FROM happenings WHERE branch_id = ? AND title = ?`,
+        [branch, title],
+      )
+    )[0][0] as number
+  }
+
+  async function turnBEntryCount(branch: string): Promise<number> {
+    return (
+      await queryApp(
+        app.window,
+        `SELECT COUNT(*) FROM story_entries WHERE branch_id = ? AND content LIKE '%E2E-SURVIVE-B%'`,
+        [branch],
+      )
+    )[0][0] as number
+  }
+
+  test('spares the classifier fact anchored to the surviving turn, clamps the watermark, and redo restores the unit', async () => {
+    await home.openStory(app.window, 'The Veilstone Courier').click()
+    await expect(reader.composer(app.window)).toBeVisible({ timeout: 20_000 })
+
+    mock.setNarrative(SURVIVE_REPLY_A)
+    await reader.composer(app.window).fill('E2E-SURVIVE-A I rest the horse.')
+    await reader.send(app.window).click()
+    await expect(app.window.getByText('E2E-SURVIVE-A the courier', { exact: false })).toBeVisible({
+      timeout: 30_000,
+    })
+
+    mock.setNarrative(SURVIVE_REPLY_B)
+    await reader.composer(app.window).fill('E2E-SURVIVE-B I cross the bridge.')
+    await reader.send(app.window).click()
+    await expect(app.window.getByText('E2E-SURVIVE-B the bridge', { exact: false })).toBeVisible({
+      timeout: 30_000,
+    })
+
+    const branch = await branchId()
+    await expect
+      .poll(() => mock.requests.some((r) => r.agent === 'periodic-classifier'), { timeout: 30_000 })
+      .toBe(true)
+    await expect.poll(() => happeningCount(branch, FACT_A), { timeout: 30_000 }).toBe(1)
+    await expect.poll(() => happeningCount(branch, FACT_B), { timeout: 30_000 }).toBe(1)
+
+    // Exactly one pass: two passes would each see a one-turn window, and t2/t4
+    // would resolve by head-fallback instead of to the turns this spec means.
+    expect(mock.requests.filter((r) => r.agent === 'periodic-classifier')).toHaveLength(1)
+
+    // The four rows this spec committed, ascending: A_user, A_reply, B_user, B_reply.
+    const rows = await queryApp(
+      app.window,
+      `SELECT id, position FROM story_entries WHERE branch_id = ? AND position > ? ORDER BY position`,
+      [branch, tip],
+    )
+    expect(rows).toHaveLength(4)
+    const aReplyPosition = rows[1][1] as number
+    const bUserPosition = rows[2][1] as number
+
+    // Precondition, not the assertion under test: the fixture is only meaningful
+    // if the two facts really landed on opposite sides of turn B's start, and
+    // both above it in the log. A head-fallback would put them both on B.
+    const anchors = await queryApp(
+      app.window,
+      `SELECT h.title, e.position, d.log_position FROM deltas d
+         JOIN happenings h ON h.branch_id = d.branch_id AND h.id = d.target_id
+         JOIN story_entries e ON e.branch_id = d.branch_id AND e.id = d.entry_id
+        WHERE d.branch_id = ? AND d.target_table = 'happenings' AND h.title IN (?, ?)`,
+      [branch, FACT_A, FACT_B],
+    )
+    expect(anchors).toHaveLength(2)
+    const anchorFor = (title: string) => anchors.find((r) => r[0] === title)!
+    expect(anchorFor(FACT_A)[1]).toBe(aReplyPosition)
+    expect(anchorFor(FACT_B)[1]).toBeGreaterThanOrEqual(bUserPosition)
+
+    const createLogPosition = (
+      await queryApp(
+        app.window,
+        `SELECT log_position FROM deltas WHERE branch_id = ? AND target_table = 'story_entries'
+           AND op = 'create' AND target_id = ?`,
+        [branch, rows[2][0] as string],
+      )
+    )[0][0] as number
+    // Both facts sit above turn B's create — the whole point: a bare suffix
+    // sweep would take the surviving turn's fact down with the undone turn.
+    expect(anchorFor(FACT_A)[2]).toBeGreaterThan(createLogPosition)
+
+    await reader.actionsTrigger(app.window).click()
+    await reader.undoRow(app.window).click()
+    await expect.poll(() => turnBEntryCount(branch), { timeout: 15_000 }).toBe(0)
+
+    // The fact anchored to the undone turn goes; the lagging fact about the
+    // surviving turn stays, despite sitting higher in the log.
+    expect(await happeningCount(branch, FACT_B)).toBe(0)
+    expect(await happeningCount(branch, FACT_A)).toBe(1)
+
+    // processedThrough clamps to position(B) - 1 so the next pass re-covers B.
+    const watermark = await queryApp(
+      app.window,
+      `SELECT json_extract(classifier_status, '$.processedThrough') FROM branches WHERE id = ?`,
+      [branch],
+    )
+    expect(watermark[0][0]).toBe(bUserPosition - 1)
+
+    // Redo restores the whole unit — the turn and its B-anchored fact.
+    await reader.actionsTrigger(app.window).click()
+    await reader.redoRow(app.window).click()
+    await expect.poll(() => turnBEntryCount(branch), { timeout: 15_000 }).toBe(2)
+    expect(await happeningCount(branch, FACT_B)).toBe(1)
+    expect(await happeningCount(branch, FACT_A)).toBe(1)
   })
 })

--- a/e2e/tests/reader-undo-redo.spec.ts
+++ b/e2e/tests/reader-undo-redo.spec.ts
@@ -221,8 +221,8 @@ test.describe('reader — undo of a turn covered by a two-turn classifier pass',
         [branch, rows[2][0] as string],
       )
     )[0][0] as number
-    // Both facts sit above turn B's create — the whole point: a bare suffix
-    // sweep would take the surviving turn's fact down with the undone turn.
+    // FACT_A sits above turn B's create — the whole point: a bare suffix sweep
+    // would take the surviving turn's fact down with the undone turn.
     expect(anchorFor(FACT_A)[2]).toBeGreaterThan(createLogPosition)
 
     await reader.actionsTrigger(app.window).click()

--- a/lib/actions/story-entries/undo-classifier.test.ts
+++ b/lib/actions/story-entries/undo-classifier.test.ts
@@ -359,3 +359,56 @@ describe('AC6 — undo floor in a wizard-created story', () => {
     expect(entriesStore.getById('e_opening')).toBeDefined()
   })
 })
+
+describe('AC4 — CTRL-Z with a classifier run mid-flight', () => {
+  it('aborts the run and holds the sweep until its terminal resolves', async () => {
+    const { db, runInTransaction } = await createTestDb()
+    const ctx = { db, runInTransaction }
+    const entries = [entry('e_opening', 1, 'opening'), entry('e_t1', 2, 'ai_reply')]
+    await db.insert(stories).values({ id: 's1', title: 'T', createdAt: 1, updatedAt: 1 })
+    await db.insert(branches).values({ id: 'b1', storyId: 's1', name: 'm', createdAt: 1 })
+    await db.insert(storyEntries).values(entries)
+    await db
+      .insert(deltas)
+      .values(delta('d_t1', 1, 'act_t1', 'ai_classifier', 'story_entries', 'e_t1', 'create'))
+    entriesStore.hydrate('b1', entries)
+
+    let resolveTerminal!: () => void
+    const terminal = new Promise<void>((r) => {
+      resolveTerminal = r
+    })
+    const abortController = new AbortController()
+    let aborted = false
+    abortController.signal.addEventListener('abort', () => {
+      aborted = true
+    })
+    // A no-gate classifier run: does not block user edits, so undo proceeds
+    // and must drain it via the C3 bracket.
+    generationStore.startRun({
+      runId: 'run_c',
+      kind: 'periodic-classifier',
+      gateBehavior: 'no-gate',
+      actionId: 'act_c',
+      storyId: 's1',
+      branchId: 'b1',
+      abortController,
+      currentPhase: '',
+      intermediates: {},
+      terminal,
+      resolveTerminal,
+    })
+
+    const done = undoLastAction('b1', ctx)
+    // The bracket aborts the doomed run synchronously, before any sweep work…
+    expect(aborted).toBe(true)
+    // …and the sweep waits for the terminal, not merely a microtask turn: an
+    // unbracketed sweep would have finished within this flush (in-memory SQLite,
+    // no real I/O), so the entry still standing is the barrier's own evidence.
+    await new Promise((r) => setTimeout(r, 0))
+    expect(entriesStore.getById('e_t1')).toBeDefined()
+
+    resolveTerminal()
+    expect((await done).status).toBe('ok')
+    expect(entriesStore.getById('e_t1')).toBeUndefined()
+  })
+})

--- a/lib/actions/story-entries/undo-classifier.test.ts
+++ b/lib/actions/story-entries/undo-classifier.test.ts
@@ -1,0 +1,261 @@
+import { eq } from 'drizzle-orm'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  branches,
+  deltas,
+  happeningAwareness,
+  happenings,
+  stories,
+  storyEntries,
+  type ClassifierStatus,
+  type Delta,
+  type EntryMetadata,
+  type Happening,
+  type HappeningAwareness,
+  type StoryEntry,
+} from '@/lib/db'
+import { createTestDb } from '@/lib/db/__tests__/test-db'
+import {
+  entriesStore,
+  generationStore,
+  happeningAwarenessStore,
+  happeningsStore,
+  undoRedoStore,
+} from '@/lib/stores'
+
+import { redoLastAction, undoLastAction } from './undo'
+
+afterEach(() => {
+  entriesStore.__reset()
+  generationStore.__reset()
+  happeningsStore.__reset()
+  happeningAwarenessStore.__reset()
+  undoRedoStore.clear()
+})
+
+const status = (processedThrough: number): ClassifierStatus => ({
+  state: 'idle',
+  lastSuccessAt: null,
+  lastError: null,
+  retryCount: 0,
+  processedThrough,
+})
+
+const entry = (
+  id: string,
+  position: number,
+  kind: StoryEntry['kind'],
+  metadata: EntryMetadata | null = null,
+): StoryEntry => ({
+  id,
+  branchId: 'b1',
+  position,
+  kind,
+  content: `${id} content`,
+  chapterId: null,
+  metadata,
+  createdAt: position,
+})
+
+const delta = (
+  id: string,
+  logPosition: number,
+  actionId: string,
+  source: Delta['source'],
+  targetTable: string,
+  targetId: string,
+  op: Delta['op'],
+  entryId: string | null = null,
+  undoPayload: Record<string, unknown> | null = null,
+): Delta => ({
+  id,
+  branchId: 'b1',
+  actionId,
+  op,
+  targetTable,
+  targetId,
+  entryId,
+  source,
+  undoPayload,
+  logPosition,
+  encodingVersion: 1,
+  createdAt: logPosition,
+})
+
+const hap = (id: string, title: string, occurredAtEntryId: string | null = null): Happening => ({
+  id,
+  branchId: 'b1',
+  title,
+  description: null,
+  category: null,
+  icon: null,
+  temporal: null,
+  occurredAtEntryId,
+  commonKnowledge: 0,
+  embeddingStale: 0,
+  createdAt: 1,
+  updatedAt: 1,
+})
+
+const AWARENESS_B: HappeningAwareness = {
+  id: 'haw_b1',
+  branchId: 'b1',
+  happeningId: 'hap_b1',
+  characterId: 'char_kael',
+  learnedAtEntryId: 'e_b',
+  decayResistance: null,
+  retrievalCount: 0,
+  source: 'witnessed firsthand',
+}
+
+const B_METADATA: EntryMetadata = { sceneEntities: [], currentLocationId: null, worldTime: 5 }
+
+// AC1's log: turn A, classifier pass anchored to A, turn B (with a piggyback
+// metadata delta), classifier pass with facts anchored to both A and B.
+async function seedAc1() {
+  const { db, runInTransaction } = await createTestDb()
+  const ctx = { db, runInTransaction }
+  const entries = [
+    entry('e_opening', 1, 'opening'),
+    entry('e_a', 2, 'ai_reply'),
+    entry('e_b', 3, 'ai_reply', B_METADATA),
+  ]
+  const haps = [
+    hap('hap_a1', 'fact about A (pass 1)', 'e_a'),
+    hap('hap_a2', 'fact about A (pass 2)', 'e_a'),
+    hap('hap_b1', 'fact about B (pass 2)', 'e_b'),
+  ]
+  await db.insert(stories).values({ id: 's1', title: 'T', createdAt: 1, updatedAt: 1 })
+  await db.insert(branches).values({
+    id: 'b1',
+    storyId: 's1',
+    name: 'm',
+    createdAt: 1,
+    classifierStatus: status(3),
+  })
+  await db.insert(storyEntries).values(entries)
+  await db.insert(happenings).values(haps)
+  await db.insert(happeningAwareness).values(AWARENESS_B)
+  await db
+    .insert(deltas)
+    .values([
+      delta('d_a_create', 1, 'act_a', 'ai_classifier', 'story_entries', 'e_a', 'create'),
+      delta(
+        'd_c1_hap',
+        2,
+        'act_c1',
+        'periodic_classifier',
+        'happenings',
+        'hap_a1',
+        'create',
+        'e_a',
+      ),
+      delta('d_b_create', 3, 'act_b', 'ai_classifier', 'story_entries', 'e_b', 'create'),
+      delta(
+        'd_b_meta',
+        4,
+        'act_b',
+        'piggyback_tagged_block',
+        'story_entries',
+        'e_b',
+        'update',
+        'e_b',
+        { metadata: null },
+      ),
+      delta(
+        'd_c2_hapA',
+        5,
+        'act_c2',
+        'periodic_classifier',
+        'happenings',
+        'hap_a2',
+        'create',
+        'e_a',
+      ),
+      delta(
+        'd_c2_hapB',
+        6,
+        'act_c2',
+        'periodic_classifier',
+        'happenings',
+        'hap_b1',
+        'create',
+        'e_b',
+      ),
+      delta(
+        'd_c2_awB',
+        7,
+        'act_c2',
+        'periodic_classifier',
+        'happening_awareness',
+        'haw_b1',
+        'create',
+        'e_b',
+      ),
+    ])
+  entriesStore.hydrate('b1', entries)
+  happeningsStore.hydrate('b1', haps)
+  happeningAwarenessStore.hydrate('b1', [AWARENESS_B])
+  return { db, ctx }
+}
+
+describe('AC1 — undo of turn B spares facts anchored to surviving turn A', () => {
+  it('reverses B, its piggyback delta, and B-anchored classifier facts; spares A-anchored facts; clamps; redo restores the unit', async () => {
+    const { db, ctx } = await seedAc1()
+
+    expect((await undoLastAction('b1', ctx)).status).toBe('ok')
+
+    // B and everything anchored to it is gone.
+    expect(entriesStore.getById('e_b')).toBeUndefined()
+    expect((await db.select().from(storyEntries).where(eq(storyEntries.id, 'e_b'))).length).toBe(0)
+    expect((await db.select().from(happenings).where(eq(happenings.id, 'hap_b1'))).length).toBe(0)
+    expect(
+      (await db.select().from(happeningAwareness).where(eq(happeningAwareness.id, 'haw_b1')))
+        .length,
+    ).toBe(0)
+
+    // A and its facts — including the LAGGING pass-2 fact committed above B — survive.
+    expect(entriesStore.getById('e_a')).toBeDefined()
+    expect((await db.select().from(happenings).where(eq(happenings.id, 'hap_a1'))).length).toBe(1)
+    expect((await db.select().from(happenings).where(eq(happenings.id, 'hap_a2'))).length).toBe(1)
+
+    // Surviving facts keep their delta rows; the reversed suffix is pruned.
+    const remaining = (await db.select().from(deltas).where(eq(deltas.branchId, 'b1'))).map(
+      (d) => d.id,
+    )
+    expect(remaining.sort()).toEqual(['d_a_create', 'd_c1_hap', 'd_c2_hapA'])
+
+    // processedThrough clamps below B (position 3 → 2).
+    const [branch] = await db.select().from(branches).where(eq(branches.id, 'b1'))
+    expect(branch.classifierStatus?.processedThrough).toBe(2)
+
+    // Redo restores the whole unit — entry (with its piggyback metadata),
+    // B-anchored facts, and their delta rows — without touching the watermark.
+    expect((await redoLastAction('b1', ctx)).status).toBe('ok')
+    expect(entriesStore.getById('e_b')).toBeDefined()
+    const [eB] = await db.select().from(storyEntries).where(eq(storyEntries.id, 'e_b'))
+    expect(eB.metadata).toEqual(B_METADATA)
+    expect((await db.select().from(happenings).where(eq(happenings.id, 'hap_b1'))).length).toBe(1)
+    expect(
+      (await db.select().from(happeningAwareness).where(eq(happeningAwareness.id, 'haw_b1')))
+        .length,
+    ).toBe(1)
+    const restored = (await db.select().from(deltas).where(eq(deltas.branchId, 'b1'))).map(
+      (d) => d.id,
+    )
+    expect(restored.sort()).toEqual(
+      [
+        'd_a_create',
+        'd_b_create',
+        'd_b_meta',
+        'd_c1_hap',
+        'd_c2_hapA',
+        'd_c2_hapB',
+        'd_c2_awB',
+      ].sort(),
+    )
+    const [branchAfterRedo] = await db.select().from(branches).where(eq(branches.id, 'b1'))
+    expect(branchAfterRedo.classifierStatus?.processedThrough).toBe(2)
+  })
+})

--- a/lib/actions/story-entries/undo-classifier.test.ts
+++ b/lib/actions/story-entries/undo-classifier.test.ts
@@ -112,11 +112,24 @@ const AWARENESS_B: HappeningAwareness = {
 
 const B_METADATA: EntryMetadata = { sceneEntities: [], currentLocationId: null, worldTime: 5 }
 
+async function seedBranch(entries: StoryEntry[], classifierStatus?: ClassifierStatus) {
+  const { db, runInTransaction } = await createTestDb()
+  await db.insert(stories).values({ id: 's1', title: 'T', createdAt: 1, updatedAt: 1 })
+  await db.insert(branches).values({
+    id: 'b1',
+    storyId: 's1',
+    name: 'm',
+    createdAt: 1,
+    ...(classifierStatus ? { classifierStatus } : {}),
+  })
+  await db.insert(storyEntries).values(entries)
+  entriesStore.hydrate('b1', entries)
+  return { db, ctx: { db, runInTransaction } }
+}
+
 // AC1's log: turn A, classifier pass anchored to A, turn B (with a piggyback
 // metadata delta), classifier pass with facts anchored to both A and B.
 async function seedAc1() {
-  const { db, runInTransaction } = await createTestDb()
-  const ctx = { db, runInTransaction }
   const entries = [
     entry('e_opening', 1, 'opening'),
     entry('e_a', 2, 'ai_reply'),
@@ -127,15 +140,7 @@ async function seedAc1() {
     hap('hap_a2', 'fact about A (pass 2)', 'e_a'),
     hap('hap_b1', 'fact about B (pass 2)', 'e_b'),
   ]
-  await db.insert(stories).values({ id: 's1', title: 'T', createdAt: 1, updatedAt: 1 })
-  await db.insert(branches).values({
-    id: 'b1',
-    storyId: 's1',
-    name: 'm',
-    createdAt: 1,
-    classifierStatus: status(3),
-  })
-  await db.insert(storyEntries).values(entries)
+  const { db, ctx } = await seedBranch(entries, status(3))
   await db.insert(happenings).values(haps)
   await db.insert(happeningAwareness).values(AWARENESS_B)
   await db
@@ -195,7 +200,6 @@ async function seedAc1() {
         'e_b',
       ),
     ])
-  entriesStore.hydrate('b1', entries)
   happeningsStore.hydrate('b1', haps)
   happeningAwarenessStore.hydrate('b1', [AWARENESS_B])
   return { db, ctx }
@@ -263,25 +267,20 @@ describe('AC1 — undo of turn B spares facts anchored to surviving turn A', () 
 
 describe('AC2 — classifier group at the literal head', () => {
   it('steps over it, targets the turn beneath, and the suffix sweep carries the classifier group down', async () => {
-    const { db, runInTransaction } = await createTestDb()
-    const ctx = { db, runInTransaction }
-    const entries = [
+    const { db, ctx } = await seedBranch([
       entry('e_opening', 1, 'opening'),
       entry('e_a', 2, 'ai_reply'),
       entry('e_b', 3, 'ai_reply'),
-    ]
-    await db.insert(stories).values({ id: 's1', title: 'T', createdAt: 1, updatedAt: 1 })
-    await db.insert(branches).values({ id: 'b1', storyId: 's1', name: 'm', createdAt: 1 })
-    await db.insert(storyEntries).values(entries)
-    await db.insert(happenings).values(hap('hap_b1', 'fact about B', 'e_b'))
+    ])
+    const hapB = hap('hap_b1', 'fact about B', 'e_b')
+    await db.insert(happenings).values(hapB)
     await db.insert(deltas).values([
       delta('d_a_create', 1, 'act_a', 'ai_classifier', 'story_entries', 'e_a', 'create'),
       delta('d_b_create', 2, 'act_b', 'ai_classifier', 'story_entries', 'e_b', 'create'),
       // The literal head is a classifier group — never an undo target.
       delta('d_c_hapB', 3, 'act_c', 'periodic_classifier', 'happenings', 'hap_b1', 'create', 'e_b'),
     ])
-    entriesStore.hydrate('b1', entries)
-    happeningsStore.hydrate('b1', [hap('hap_b1', 'fact about B', 'e_b')])
+    happeningsStore.hydrate('b1', [hapB])
 
     expect((await undoLastAction('b1', ctx)).status).toBe('ok')
 
@@ -299,13 +298,12 @@ describe('AC2 — classifier group at the literal head', () => {
 
 describe('AC3 — user field-edit above a classifier group', () => {
   it('reverses only the edit group; the classifier group stays put', async () => {
-    const { db, runInTransaction } = await createTestDb()
-    const ctx = { db, runInTransaction }
-    const entries = [entry('e_opening', 1, 'opening'), entry('e_a', 2, 'ai_reply')]
-    await db.insert(stories).values({ id: 's1', title: 'T', createdAt: 1, updatedAt: 1 })
-    await db.insert(branches).values({ id: 'b1', storyId: 's1', name: 'm', createdAt: 1 })
-    await db.insert(storyEntries).values(entries)
-    await db.insert(happenings).values(hap('hap_a1', 'Edited title', 'e_a'))
+    const { db, ctx } = await seedBranch([
+      entry('e_opening', 1, 'opening'),
+      entry('e_a', 2, 'ai_reply'),
+    ])
+    const hapA = hap('hap_a1', 'Edited title', 'e_a')
+    await db.insert(happenings).values(hapA)
     await db.insert(deltas).values([
       delta('d_a_create', 1, 'act_a', 'ai_classifier', 'story_entries', 'e_a', 'create'),
       delta('d_c_hapA', 2, 'act_c', 'periodic_classifier', 'happenings', 'hap_a1', 'create', 'e_a'),
@@ -314,8 +312,7 @@ describe('AC3 — user field-edit above a classifier group', () => {
         title: 'Original title',
       }),
     ])
-    entriesStore.hydrate('b1', entries)
-    happeningsStore.hydrate('b1', [hap('hap_a1', 'Edited title', 'e_a')])
+    happeningsStore.hydrate('b1', [hapA])
 
     expect((await undoLastAction('b1', ctx)).status).toBe('ok')
 
@@ -337,13 +334,8 @@ describe('AC3 — user field-edit above a classifier group', () => {
 
 describe('AC6 — undo floor in a wizard-created story', () => {
   it('rejects in a fresh story (no deltas) and stops at the opening after the only turn is undone', async () => {
-    const { db, runInTransaction } = await createTestDb()
-    const ctx = { db, runInTransaction }
-    await db.insert(stories).values({ id: 's1', title: 'T', createdAt: 1, updatedAt: 1 })
-    await db.insert(branches).values({ id: 'b1', storyId: 's1', name: 'm', createdAt: 1 })
     // Wizard commit: opening baked in, delta log empty.
-    await db.insert(storyEntries).values(entry('e_opening', 1, 'opening'))
-    entriesStore.hydrate('b1', [entry('e_opening', 1, 'opening')])
+    const { db, ctx } = await seedBranch([entry('e_opening', 1, 'opening')])
 
     expect((await undoLastAction('b1', ctx)).status).toBe('rejected')
 
@@ -363,16 +355,13 @@ describe('AC6 — undo floor in a wizard-created story', () => {
 
 describe('AC4 — CTRL-Z with a classifier run mid-flight', () => {
   it('aborts the run and holds the sweep until its terminal resolves', async () => {
-    const { db, runInTransaction } = await createTestDb()
-    const ctx = { db, runInTransaction }
-    const entries = [entry('e_opening', 1, 'opening'), entry('e_t1', 2, 'ai_reply')]
-    await db.insert(stories).values({ id: 's1', title: 'T', createdAt: 1, updatedAt: 1 })
-    await db.insert(branches).values({ id: 'b1', storyId: 's1', name: 'm', createdAt: 1 })
-    await db.insert(storyEntries).values(entries)
+    const { db, ctx } = await seedBranch([
+      entry('e_opening', 1, 'opening'),
+      entry('e_t1', 2, 'ai_reply'),
+    ])
     await db
       .insert(deltas)
       .values(delta('d_t1', 1, 'act_t1', 'ai_classifier', 'story_entries', 'e_t1', 'create'))
-    entriesStore.hydrate('b1', entries)
 
     let resolveTerminal!: () => void
     const terminal = new Promise<void>((r) => {
@@ -416,19 +405,12 @@ describe('AC4 — CTRL-Z with a classifier run mid-flight', () => {
 
 describe('AC5 — redo of a classifier-processed turn tolerates re-derivation', () => {
   it('keeps the watermark clamped after redo; a re-deriving pass upserts awareness cleanly and only duplicates the happening', async () => {
-    const { db, runInTransaction } = await createTestDb()
-    const ctx = { db, runInTransaction }
-    const entries = [entry('e_opening', 1, 'opening'), entry('e_b', 2, 'ai_reply')]
-    await db.insert(stories).values({ id: 's1', title: 'T', createdAt: 1, updatedAt: 1 })
-    await db.insert(branches).values({
-      id: 'b1',
-      storyId: 's1',
-      name: 'm',
-      createdAt: 1,
-      classifierStatus: status(2),
-    })
-    await db.insert(storyEntries).values(entries)
-    await db.insert(happenings).values(hap('hap_b1', 'fact about B', 'e_b'))
+    const { db, ctx } = await seedBranch(
+      [entry('e_opening', 1, 'opening'), entry('e_b', 2, 'ai_reply')],
+      status(2),
+    )
+    const hapB = hap('hap_b1', 'fact about B', 'e_b')
+    await db.insert(happenings).values(hapB)
     await db.insert(happeningAwareness).values(AWARENESS_B)
     await db
       .insert(deltas)
@@ -455,8 +437,7 @@ describe('AC5 — redo of a classifier-processed turn tolerates re-derivation', 
           'e_b',
         ),
       ])
-    entriesStore.hydrate('b1', entries)
-    happeningsStore.hydrate('b1', [hap('hap_b1', 'fact about B', 'e_b')])
+    happeningsStore.hydrate('b1', [hapB])
     happeningAwarenessStore.hydrate('b1', [AWARENESS_B])
 
     expect((await undoLastAction('b1', ctx)).status).toBe('ok')

--- a/lib/actions/story-entries/undo-classifier.test.ts
+++ b/lib/actions/story-entries/undo-classifier.test.ts
@@ -25,6 +25,7 @@ import {
 } from '@/lib/stores'
 
 import { redoLastAction, undoLastAction } from './undo'
+import { applyDeltaAction } from '../delta/apply-delta-action'
 
 afterEach(() => {
   entriesStore.__reset()
@@ -410,5 +411,128 @@ describe('AC4 — CTRL-Z with a classifier run mid-flight', () => {
     resolveTerminal()
     expect((await done).status).toBe('ok')
     expect(entriesStore.getById('e_t1')).toBeUndefined()
+  })
+})
+
+describe('AC5 — redo of a classifier-processed turn tolerates re-derivation', () => {
+  it('keeps the watermark clamped after redo; a re-deriving pass upserts awareness cleanly and only duplicates the happening', async () => {
+    const { db, runInTransaction } = await createTestDb()
+    const ctx = { db, runInTransaction }
+    const entries = [entry('e_opening', 1, 'opening'), entry('e_b', 2, 'ai_reply')]
+    await db.insert(stories).values({ id: 's1', title: 'T', createdAt: 1, updatedAt: 1 })
+    await db.insert(branches).values({
+      id: 'b1',
+      storyId: 's1',
+      name: 'm',
+      createdAt: 1,
+      classifierStatus: status(2),
+    })
+    await db.insert(storyEntries).values(entries)
+    await db.insert(happenings).values(hap('hap_b1', 'fact about B', 'e_b'))
+    await db.insert(happeningAwareness).values(AWARENESS_B)
+    await db
+      .insert(deltas)
+      .values([
+        delta('d_b_create', 1, 'act_b', 'ai_classifier', 'story_entries', 'e_b', 'create'),
+        delta(
+          'd_c_hap',
+          2,
+          'act_c',
+          'periodic_classifier',
+          'happenings',
+          'hap_b1',
+          'create',
+          'e_b',
+        ),
+        delta(
+          'd_c_aw',
+          3,
+          'act_c',
+          'periodic_classifier',
+          'happening_awareness',
+          'haw_b1',
+          'create',
+          'e_b',
+        ),
+      ])
+    entriesStore.hydrate('b1', entries)
+    happeningsStore.hydrate('b1', [hap('hap_b1', 'fact about B', 'e_b')])
+    happeningAwarenessStore.hydrate('b1', [AWARENESS_B])
+
+    expect((await undoLastAction('b1', ctx)).status).toBe('ok')
+    expect((await redoLastAction('b1', ctx)).status).toBe('ok')
+
+    // Redo does NOT restore processedThrough — the clamp survives, so the next
+    // pass re-covers B (data-model.md → Survival anchor, redo tolerance).
+    const [branch] = await db.select().from(branches).where(eq(branches.id, 'b1'))
+    expect(branch.classifierStatus?.processedThrough).toBe(1)
+
+    // The re-deriving pass, at the write-path seam: a fresh happening row for
+    // the same fact is a tolerated duplicate (cleaned at M5 chapter-close dedup)…
+    const dupHap = await applyDeltaAction(
+      {
+        action: {
+          kind: 'createHappening',
+          source: 'periodic_classifier',
+          payload: {
+            entry: { ...hap('hap_b1_dup', 'fact about B', 'e_b'), createdAt: 9, updatedAt: 9 },
+          },
+        },
+        actionId: 'act_rederive',
+        branchId: 'b1',
+        entryId: 'e_b',
+      },
+      ctx,
+    )
+    expect(dupHap.status).toBe('ok')
+
+    // …while the awareness re-derive hits the natural-key upsert: it merges
+    // into the redo-restored row instead of violating haw_natural_uniq.
+    const mergeAw = await applyDeltaAction(
+      {
+        action: {
+          kind: 'upsertHappeningAwareness',
+          source: 'periodic_classifier',
+          payload: {
+            branchId: 'b1',
+            characterId: 'char_kael',
+            happeningId: 'hap_b1',
+            source: 'retold by Jorin',
+          },
+        },
+        actionId: 'act_rederive',
+        branchId: 'b1',
+        entryId: 'e_b',
+      },
+      ctx,
+    )
+    expect(mergeAw.status).toBe('ok')
+
+    // A field-less re-derive is the other tolerated shape: a rejection, not a throw.
+    const bareAw = await applyDeltaAction(
+      {
+        action: {
+          kind: 'upsertHappeningAwareness',
+          source: 'periodic_classifier',
+          payload: { branchId: 'b1', characterId: 'char_kael', happeningId: 'hap_b1' },
+        },
+        actionId: 'act_rederive',
+        branchId: 'b1',
+        entryId: 'e_b',
+      },
+      ctx,
+    )
+    expect(bareAw.status).toBe('rejected')
+
+    // Exactly one awareness row for the natural key — absorbed, not duplicated.
+    const awRows = await db
+      .select()
+      .from(happeningAwareness)
+      .where(eq(happeningAwareness.happeningId, 'hap_b1'))
+    expect(awRows.length).toBe(1)
+    expect(awRows[0].source).toBe('retold by Jorin')
+    // Two happening rows for the fact — the tolerated duplicate.
+    const hapRows = await db.select().from(happenings).where(eq(happenings.branchId, 'b1'))
+    expect(hapRows.map((h) => h.id).sort()).toEqual(['hap_b1', 'hap_b1_dup'])
   })
 })

--- a/lib/actions/story-entries/undo-classifier.test.ts
+++ b/lib/actions/story-entries/undo-classifier.test.ts
@@ -259,3 +259,103 @@ describe('AC1 — undo of turn B spares facts anchored to surviving turn A', () 
     expect(branchAfterRedo.classifierStatus?.processedThrough).toBe(2)
   })
 })
+
+describe('AC2 — classifier group at the literal head', () => {
+  it('steps over it, targets the turn beneath, and the suffix sweep carries the classifier group down', async () => {
+    const { db, runInTransaction } = await createTestDb()
+    const ctx = { db, runInTransaction }
+    const entries = [
+      entry('e_opening', 1, 'opening'),
+      entry('e_a', 2, 'ai_reply'),
+      entry('e_b', 3, 'ai_reply'),
+    ]
+    await db.insert(stories).values({ id: 's1', title: 'T', createdAt: 1, updatedAt: 1 })
+    await db.insert(branches).values({ id: 'b1', storyId: 's1', name: 'm', createdAt: 1 })
+    await db.insert(storyEntries).values(entries)
+    await db.insert(happenings).values(hap('hap_b1', 'fact about B', 'e_b'))
+    await db.insert(deltas).values([
+      delta('d_a_create', 1, 'act_a', 'ai_classifier', 'story_entries', 'e_a', 'create'),
+      delta('d_b_create', 2, 'act_b', 'ai_classifier', 'story_entries', 'e_b', 'create'),
+      // The literal head is a classifier group — never an undo target.
+      delta('d_c_hapB', 3, 'act_c', 'periodic_classifier', 'happenings', 'hap_b1', 'create', 'e_b'),
+    ])
+    entriesStore.hydrate('b1', entries)
+    happeningsStore.hydrate('b1', [hap('hap_b1', 'fact about B', 'e_b')])
+
+    expect((await undoLastAction('b1', ctx)).status).toBe('ok')
+
+    // The turn beneath the classifier group was the target…
+    expect(entriesStore.getById('e_b')).toBeUndefined()
+    expect(entriesStore.getById('e_a')).toBeDefined()
+    // …and the head classifier group was carried down with the suffix.
+    expect((await db.select().from(happenings).where(eq(happenings.id, 'hap_b1'))).length).toBe(0)
+    const remaining = (await db.select().from(deltas).where(eq(deltas.branchId, 'b1'))).map(
+      (d) => d.id,
+    )
+    expect(remaining).toEqual(['d_a_create'])
+  })
+})
+
+describe('AC3 — user field-edit above a classifier group', () => {
+  it('reverses only the edit group; the classifier group stays put', async () => {
+    const { db, runInTransaction } = await createTestDb()
+    const ctx = { db, runInTransaction }
+    const entries = [entry('e_opening', 1, 'opening'), entry('e_a', 2, 'ai_reply')]
+    await db.insert(stories).values({ id: 's1', title: 'T', createdAt: 1, updatedAt: 1 })
+    await db.insert(branches).values({ id: 'b1', storyId: 's1', name: 'm', createdAt: 1 })
+    await db.insert(storyEntries).values(entries)
+    await db.insert(happenings).values(hap('hap_a1', 'Edited title', 'e_a'))
+    await db.insert(deltas).values([
+      delta('d_a_create', 1, 'act_a', 'ai_classifier', 'story_entries', 'e_a', 'create'),
+      delta('d_c_hapA', 2, 'act_c', 'periodic_classifier', 'happenings', 'hap_a1', 'create', 'e_a'),
+      // User edits the happening's title afterwards — a non-prose group at the head.
+      delta('d_edit', 3, 'act_edit', 'user_edit', 'happenings', 'hap_a1', 'update', null, {
+        title: 'Original title',
+      }),
+    ])
+    entriesStore.hydrate('b1', entries)
+    happeningsStore.hydrate('b1', [hap('hap_a1', 'Edited title', 'e_a')])
+
+    expect((await undoLastAction('b1', ctx)).status).toBe('ok')
+
+    // Group path: only the edit reversed — the row survives with its old title.
+    const [row] = await db.select().from(happenings).where(eq(happenings.id, 'hap_a1'))
+    expect(row.title).toBe('Original title')
+    expect(entriesStore.getById('e_a')).toBeDefined()
+    const remaining = (await db.select().from(deltas).where(eq(deltas.branchId, 'b1'))).map(
+      (d) => d.id,
+    )
+    expect(remaining.sort()).toEqual(['d_a_create', 'd_c_hapA'])
+
+    // Redo re-applies the single-delta frame.
+    expect((await redoLastAction('b1', ctx)).status).toBe('ok')
+    const [redone] = await db.select().from(happenings).where(eq(happenings.id, 'hap_a1'))
+    expect(redone.title).toBe('Edited title')
+  })
+})
+
+describe('AC6 — undo floor in a wizard-created story', () => {
+  it('rejects in a fresh story (no deltas) and stops at the opening after the only turn is undone', async () => {
+    const { db, runInTransaction } = await createTestDb()
+    const ctx = { db, runInTransaction }
+    await db.insert(stories).values({ id: 's1', title: 'T', createdAt: 1, updatedAt: 1 })
+    await db.insert(branches).values({ id: 'b1', storyId: 's1', name: 'm', createdAt: 1 })
+    // Wizard commit: opening baked in, delta log empty.
+    await db.insert(storyEntries).values(entry('e_opening', 1, 'opening'))
+    entriesStore.hydrate('b1', [entry('e_opening', 1, 'opening')])
+
+    expect((await undoLastAction('b1', ctx)).status).toBe('rejected')
+
+    // First turn arrives, then gets undone — the log empties again, floor holds.
+    await db.insert(storyEntries).values(entry('e_t1', 2, 'user_action'))
+    await db
+      .insert(deltas)
+      .values(delta('d_t1', 1, 'act_t1', 'user_edit', 'story_entries', 'e_t1', 'create'))
+    entriesStore.hydrate('b1', [entry('e_opening', 1, 'opening'), entry('e_t1', 2, 'user_action')])
+
+    expect((await undoLastAction('b1', ctx)).status).toBe('ok')
+    expect(entriesStore.getById('e_t1')).toBeUndefined()
+    expect((await undoLastAction('b1', ctx)).status).toBe('rejected')
+    expect(entriesStore.getById('e_opening')).toBeDefined()
+  })
+})

--- a/lib/undo/index.test.ts
+++ b/lib/undo/index.test.ts
@@ -103,4 +103,30 @@ describe('selectUndoTarget', () => {
     const rows = [delta({ actionId: 'act_c', source: 'periodic_classifier', targetTable: 'lore' })]
     expect(selectUndoTarget(rows)).toBeNull()
   })
+
+  it('targets only the most recent of consecutive prose turns', () => {
+    // Two turns, two action_ids. The earliest-create anchor is group-scoped, so
+    // the turn beneath must not pull the window down to its own entry.
+    const rows = [
+      delta({
+        actionId: 'act_t2',
+        source: 'ai_classifier',
+        targetTable: 'story_entries',
+        op: 'create',
+        targetId: 'entry_t2',
+      }),
+      delta({
+        actionId: 'act_t1',
+        source: 'ai_classifier',
+        targetTable: 'story_entries',
+        op: 'create',
+        targetId: 'entry_t1',
+      }),
+    ]
+    expect(selectUndoTarget(rows)).toEqual({
+      actionId: 'act_t2',
+      kind: 'turn',
+      entryId: 'entry_t2',
+    })
+  })
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved undo and redo behavior when automated facts are generated across multiple story turns.
  * Ensured undo removes only facts tied to the reverted turn and redo restores them correctly.
  * Improved handling of classifier progress, cancellation, and reprocessing during undo/redo.
  * Fixed selection of the correct target when undoing consecutive prose turns.
* **Tests**
  * Added comprehensive coverage for classifier synchronization, anchored facts, awareness updates, and redo scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->