### PR TITLE
Make the action choices side panel configurable

### DIFF
--- a/src/lib/components/settings/tabs/interface.svelte
+++ b/src/lib/components/settings/tabs/interface.svelte
@@ -281,7 +281,8 @@
           max={ACTION_CHOICES_PANEL_WIDTH.max}
           step={1}
           value={settings.uiSettings.actionChoicesPanelWidth}
-          onValueChange={(width) => settings.setActionChoicesPanelWidth(width)}
+          onValueChange={(width) => settings.previewActionChoicesPanelWidth(width)}
+          onValueCommit={(width) => settings.setActionChoicesPanelWidth(width)}
         />
         <div class="text-muted-foreground flex justify-between text-xs">
           <span>{ACTION_CHOICES_PANEL_WIDTH.min} rem</span>

--- a/src/lib/components/settings/tabs/interface.svelte
+++ b/src/lib/components/settings/tabs/interface.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte'
   import { settings, STORY_WIDTH_OPTIONS } from '$lib/stores/settings.svelte'
+  import { ACTION_CHOICES_PANEL_WIDTH } from '$lib/stores/uiLayoutSettings'
   import { ui } from '$lib/stores/ui.svelte'
   import { database } from '$lib/services/database'
   import { grammarService } from '$lib/services/grammar'
@@ -222,29 +223,72 @@
     </Select.Root>
   </div>
 
-  <!-- Story Content Width -->
-  <div class="space-y-2">
-    <div class="flex items-center justify-between">
-      <Label>Story Content Width</Label>
-      <span class="text-muted-foreground text-sm">
-        {STORY_WIDTH_OPTIONS[storyWidthIndex]?.label ?? 'Default'}
-      </span>
+  <!-- Story Layout -->
+  <div class="space-y-4 rounded-lg border p-3">
+    <Label class="text-base font-medium">Story Layout</Label>
+
+    <div class="space-y-2">
+      <div class="flex items-center justify-between">
+        <Label>Story Width</Label>
+        <span class="text-muted-foreground text-sm">
+          {STORY_WIDTH_OPTIONS[storyWidthIndex]?.label ?? 'Default'}
+        </span>
+      </div>
+      <p class="text-muted-foreground text-xs">
+        Maximum width of the story column, action input, and inline images
+      </p>
+      <Slider
+        type="single"
+        min={0}
+        max={STORY_WIDTH_OPTIONS.length - 1}
+        step={1}
+        value={storyWidthIndex}
+        onValueChange={(idx) => settings.setStoryMaxWidth(STORY_WIDTH_OPTIONS[idx].key)}
+      />
+      <div class="text-muted-foreground flex justify-between text-xs">
+        <span>{STORY_WIDTH_OPTIONS[0].label}</span>
+        <span>{STORY_WIDTH_OPTIONS[STORY_WIDTH_OPTIONS.length - 1].label}</span>
+      </div>
     </div>
-    <p class="text-muted-foreground text-xs">
-      Max width of the story area — applies to text and inline images
-    </p>
-    <Slider
-      type="single"
-      min={0}
-      max={STORY_WIDTH_OPTIONS.length - 1}
-      step={1}
-      value={storyWidthIndex}
-      onValueChange={(idx) => settings.setStoryMaxWidth(STORY_WIDTH_OPTIONS[idx].key)}
-    />
-    <div class="text-muted-foreground flex justify-between text-xs">
-      <span>{STORY_WIDTH_OPTIONS[0].label}</span>
-      <span>{STORY_WIDTH_OPTIONS[STORY_WIDTH_OPTIONS.length - 1].label}</span>
+
+    <div class="flex items-center justify-between gap-4">
+      <div>
+        <Label>Action Choices Side Panel</Label>
+        <p class="text-muted-foreground text-xs">
+          On wide windows, show adventure choices beside the story instead of below it
+        </p>
+      </div>
+      <Switch
+        checked={settings.uiSettings.actionChoicesSidePanel}
+        onCheckedChange={(v) => settings.setActionChoicesSidePanel(v)}
+      />
     </div>
+
+    {#if settings.uiSettings.actionChoicesSidePanel}
+      <div class="space-y-2">
+        <div class="flex items-center justify-between">
+          <Label>Action Choices Width</Label>
+          <span class="text-muted-foreground text-sm">
+            {settings.uiSettings.actionChoicesPanelWidth} rem
+          </span>
+        </div>
+        <p class="text-muted-foreground text-xs">
+          Preferred width of the choices column; it can shrink when window space is limited
+        </p>
+        <Slider
+          type="single"
+          min={ACTION_CHOICES_PANEL_WIDTH.min}
+          max={ACTION_CHOICES_PANEL_WIDTH.max}
+          step={1}
+          value={settings.uiSettings.actionChoicesPanelWidth}
+          onValueChange={(width) => settings.setActionChoicesPanelWidth(width)}
+        />
+        <div class="text-muted-foreground flex justify-between text-xs">
+          <span>{ACTION_CHOICES_PANEL_WIDTH.min} rem</span>
+          <span>{ACTION_CHOICES_PANEL_WIDTH.max} rem</span>
+        </div>
+      </div>
+    {/if}
   </div>
 
   <!-- Word Count Toggle -->

--- a/src/lib/components/story/StoryView.svelte
+++ b/src/lib/components/story/StoryView.svelte
@@ -13,12 +13,22 @@
   import EmptyState from '$lib/components/ui/empty-state/empty-state.svelte'
   import { eventBus, type BranchSwitchedEvent } from '$lib/services/events'
 
-  const storyMaxWidthStyle = $derived.by(() => {
+  const storyWidthStyle = $derived.by(() => {
     const maxWidth =
       STORY_WIDTH_OPTIONS.find((o) => o.key === settings.uiSettings.storyMaxWidth)?.maxWidth ??
       '48rem'
-    return `max-width: ${maxWidth}`
+    return `--story-max-width: ${maxWidth}; --choice-panel-width: ${settings.uiSettings.actionChoicesPanelWidth}rem`
   })
+
+  const actionChoicesAvailable = $derived(
+    story.storyMode === 'adventure' && !settings.uiSettings.disableSuggestions,
+  )
+
+  const sidePanelLayoutEnabled = $derived(
+    actionChoicesAvailable && settings.uiSettings.actionChoicesSidePanel,
+  )
+
+  const showActionChoices = $derived(actionChoicesAvailable && !ui.isStreaming && !ui.isGenerating)
 
   let storyContainer: HTMLDivElement
   let containerHeight = $state(0)
@@ -463,7 +473,7 @@
   })
 </script>
 
-<div class="relative flex h-full flex-col overflow-hidden">
+<div class="story-view relative flex h-full flex-col overflow-hidden">
   <!-- Background Image Layer -->
   {#if story.currentBgImage}
     {#key story.currentBgImage}
@@ -490,82 +500,94 @@
     onscroll={handleScroll}
   >
     <div
-      class="mx-auto space-y-2.5 sm:space-y-3"
-      style={storyMaxWidthStyle}
+      class="story-layout mx-auto w-full {sidePanelLayoutEnabled ? 'with-choice-column' : ''}"
+      style={storyWidthStyle}
       bind:clientHeight={innerHeight}
     >
-      {#if story.entries.length === 0 && !ui.isStreaming}
-        <EmptyState
-          icon={BookOpen}
-          title="Your adventure begins here..."
-          description="Type an action below to start your story."
-          class="py-12 sm:py-20"
-        />
-      {:else}
-        <!-- Show collapsed entries indicator if there are hidden entries at top -->
-        {#if displayedEntries.hiddenAtTop > 0}
-          <div class="border-border mb-3 flex flex-col items-center gap-2 border-b py-3">
-            <p class="text-muted-foreground text-sm">
-              {displayedEntries.hiddenAtTop} earlier entries hidden for performance
-            </p>
-            <div class="flex flex-row gap-2">
-              <Button variant="secondary" size="sm" class="h-7 text-xs" onclick={showMoreAbove}>
-                Show {Math.min(LOAD_MORE_BATCH, displayedEntries.hiddenAtTop)} more
-              </Button>
-              {#if !settings.uiSettings.showScrollToTop}
-                <Button variant="secondary" size="sm" class="h-7 text-xs" onclick={scrollToTop}>
-                  Go to top
+      <div class="story-column space-y-2.5 sm:space-y-3">
+        {#if story.entries.length === 0 && !ui.isStreaming}
+          <EmptyState
+            icon={BookOpen}
+            title="Your adventure begins here..."
+            description="Type an action below to start your story."
+            class="py-12 sm:py-20"
+          />
+        {:else}
+          <!-- Show collapsed entries indicator if there are hidden entries at top -->
+          {#if displayedEntries.hiddenAtTop > 0}
+            <div class="border-border mb-3 flex flex-col items-center gap-2 border-b py-3">
+              <p class="text-muted-foreground text-sm">
+                {displayedEntries.hiddenAtTop} earlier entries hidden for performance
+              </p>
+              <div class="flex flex-row gap-2">
+                <Button variant="secondary" size="sm" class="h-7 text-xs" onclick={showMoreAbove}>
+                  Show {Math.min(LOAD_MORE_BATCH, displayedEntries.hiddenAtTop)} more
                 </Button>
-              {/if}
+                {#if !settings.uiSettings.showScrollToTop}
+                  <Button variant="secondary" size="sm" class="h-7 text-xs" onclick={scrollToTop}>
+                    Go to top
+                  </Button>
+                {/if}
+              </div>
             </div>
-          </div>
+          {/if}
+
+          {#each displayedEntries.entries as entry (entry.id)}
+            <!-- data-entry-id lets branch-switch landing locate a specific entry element -->
+            <div data-entry-id={entry.id}>
+              <StoryEntry {entry} />
+            </div>
+          {/each}
+
+          <!-- Show streaming entry while generating -->
+          {#if ui.isStreaming}
+            <StreamingEntry />
+          {/if}
+
+          <!-- Show post-generation status (e.g. Updating world...) -->
+          {#if ui.isGenerating && !ui.isStreaming && ui.generationStatus}
+            <div
+              class="text-muted-foreground animate-fade-in flex items-center justify-center gap-2 py-2"
+            >
+              <Loader2 class="h-4 w-4 animate-spin" />
+              <span class="text-sm">{ui.generationStatus}</span>
+            </div>
+          {/if}
+
+          {#if showActionChoices && !sidePanelLayoutEnabled}
+            <ActionChoices />
+          {/if}
+
+          <!-- Show collapsed entries indicator if there are hidden entries at bottom -->
+          {#if displayedEntries.hiddenAtBottom > 0}
+            <div class="border-border mt-3 flex flex-col items-center gap-2 border-t py-3">
+              <p class="text-muted-foreground text-sm">
+                {displayedEntries.hiddenAtBottom} later entries hidden for performance
+              </p>
+              <div class="flex flex-row gap-2">
+                <Button variant="secondary" size="sm" class="h-7 text-xs" onclick={showMoreBelow}>
+                  Show {Math.min(LOAD_MORE_BATCH, displayedEntries.hiddenAtBottom)} more
+                </Button>
+                {#if !settings.uiSettings.showScrollToBottom}
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    class="h-7 text-xs"
+                    onclick={scrollToBottom}
+                  >
+                    Go to bottom
+                  </Button>
+                {/if}
+              </div>
+            </div>
+          {/if}
         {/if}
+      </div>
 
-        {#each displayedEntries.entries as entry (entry.id)}
-          <!-- data-entry-id lets branch-switch landing locate a specific entry element -->
-          <div data-entry-id={entry.id}>
-            <StoryEntry {entry} />
-          </div>
-        {/each}
-
-        <!-- Show streaming entry while generating -->
-        {#if ui.isStreaming}
-          <StreamingEntry />
-        {/if}
-
-        <!-- Show post-generation status (e.g. Updating world...) -->
-        {#if ui.isGenerating && !ui.isStreaming && ui.generationStatus}
-          <div
-            class="text-muted-foreground animate-fade-in flex items-center justify-center gap-2 py-2"
-          >
-            <Loader2 class="h-4 w-4 animate-spin" />
-            <span class="text-sm">{ui.generationStatus}</span>
-          </div>
-        {/if}
-
-        <!-- Show RPG-style action choices after narration (adventure mode only) -->
-        {#if !ui.isStreaming && !ui.isGenerating && story.storyMode === 'adventure' && !settings.uiSettings.disableSuggestions}
+      {#if showActionChoices && sidePanelLayoutEnabled}
+        <aside class="choice-column" aria-label="Action choices">
           <ActionChoices />
-        {/if}
-
-        <!-- Show collapsed entries indicator if there are hidden entries at bottom -->
-        {#if displayedEntries.hiddenAtBottom > 0}
-          <div class="border-border mt-3 flex flex-col items-center gap-2 border-t py-3">
-            <p class="text-muted-foreground text-sm">
-              {displayedEntries.hiddenAtBottom} later entries hidden for performance
-            </p>
-            <div class="flex flex-row gap-2">
-              <Button variant="secondary" size="sm" class="h-7 text-xs" onclick={showMoreBelow}>
-                Show {Math.min(LOAD_MORE_BATCH, displayedEntries.hiddenAtBottom)} more
-              </Button>
-              {#if !settings.uiSettings.showScrollToBottom}
-                <Button variant="secondary" size="sm" class="h-7 text-xs" onclick={scrollToBottom}>
-                  Go to bottom
-                </Button>
-              {/if}
-            </div>
-          </div>
-        {/if}
+        </aside>
       {/if}
     </div>
 
@@ -616,8 +638,51 @@
       ? 'bg-background/60 backdrop-blur-md'
       : 'bg-card'}"
   >
-    <div class="mx-auto" style={storyMaxWidthStyle}>
-      <ActionInput />
+    <div
+      class="story-input-layout mx-auto w-full {sidePanelLayoutEnabled ? 'with-choice-column' : ''}"
+      style={storyWidthStyle}
+    >
+      <div class="story-input-column">
+        <ActionInput />
+      </div>
     </div>
   </div>
 </div>
+
+<style>
+  .story-view {
+    container-name: story-view;
+    container-type: inline-size;
+  }
+
+  .story-layout,
+  .story-input-layout {
+    max-width: var(--story-max-width);
+  }
+
+  .story-column {
+    min-width: 0;
+  }
+
+  @container story-view (min-width: 88rem) {
+    .story-layout.with-choice-column,
+    .story-input-layout.with-choice-column {
+      display: grid;
+      grid-template-columns: minmax(32rem, 1fr) minmax(16rem, var(--choice-panel-width));
+      gap: 1.5rem;
+      max-width: calc(var(--story-max-width) + var(--choice-panel-width) + 1.5rem);
+    }
+
+    .choice-column {
+      position: sticky;
+      bottom: 0.5rem;
+      grid-column: 2;
+      min-width: 0;
+      align-self: end;
+    }
+
+    .story-input-column {
+      grid-column: 1;
+    }
+  }
+</style>

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -2672,9 +2672,15 @@ class SettingsStore {
     await database.setSetting('action_choices_side_panel', enabled.toString())
   }
 
-  async setActionChoicesPanelWidth(width: number) {
+  /** Update the live layout while dragging; persistence happens once when the control commits. */
+  previewActionChoicesPanelWidth(width: number) {
     const normalizedWidth = normalizeActionChoicesPanelWidth(width)
     this.uiSettings.actionChoicesPanelWidth = normalizedWidth
+  }
+
+  async setActionChoicesPanelWidth(width: number) {
+    this.previewActionChoicesPanelWidth(width)
+    const normalizedWidth = this.uiSettings.actionChoicesPanelWidth
     await database.setSetting('action_choices_panel_width', normalizedWidth.toString())
   }
 

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -15,6 +15,7 @@ import type {
   UISettings,
   UpdateSettings,
 } from '$lib/types'
+import { ACTION_CHOICES_PANEL_DEFAULTS, normalizeActionChoicesPanelWidth } from './uiLayoutSettings'
 import { database } from '$lib/services/database'
 import { grammarService } from '$lib/services/grammar'
 import { PROVIDERS } from '$lib/services/ai/sdk/providers/config'
@@ -1196,6 +1197,8 @@ export function getDefaultUISettings(): UISettings {
     showScrollToTop: false,
     showScrollToBottom: true,
     storyMaxWidth: '3xl',
+    actionChoicesSidePanel: ACTION_CHOICES_PANEL_DEFAULTS.enabled,
+    actionChoicesPanelWidth: ACTION_CHOICES_PANEL_DEFAULTS.width,
     highlightDialogue: false,
     dialogueColor: '',
   }
@@ -1572,6 +1575,16 @@ class SettingsStore {
       const storyMaxWidth = await database.getSetting('story_max_width')
       if (storyMaxWidth && VALID_STORY_WIDTH_KEYS.includes(storyMaxWidth))
         this.uiSettings.storyMaxWidth = storyMaxWidth as UISettings['storyMaxWidth']
+
+      const actionChoicesSidePanel = await database.getSetting('action_choices_side_panel')
+      if (actionChoicesSidePanel !== null)
+        this.uiSettings.actionChoicesSidePanel = actionChoicesSidePanel === 'true'
+
+      const actionChoicesPanelWidth = await database.getSetting('action_choices_panel_width')
+      if (actionChoicesPanelWidth !== null)
+        this.uiSettings.actionChoicesPanelWidth = normalizeActionChoicesPanelWidth(
+          Number.parseFloat(actionChoicesPanelWidth),
+        )
 
       const highlightDialogue = await database.getSetting('highlight_dialogue')
       if (highlightDialogue !== null)
@@ -2654,6 +2667,17 @@ class SettingsStore {
     await database.setSetting('story_max_width', width)
   }
 
+  async setActionChoicesSidePanel(enabled: boolean) {
+    this.uiSettings.actionChoicesSidePanel = enabled
+    await database.setSetting('action_choices_side_panel', enabled.toString())
+  }
+
+  async setActionChoicesPanelWidth(width: number) {
+    const normalizedWidth = normalizeActionChoicesPanelWidth(width)
+    this.uiSettings.actionChoicesPanelWidth = normalizedWidth
+    await database.setSetting('action_choices_panel_width', normalizedWidth.toString())
+  }
+
   /**
    * Publish the dialogue colour to CSS. The toggle and the colour live on the root
    * element, not in the rendered markup: the `<span class="dialogue-line">` wrappers
@@ -3116,6 +3140,15 @@ class SettingsStore {
     await database.setSetting(
       'show_scroll_to_bottom',
       this.uiSettings.showScrollToBottom.toString(),
+    )
+    await database.setSetting('story_max_width', this.uiSettings.storyMaxWidth)
+    await database.setSetting(
+      'action_choices_side_panel',
+      this.uiSettings.actionChoicesSidePanel.toString(),
+    )
+    await database.setSetting(
+      'action_choices_panel_width',
+      this.uiSettings.actionChoicesPanelWidth.toString(),
     )
     await database.setSetting('highlight_dialogue', this.uiSettings.highlightDialogue.toString())
     await database.setSetting('dialogue_color', this.uiSettings.dialogueColor)

--- a/src/lib/stores/uiLayoutSettings.ts
+++ b/src/lib/stores/uiLayoutSettings.ts
@@ -1,0 +1,24 @@
+export const ACTION_CHOICES_PANEL_WIDTH = {
+  // Keep a broad safety envelope for persisted values without dictating a desktop layout.
+  // CSS may shrink the preferred width when the current window cannot fit both columns.
+  min: 16,
+  max: 160,
+  default: 32,
+} as const
+
+export const ACTION_CHOICES_PANEL_DEFAULTS = {
+  enabled: false,
+  width: ACTION_CHOICES_PANEL_WIDTH.default,
+} as const
+
+/**
+ * Settings are stored as untyped strings, so clamp both old/corrupt persisted values and
+ * values supplied by UI controls before publishing them to the layout's CSS variable.
+ */
+export function normalizeActionChoicesPanelWidth(width: number): number {
+  if (!Number.isFinite(width)) return ACTION_CHOICES_PANEL_WIDTH.default
+  return Math.min(
+    ACTION_CHOICES_PANEL_WIDTH.max,
+    Math.max(ACTION_CHOICES_PANEL_WIDTH.min, Math.round(width)),
+  )
+}

--- a/src/lib/stores/uiSettings.test.ts
+++ b/src/lib/stores/uiSettings.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ACTION_CHOICES_PANEL_DEFAULTS,
+  ACTION_CHOICES_PANEL_WIDTH,
+  normalizeActionChoicesPanelWidth,
+} from './uiLayoutSettings'
+
+describe('action choices side-panel settings', () => {
+  it('keeps the side-panel layout opt-in', () => {
+    expect(ACTION_CHOICES_PANEL_DEFAULTS.enabled).toBe(false)
+    expect(ACTION_CHOICES_PANEL_DEFAULTS.width).toBe(ACTION_CHOICES_PANEL_WIDTH.default)
+  })
+
+  it('normalizes persisted and user-selected widths to the supported range', () => {
+    expect(normalizeActionChoicesPanelWidth(ACTION_CHOICES_PANEL_WIDTH.min - 10)).toBe(
+      ACTION_CHOICES_PANEL_WIDTH.min,
+    )
+    expect(normalizeActionChoicesPanelWidth(31.6)).toBe(32)
+    expect(normalizeActionChoicesPanelWidth(ACTION_CHOICES_PANEL_WIDTH.max + 10)).toBe(
+      ACTION_CHOICES_PANEL_WIDTH.max,
+    )
+    expect(normalizeActionChoicesPanelWidth(Number.NaN)).toBe(ACTION_CHOICES_PANEL_WIDTH.default)
+  })
+})

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -733,6 +733,10 @@ export interface UISettings {
   showScrollToTop: boolean
   showScrollToBottom: boolean
   storyMaxWidth: '2xl' | '3xl' | '4xl' | '5xl' | '7xl' | '9xl'
+  /** Place adventure action choices beside the story when the viewport is wide enough. */
+  actionChoicesSidePanel: boolean
+  /** Preferred width of the action-choices column, in rem. */
+  actionChoicesPanelWidth: number
   /** Colour quoted speech in story text. Has no effect on Visual Prose stories. */
   highlightDialogue: boolean
   /**


### PR DESCRIPTION
## Summary

- keep adventure action choices inline by default and make the responsive side panel opt-in
- group the story-width and action-choice-width controls under **Settings → Interface → Story Layout**
- persist the side-panel preference and preferred choice-column width, with responsive shrinking on smaller windows
- normalize malformed stored widths within a broad 16–160 rem safety envelope

## Screenshots

### Responsive action choices side panel

![Responsive action choices side panel](https://github.com/user-attachments/assets/8a7f9146-d5a5-48bb-8b65-6956b943fad5)

### Story layout settings

![Story layout settings](https://github.com/user-attachments/assets/eaf6db18-8f6f-4de8-b834-52e0614a0c06)

## Verification

- `npm test` — 83 files, 1,193 tests passed
- `npm run check` — 0 errors, 0 warnings
- `npm run lint` — 0 errors (203 existing boundary warnings)
- focused side-panel settings tests — 2 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional side panel for adventure action choices on wide screens.
  * Added settings to enable the panel and adjust its width.
  * Improved responsive story and input layouts for wider displays.
* **Bug Fixes**
  * Panel width settings are now validated and constrained to supported limits.
* **Tests**
  * Added coverage for default settings and panel-width validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->