### PR TITLE
fix: entry card reasoning overflow

### DIFF
--- a/app/reader-composer/[branchId].tsx
+++ b/app/reader-composer/[branchId].tsx
@@ -10,6 +10,7 @@ import { GenerationStatusPill } from '@/components/compounds/generation-status-p
 import { Composer, type ComposerHandle } from '@/components/reader/composer'
 import { isDraftEmpty } from '@/components/reader/composer-draft'
 import { readerPillPhase } from '@/components/reader/generation-phase'
+import { KeyboardInsetColumn } from '@/components/reader/keyboard-inset-column'
 import ReaderDocument, { type ReaderDocumentRef } from '@/components/reader/reader-document'
 import {
   type EditResult,
@@ -1146,7 +1147,7 @@ export default function ReaderComposerRoute() {
       }
     >
       <View className="flex-1 flex-row">
-        <View className="flex-1">
+        <KeyboardInsetColumn>
           <View className="flex-1">
             {hydrationFailed ? (
               <View className="flex-1 items-center justify-center">
@@ -1235,7 +1236,7 @@ export default function ReaderComposerRoute() {
               />
             </View>
           </View>
-        </View>
+        </KeyboardInsetColumn>
         {showRail ? (
           <View className="w-[260px] border-l border-border bg-bg-sunken p-3">
             <Text variant="muted" size="sm">

--- a/components/compounds/entry-card.stories.tsx
+++ b/components/compounds/entry-card.stories.tsx
@@ -229,6 +229,62 @@ export const ReasoningTogglesOnBrainClick: StoryT = {
   },
 }
 
+// Nothing between the narrative island and the reader's scroller clips
+// overflow, so anything that refuses to wrap escapes the card and gives that
+// scroller a horizontal axis. scrollWidth reports overflowing content even
+// under overflow: visible, which is what makes the leak measurable here.
+async function expectReasoningStaysInsideCard(canvasElement: HTMLElement) {
+  await userEvent.click(screen.getByRole('button', { name: 'Show reasoning' }))
+  const island = await waitFor(() => {
+    const found = canvasElement.querySelector<HTMLElement>('.narrative-html')
+    expect(found).not.toBeNull()
+    return found as HTMLElement
+  })
+  expect(island.scrollWidth).toBeLessThanOrEqual(island.clientWidth)
+}
+
+/**
+ * Reasoning streams arrive indented, which `marked` reads as an indented code
+ * block — and `<pre>` defaults to `white-space: pre`, which suppresses line
+ * breaking outright.
+ */
+export const ReasoningIndentedBlockWraps: StoryT = {
+  ...wrap,
+  args: {
+    ...baseProps,
+    kind: 'ai_reply',
+    content: 'The floorboards were cool beneath her bare feet.',
+    meta: aiMeta,
+    reasoning: `Maya [c1].
+Write the next beat as prose. Do not break character or address the reader.
+
+    *   *Current state:* Maya is moving from her bedroom to the kitchen.
+    *   *Goal:* Expand on the sensory details of the walk and her arrival in the kitchen, maintaining the established "mundane" and "safe" tone, while potentially hinting at something.
+`,
+  },
+  play: async ({ canvasElement }) => {
+    await expectReasoningStaysInsideCard(canvasElement)
+  },
+}
+
+/**
+ * The second escape route, independent of the code-block one: an unbroken run
+ * of characters has no break opportunity for normal wrapping to take.
+ */
+export const ReasoningLongTokenWraps: StoryT = {
+  ...wrap,
+  args: {
+    ...baseProps,
+    kind: 'ai_reply',
+    content: 'The floorboards were cool beneath her bare feet.',
+    meta: aiMeta,
+    reasoning: `Considering the retrieval key ${'x'.repeat(400)} before drafting.`,
+  },
+  play: async ({ canvasElement }) => {
+    await expectReasoningStaysInsideCard(canvasElement)
+  },
+}
+
 export const SystemRetryFires: StoryT = {
   ...wrap,
   args: {

--- a/components/compounds/rich-entry-content.tsx
+++ b/components/compounds/rich-entry-content.tsx
@@ -15,7 +15,7 @@ const HOST_STYLE: CSSProperties = { contain: 'layout paint' }
 // don't reach into a shadow tree, only inherited properties do. Entry styles
 // come after, so provider CSS wins ties.
 const BASELINE_CSS =
-  'p{margin:4px 0}blockquote{border-left:2px solid var(--border);padding-left:8px;font-style:italic}code{font-family:var(--font-mono)}'
+  ':host{overflow-wrap:break-word}pre{white-space:pre-wrap}p{margin:4px 0}blockquote{border-left:2px solid var(--border);padding-left:8px;font-style:italic}code{font-family:var(--font-mono)}'
 
 export function RichEntryContent({ markedHtml }: RichEntryContentProps) {
   const hostRef = useRef<HTMLDivElement>(null)

--- a/components/reader/composer.stories.tsx
+++ b/components/reader/composer.stories.tsx
@@ -45,8 +45,8 @@ export const SendBlocked: Story = {
 }
 
 /**
- * Send hands the draft up and clears the input. Send also dismisses the soft
- * keyboard, which no browser has — this pins the surviving half, that the
+ * Send hands the draft up and clears the input. The keyboard dismissal that
+ * rides along on native has no web equivalent, so this pins the surviving half:
  * dismissal never swallows the submit.
  */
 export const SendHandsUpDraftAndClears: Story = {

--- a/components/reader/composer.stories.tsx
+++ b/components/reader/composer.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite'
-import { fn } from 'storybook/test'
+import { expect, fn, screen, userEvent, waitFor } from 'storybook/test'
 
 import { Composer } from './composer'
 
@@ -41,5 +41,39 @@ export const SendBlocked: Story = {
     isGenerating: false,
     sendBlocked: true,
     disabledReason: 'Unavailable while generating.',
+  },
+}
+
+/**
+ * Send hands the draft up and clears the input. Send also dismisses the soft
+ * keyboard, which no browser has — this pins the surviving half, that the
+ * dismissal never swallows the submit.
+ */
+export const SendHandsUpDraftAndClears: Story = {
+  args: { modesEnabled: false, isGenerating: false },
+  play: async ({ args, canvasElement }) => {
+    const input = canvasElement.querySelector('textarea')
+    if (input == null) throw new Error('composer input not found')
+
+    await userEvent.click(input)
+    await userEvent.type(input, 'I step into the dim light.')
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    await waitFor(() =>
+      expect(args.onSend).toHaveBeenCalledWith('I step into the dim light.', 'free'),
+    )
+    await waitFor(() => expect(input.value).toBe(''))
+  },
+}
+
+/** An empty draft is not sendable, so Send is inert rather than dispatching. */
+export const EmptyDraftDoesNotSend: Story = {
+  args: { modesEnabled: false, isGenerating: false },
+  play: ({ args }) => {
+    const send = screen.getByRole('button', { name: 'Send' })
+    // The shipped gate is an inline pointer-events style, not just an attribute
+    // (rn-primitives doesn't reliably block disabled clicks on web).
+    expect(getComputedStyle(send).pointerEvents).toBe('none')
+    expect(args.onSend).not.toHaveBeenCalled()
   },
 }

--- a/components/reader/composer.tsx
+++ b/components/reader/composer.tsx
@@ -13,6 +13,7 @@ import { Select, type SelectOption } from '@/components/ui/select'
 import { Text } from '@/components/ui/text'
 import type { ComposerMode } from '@/lib/composer-wrap'
 import { t } from '@/lib/i18n'
+import { dismissKeyboard, isKeyboardVisible } from '@/lib/keyboard'
 import { lintNarrativeText } from '@/lib/spellcheck'
 
 import { SpellcheckTextarea } from './spellcheck-textarea'
@@ -135,6 +136,12 @@ export const Composer = forwardRef(function Composer(
 
   function handleSubmit() {
     if (!canSend) return
+    // Dismissing also blurs (`keepFocus` defaults false), which is what keeps
+    // the input refocusable — a focused input under a hidden keyboard is the
+    // state a tap won't reopen on Android. Guarded rather than platform-forked:
+    // the controller reports no keyboard on web or with a hardware one, so
+    // there is nothing to dismiss and nothing to blur.
+    if (isKeyboardVisible()) void dismissKeyboard()
     onSend(text, modesEnabled ? mode : 'free')
     setText('')
     setLints([])

--- a/components/reader/composer.tsx
+++ b/components/reader/composer.tsx
@@ -136,11 +136,9 @@ export const Composer = forwardRef(function Composer(
 
   function handleSubmit() {
     if (!canSend) return
-    // Dismissing also blurs (`keepFocus` defaults false), which is what keeps
-    // the input refocusable — a focused input under a hidden keyboard is the
-    // state a tap won't reopen on Android. Guarded rather than platform-forked:
-    // the controller reports no keyboard on web or with a hardware one, so
-    // there is nothing to dismiss and nothing to blur.
+    // Dismissing also blurs (`keepFocus` defaults false): on Android a focused
+    // input under a hidden keyboard is the state a tap won't reopen. The guard
+    // is a no-op on web and with a hardware keyboard.
     if (isKeyboardVisible()) void dismissKeyboard()
     onSend(text, modesEnabled ? mode : 'free')
     setText('')

--- a/components/reader/keyboard-inset-column.native.tsx
+++ b/components/reader/keyboard-inset-column.native.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react'
+import { useReanimatedKeyboardAnimation } from 'react-native-keyboard-controller'
+import Animated, { useAnimatedStyle } from 'react-native-reanimated'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+
+/**
+ * Reserves the soft keyboard's height at the bottom of the reader column so the
+ * composer stays above it.
+ *
+ * Padding, not translation: the reader above holds `flex-1`, so it compresses
+ * and the newest entry stays visible directly above the input while the top bar
+ * holds still.
+ *
+ * The composer is the bottom-most element of a full-height column, so its
+ * overlap with the keyboard is exactly the keyboard height — no runtime screen
+ * position is involved. That is why this drives padding off the animation hook
+ * rather than using the library's `KeyboardAvoidingView`, whose one-shot
+ * `viewPositionInWindow` measurement exists for containers that could be
+ * anywhere on screen. See
+ * lessons-learned/kav-automatic-offset-animation-race.md.
+ */
+export function KeyboardInsetColumn({ children }: { children: ReactNode }) {
+  const keyboard = useReanimatedKeyboardAnimation()
+  const { bottom } = useSafeAreaInsets()
+
+  const style = useAnimatedStyle(() => ({
+    flex: 1,
+    // `height` runs negative while the keyboard is up. ScreenShell already pads
+    // the bottom safe area, so subtract whatever it contributes right now —
+    // correct whether or not the platform zeroes that inset while the IME shows.
+    paddingBottom: Math.max(0, -keyboard.height.get() - bottom),
+  }))
+
+  return <Animated.View style={style}>{children}</Animated.View>
+}

--- a/components/reader/keyboard-inset-column.native.tsx
+++ b/components/reader/keyboard-inset-column.native.tsx
@@ -4,19 +4,11 @@ import Animated, { useAnimatedStyle } from 'react-native-reanimated'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 /**
- * Reserves the soft keyboard's height at the bottom of the reader column so the
- * composer stays above it.
- *
- * Padding, not translation: the reader above holds `flex-1`, so it compresses
- * and the newest entry stays visible directly above the input while the top bar
- * holds still.
- *
- * The composer is the bottom-most element of a full-height column, so its
- * overlap with the keyboard is exactly the keyboard height — no runtime screen
- * position is involved. That is why this drives padding off the animation hook
- * rather than using the library's `KeyboardAvoidingView`, whose one-shot
- * `viewPositionInWindow` measurement exists for containers that could be
- * anywhere on screen. See
+ * Reserves the soft keyboard's height below the reader column so the composer
+ * stays above it. Padding, not translation: the reader holds `flex-1`, so it
+ * compresses and the newest entry stays visible while the top bar holds still.
+ * Hand-driven off the animation hook rather than the library's
+ * `KeyboardAvoidingView` — see
  * lessons-learned/kav-automatic-offset-animation-race.md.
  */
 export function KeyboardInsetColumn({ children }: { children: ReactNode }) {

--- a/components/reader/keyboard-inset-column.tsx
+++ b/components/reader/keyboard-inset-column.tsx
@@ -1,0 +1,8 @@
+import type { ReactNode } from 'react'
+import { View } from 'react-native'
+
+// Web and Electron have no soft keyboard to make room for, so the column is
+// plain. The native variant carries the whole mechanism.
+export function KeyboardInsetColumn({ children }: { children: ReactNode }) {
+  return <View className="flex-1">{children}</View>
+}

--- a/components/reader/spellcheck-textarea.stories.tsx
+++ b/components/reader/spellcheck-textarea.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-native-web-vite'
 import type { Lint } from 'harper.js'
 import { useState } from 'react'
 import { View } from 'react-native'
+import { expect } from 'storybook/test'
 
 import { SpellcheckTextarea } from './spellcheck-textarea'
 
@@ -44,3 +45,30 @@ function EditableDemo({ lints }: { lints: Lint[] }) {
 export const WithLints: Story = { render: () => <EditableDemo lints={SAMPLE_LINTS} /> }
 
 export const Clean: Story = { render: () => <EditableDemo lints={[]} /> }
+
+// The underline overlay duplicates the whole draft on top of the input, so it
+// must exist only when it has an underline to draw. Native holds the no-lint
+// state permanently (harper can't run on Hermes), and there the duplicate showed
+// through as doubled glyphs.
+function countMirrorsOf(canvasElement: HTMLElement, text: string): number {
+  return Array.from(canvasElement.querySelectorAll('span')).filter(
+    (el) => el.children.length === 0 && (el.textContent ?? '').includes(text),
+  ).length
+}
+
+export const CleanDraftRendersNoOverlay: Story = {
+  render: () => <EditableDemo lints={[]} />,
+  play: ({ canvasElement }) => {
+    const textarea = canvasElement.querySelector('textarea')
+    expect(textarea?.value).toBe(SAMPLE_TEXT)
+    expect(countMirrorsOf(canvasElement, 'quick')).toBe(0)
+  },
+}
+
+export const LintedDraftRendersOverlay: Story = {
+  render: () => <EditableDemo lints={SAMPLE_LINTS} />,
+  play: ({ canvasElement }) => {
+    // 'brwn' is a lint span, so the overlay must carry it as its own node.
+    expect(countMirrorsOf(canvasElement, 'brwn')).toBeGreaterThan(0)
+  },
+}

--- a/components/reader/spellcheck-textarea.tsx
+++ b/components/reader/spellcheck-textarea.tsx
@@ -57,10 +57,17 @@ export function SpellcheckTextarea({
   const [scrollOffsetY, setScrollOffsetY] = useState(0)
   const [tooltip, setTooltip] = useState<TooltipState | null>(null)
 
-  const segments = buildTextSegments(
-    value,
-    lints.map((lint) => lint.span()),
-  )
+  // The overlay's only job is carrying underlines, so with no lints it is a
+  // transparent full-text duplicate of the input that can never draw anything.
+  // Native is always in that state — harper needs WebAssembly, which Hermes
+  // lacks, so `lintNarrativeText` there returns no lints by construction.
+  const hasLints = lints.length > 0
+  const segments = hasLints
+    ? buildTextSegments(
+        value,
+        lints.map((lint) => lint.span()),
+      )
+    : []
 
   const handleScroll = (event: TextInputScrollEvent) => {
     setScrollOffsetY(event.nativeEvent.contentOffset.y)
@@ -119,30 +126,32 @@ export function SpellcheckTextarea({
     <View ref={containerRef} className="relative">
       <Textarea value={value} onScroll={handleScroll} {...textareaProps} />
 
-      <View pointerEvents="box-none" className="absolute inset-0 overflow-hidden">
-        <TextClassContext.Provider value="text-transparent">
-          <Text
-            className={OVERLAY_TEXT_CLASS}
-            style={[OVERLAY_ROOT_STYLE, { transform: [{ translateY: -scrollOffsetY }] }]}
-          >
-            {segments.map((segment, i) => {
-              if (segment.kind === 'plain') return <Text key={`p-${i}`}>{segment.text}</Text>
-              const lint = lints[segment.index]
-              return (
-                <Text
-                  key={segment.key}
-                  className={LINT_UNDERLINE_CLASS}
-                  style={LINT_HIT_STYLE}
-                  onPress={() => handlePress(lint)}
-                  {...hoverProps(segment.key, lint)}
-                >
-                  {segment.text}
-                </Text>
-              )
-            })}
-          </Text>
-        </TextClassContext.Provider>
-      </View>
+      {hasLints ? (
+        <View pointerEvents="box-none" className="absolute inset-0 overflow-hidden">
+          <TextClassContext.Provider value="text-transparent">
+            <Text
+              className={OVERLAY_TEXT_CLASS}
+              style={[OVERLAY_ROOT_STYLE, { transform: [{ translateY: -scrollOffsetY }] }]}
+            >
+              {segments.map((segment, i) => {
+                if (segment.kind === 'plain') return <Text key={`p-${i}`}>{segment.text}</Text>
+                const lint = lints[segment.index]
+                return (
+                  <Text
+                    key={segment.key}
+                    className={LINT_UNDERLINE_CLASS}
+                    style={LINT_HIT_STYLE}
+                    onPress={() => handlePress(lint)}
+                    {...hoverProps(segment.key, lint)}
+                  >
+                    {segment.text}
+                  </Text>
+                )
+              })}
+            </Text>
+          </TextClassContext.Provider>
+        </View>
+      ) : null}
 
       {tooltip ? (
         <View

--- a/docs/implementation/lessons-learned/README.md
+++ b/docs/implementation/lessons-learned/README.md
@@ -44,6 +44,10 @@ slice plans when relevant.
   — web inherits `body { color: var(--fg-primary) }`, native
   RenderHTML always gets a `baseStyle` color; never patch color
   per-island.
+- [RN's global `fetch` cannot stream](./rn-fetch-cannot-stream.md)
+  — whatwg-fetch is XHR-backed and exposes no `body`, so SSE calls
+  fail as an AI SDK `Failed to process successful response` at
+  status 200; route native through `expo/fetch`.
 - [Wide-table scroll containment](./table-scroll-containment.md)
   — wide tables wrap in their own `overflow-x: auto`; horizontal
   scroll must not bubble.

--- a/docs/implementation/lessons-learned/rn-fetch-cannot-stream.md
+++ b/docs/implementation/lessons-learned/rn-fetch-cannot-stream.md
@@ -1,0 +1,74 @@
+# React Native's global `fetch` cannot stream — SSE needs `expo/fetch`
+
+`react-native/Libraries/Network/fetch.js` is one line of substance:
+`require('whatwg-fetch')`. That polyfill is XHR-backed and declares
+**no `body` getter at all**, so `response.body` is `undefined` on
+native while it is a `ReadableStream` on web and Electron. Every
+server-sent-events call therefore reaches a stream consumer with
+nothing to read.
+
+Through the AI SDK the failure arrives heavily disguised. Its
+event-source handler checks `response.body == null` and throws
+`EmptyResponseBodyError`; `postToApi` catches anything the handler
+throws and rethrows it as an `APICallError` whose own message is
+`Failed to process successful response`, with the real fault demoted
+to `cause` and `statusCode` set to the response's **200**. Three
+consequences worth recognising on sight:
+
+- The log names the envelope, not the fault. Code that reduces an
+  error to `.message` reports a sentence with no diagnostic content.
+- A 200 status routes the failure into whatever branch handles
+  "successful-looking response", so it can be classified retryable
+  and re-issue a request the server already answered in full.
+- XHR resolves only once the whole response has arrived, so the
+  error fires the instant generation completes. It reads as a
+  post-generation bug when it is really a transport that never
+  streamed at all.
+
+## Fix
+
+`lib/ai/transport/platform-fetch.ts` plus its `.native.ts` sibling.
+Native routes through `expo/fetch`, whose `FetchResponse` exposes a
+real `body` stream. `expo/fetch` is part of core `expo`, so it needs
+no config plugin and no dev-client rebuild — unlike a third-party
+native module, see
+[native-module RN libs need a dev-client rebuild](./native-dep-expo-link.md).
+
+Two traps sit in the swap itself:
+
+1. `expo/fetch` takes `(url, init)`, never a `Request`. Its
+   `FetchRequestLike` needs a real `body` property and a whatwg
+   `Request` has none, so handing it one sends an **empty body** with
+   no error anywhere. Pass the body explicitly, and pass it
+   unserialized so a non-text body is not round-tripped through
+   `.text()`.
+2. `FetchResponse.clone()` throws `Not implemented`. Any wrapper that
+   clones a response — the HTTP-capture wrapper did — breaks every
+   native call, not only the streaming ones.
+
+## How to apply
+
+Probe for the capability, do not branch on the platform. Whether a
+response can be cloned is a property of the object you were handed,
+not of the bundle you are in, so `try { response.clone() } catch {
+return null }` both reads truer and stays testable from the `unit`
+project, which resolves the web variant of a `.native.ts` pair.
+
+When capture and consumption compete for one body: rebuild rather
+than clone where the body is finite (read the text, hand back a fresh
+`Response`), and give the stream up to its real consumer where it is
+not. Teeing works too, but it puts a synthetic response in the hot
+path of every call on the platform hardest to test.
+
+Guard the emptiness check as `!= null`, not `!== null`. The whatwg
+body is `undefined`, so a strict comparison declares a stream present
+and sends an unreadable response down the streaming path.
+
+Finally, never log an AI SDK error as `.message`. Flatten the `cause`
+chain (`describeProviderError` in `lib/ai/transport/`) or the most
+common provider faults — empty body, schema mismatch — all render as
+the same contentless sentence.
+
+Related: [Metro's native resolution ignores browser-targeted builds](./metro-native-ignores-browser-builds.md)
+— same shape of surprise, where a dependency works on web and breaks
+every Android bundle.

--- a/docs/implementation/triage.md
+++ b/docs/implementation/triage.md
@@ -1532,3 +1532,15 @@ failing` (fails in ~11 ms, consistent with a cascade from shared
   the failure entry a pure notice with no custody role and delete this
   class of bug rather than patching its instances. Wants a reader-composer
   design pass, not a local fix. Raised 2026-08-16.
+- **`text-transparent` was never proven to apply to `Text` on Android.**
+  The composer's lint overlay stacks an invisible copy of the whole draft
+  over the input to carry underlines, and it was the codebase's only user
+  of `text-transparent`. On Android that copy painted, showing as doubled
+  glyphs. The overlay now renders only when lints exist, which is never
+  on native (harper needs WebAssembly, Hermes has none), so nothing
+  depends on the class there today and the visible bug is gone — but the
+  cause was not diagnosed on-device, only routed around. Anything that
+  later wants invisible native text (a native linter restoring this
+  overlay, a measurement mirror, a fade-through) must verify on hardware
+  that the class resolves rather than assuming parity with RN-Web, which
+  handles it correctly. Raised 2026-08-17.

--- a/global.css
+++ b/global.css
@@ -582,11 +582,23 @@
   background-color: var(--fg-secondary);
 }
 
-/* Narrative markdown render — mirrors lib/markdown/native.ts's
- * narrativeTagsStyles for cross-platform parity (docs/tech-stack.md ->
- * Markdown rendering + HTML sanitization).
+/* Narrative markdown render — kept in parity with rich-entry-content.tsx's
+ * BASELINE_CSS, which restates these as bare element selectors because a
+ * document class selector can't reach into the rich path's shadow tree
+ * (docs/tech-stack.md -> Markdown rendering + HTML sanitization).
  */
 @layer components {
+  /* Nothing between here and the reader's scroller clips overflow, so unwrapped
+   * content escapes the entry card and gives that scroller a horizontal axis.
+   * `overflow-wrap` inherits, covering long unbroken model tokens everywhere;
+   * `pre` additionally needs its default `white-space: pre` relaxed, since
+   * indented reasoning streams parse as code blocks. */
+  .narrative-html {
+    overflow-wrap: break-word;
+  }
+  .narrative-html pre {
+    white-space: pre-wrap;
+  }
   .narrative-html p {
     margin-top: 4px;
     margin-bottom: 4px;

--- a/lib/ai/index.ts
+++ b/lib/ai/index.ts
@@ -15,7 +15,7 @@ export {
 // production call paths go through streamText / generateStructured.
 export { getModel } from './model'
 export { callWithRetry, type CallRetryError } from './transport/call-with-retry'
-export { ProviderTimeoutError } from './transport/classify-provider-error'
+export { describeProviderError, ProviderTimeoutError } from './transport/classify-provider-error'
 export {
   resolveModel,
   type ResolveModelConfig,

--- a/lib/ai/transport/classify-provider-error.test.ts
+++ b/lib/ai/transport/classify-provider-error.test.ts
@@ -121,4 +121,8 @@ describe('describeProviderError', () => {
     expect(describeProviderError('boom')).toBe('boom')
     expect(describeProviderError(undefined)).toBe('')
   })
+
+  it('labels a throwable that cannot be coerced to a string', () => {
+    expect(describeProviderError(Object.create(null))).toBe('[uncoercible value]')
+  })
 })

--- a/lib/ai/transport/classify-provider-error.test.ts
+++ b/lib/ai/transport/classify-provider-error.test.ts
@@ -1,7 +1,11 @@
 import { APICallError } from 'ai'
 import { describe, expect, it } from 'vitest'
 
-import { ProviderTimeoutError, classifyProviderError } from './classify-provider-error'
+import {
+  ProviderTimeoutError,
+  classifyProviderError,
+  describeProviderError,
+} from './classify-provider-error'
 
 function apiError(statusCode: number | undefined): APICallError {
   return new APICallError({
@@ -62,5 +66,59 @@ describe('classifyProviderError', () => {
 
   it('returns undefined retryAfterMs when the header is absent', () => {
     expect(classifyProviderError(apiError(503)).retryAfterMs).toBeUndefined()
+  })
+})
+
+describe('describeProviderError', () => {
+  // The shape the AI SDK produces when a response handler throws: the envelope
+  // names itself, the root cause is one link down (post-to-api.ts).
+  function wrapped(cause: Error): APICallError {
+    return new APICallError({
+      message: 'Failed to process successful response',
+      cause,
+      statusCode: 200,
+      url: 'https://api.test/v1/chat/completions',
+      requestBodyValues: {},
+    })
+  }
+
+  it('names the root cause, not just the envelope', () => {
+    const inner = new Error('Empty response body')
+    inner.name = 'EmptyResponseBodyError'
+    expect(describeProviderError(wrapped(inner))).toBe(
+      'APICallError: Failed to process successful response ← EmptyResponseBodyError: Empty response body',
+    )
+  })
+
+  it('walks a multi-link chain', () => {
+    const root = new Error('invalid json')
+    const mid = new Error('type validation failed', { cause: root })
+    expect(describeProviderError(wrapped(mid))).toBe(
+      'APICallError: Failed to process successful response ← type validation failed ← invalid json',
+    )
+  })
+
+  it('does not repeat a name already carried by the message', () => {
+    const inner = new Error('TypeValidationError: bad shape')
+    inner.name = 'TypeValidationError'
+    expect(describeProviderError(inner)).toBe('TypeValidationError: bad shape')
+  })
+
+  it('collapses a link whose label repeats the one before it', () => {
+    const root = new Error('same')
+    expect(describeProviderError(new Error('same', { cause: root }))).toBe('same')
+  })
+
+  it('terminates on a cyclic cause chain', () => {
+    const a = new Error('a')
+    const b = new Error('b')
+    ;(a as { cause?: unknown }).cause = b
+    ;(b as { cause?: unknown }).cause = a
+    expect(describeProviderError(a)).toBe('a ← b ← a ← b ← a')
+  })
+
+  it('handles non-Error throwables', () => {
+    expect(describeProviderError('boom')).toBe('boom')
+    expect(describeProviderError(undefined)).toBe('')
   })
 })

--- a/lib/ai/transport/classify-provider-error.ts
+++ b/lib/ai/transport/classify-provider-error.ts
@@ -16,6 +16,39 @@ export class ProviderTimeoutError extends Error {
   }
 }
 
+const MAX_CAUSE_DEPTH = 5
+
+function labelOf(error: unknown): string {
+  if (!(error instanceof Error)) return String(error)
+  // The AI SDK stamps every error name with an `AI_` prefix; it carries no
+  // information the surrounding log line doesn't already have.
+  const name = error.name.replace(/^AI_/, '')
+  const { message } = error
+  if (message.length === 0) return name
+  return name.length > 0 && name !== 'Error' && !message.startsWith(name)
+    ? `${name}: ${message}`
+    : message
+}
+
+/**
+ * Flattens an error's `cause` chain into one line, root-most link last.
+ *
+ * The AI SDK wraps anything its response handler throws in an `APICallError`
+ * whose own message names only the envelope ("Failed to process successful
+ * response"); the actual failure — empty body, schema mismatch — is a `cause`
+ * link down. A bare `.message` therefore reports nothing actionable.
+ */
+export function describeProviderError(error: unknown): string {
+  const links: string[] = []
+  let current: unknown = error
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH && current != null; depth++) {
+    const label = labelOf(current)
+    if (links.at(-1) !== label) links.push(label)
+    current = current instanceof Error ? current.cause : undefined
+  }
+  return links.join(' ← ')
+}
+
 function parseRetryAfter(headers: Record<string, string> | undefined): number | undefined {
   if (headers === undefined) return undefined
   const key = Object.keys(headers).find((k) => k.toLowerCase() === 'retry-after')
@@ -41,25 +74,25 @@ export function classifyProviderError(error: unknown): {
     const retryAfterMs = parseRetryAfter(error.responseHeaders)
     if (status === 401 || status === 403) {
       return {
-        error: { tier: 'provider', reason: 'auth', detail: error.message },
+        error: { tier: 'provider', reason: 'auth', detail: describeProviderError(error) },
         retryable: false,
       }
     }
     if (status === 429) {
       return {
-        error: { tier: 'provider', reason: 'network', detail: error.message },
+        error: { tier: 'provider', reason: 'network', detail: describeProviderError(error) },
         retryable: true,
         ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
       }
     }
     if (status !== undefined && status >= 400 && status < 500) {
       return {
-        error: { tier: 'provider', reason: 'unknown', detail: error.message },
+        error: { tier: 'provider', reason: 'unknown', detail: describeProviderError(error) },
         retryable: false,
       }
     }
     return {
-      error: { tier: 'provider', reason: 'network', detail: error.message },
+      error: { tier: 'provider', reason: 'network', detail: describeProviderError(error) },
       retryable: true,
       ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
     }
@@ -68,7 +101,7 @@ export function classifyProviderError(error: unknown): {
     error: {
       tier: 'provider',
       reason: 'unknown',
-      detail: error instanceof Error ? error.message : String(error),
+      detail: describeProviderError(error),
     },
     retryable: true,
   }

--- a/lib/ai/transport/classify-provider-error.ts
+++ b/lib/ai/transport/classify-provider-error.ts
@@ -18,8 +18,18 @@ export class ProviderTimeoutError extends Error {
 
 const MAX_CAUSE_DEPTH = 5
 
+// A thrown value need not be coercible: `String()` on a null-prototype object
+// throws, which would replace the provider failure with a TypeError.
+function coerce(value: unknown): string {
+  try {
+    return String(value)
+  } catch {
+    return '[uncoercible value]'
+  }
+}
+
 function labelOf(error: unknown): string {
-  if (!(error instanceof Error)) return String(error)
+  if (!(error instanceof Error)) return coerce(error)
   // The AI SDK stamps every error name with an `AI_` prefix; it carries no
   // information the surrounding log line doesn't already have.
   const name = error.name.replace(/^AI_/, '')

--- a/lib/ai/transport/fetch.test.ts
+++ b/lib/ai/transport/fetch.test.ts
@@ -161,4 +161,64 @@ describe('createFetchWithCapture', () => {
       expect(sink.failCall).toHaveBeenCalledWith('call-1', 'Error: stream exploded')
     })
   })
+  // expo/fetch's FetchResponse.clone() throws 'Not implemented'. These two cover
+  // the native transport's shape without needing the native bundle.
+  describe('when the response cannot be cloned', () => {
+    function uncloneable(body: BodyInit | null, headers: Record<string, string>): Response {
+      const response = new Response(body, { status: 200, headers })
+      Object.defineProperty(response, 'clone', {
+        value: () => {
+          throw new Error('Not implemented')
+        },
+      })
+      return response
+    }
+
+    it('captures an event stream without its body and leaves the stream to the caller', async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('data: one\n\n'))
+          controller.close()
+        },
+      })
+      const originalResponse = uncloneable(stream, {
+        'content-type': 'text/event-stream',
+      })
+      const wrappedFetch = createFetchWithCapture({
+        source: 'unit-test',
+        fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(originalResponse),
+      })
+
+      const response = await wrappedFetch('https://example.test/v1/stream')
+
+      expect(response).toBe(originalResponse)
+      expect(sink.completeCall).toHaveBeenCalledWith('call-1', {
+        status: 200,
+        responseHeaders: { 'content-type': 'text/event-stream' },
+        streamed: true,
+      })
+      expect(sink.failCall).not.toHaveBeenCalled()
+      // The point of skipping capture: the SDK still gets a readable stream.
+      expect(await response.text()).toBe('data: one\n\n')
+    })
+
+    it('rebuilds a non-streaming response so the body is still readable', async () => {
+      const wrappedFetch = createFetchWithCapture({
+        source: 'unit-test',
+        fetchImpl: vi
+          .fn<typeof fetch>()
+          .mockResolvedValue(uncloneable('{"ok":true}', { 'content-type': 'application/json' })),
+      })
+
+      const response = await wrappedFetch('https://example.test/v1/embeddings')
+
+      expect(sink.completeCall).toHaveBeenCalledWith('call-1', {
+        status: 200,
+        responseHeaders: { 'content-type': 'application/json' },
+        responseBody: '{"ok":true}',
+        streamed: false,
+      })
+      expect(await response.json()).toEqual({ ok: true })
+    })
+  })
 })

--- a/lib/ai/transport/fetch.ts
+++ b/lib/ai/transport/fetch.ts
@@ -1,16 +1,21 @@
 import { httpCallSink } from '@/lib/diagnostics'
 
+import { platformFetch } from './platform-fetch'
+
 type FetchWithCaptureOptions = {
   source: string
   fetchImpl?: typeof fetch
   actionId?: string
 }
 
+// Statuses whose Response must not carry a body, so a rebuild can't pass one.
+const BODYLESS_STATUSES = new Set([204, 205, 304])
+
 function headersToRecord(headers: HeadersInit | undefined): Record<string, string> {
   return Object.fromEntries(new Headers(headers).entries())
 }
 
-async function captureRequestBody(requestClone: Request): Promise<unknown> {
+async function captureRequestBody(requestClone: Request): Promise<string | undefined> {
   if (requestClone.body === null) return undefined
   return requestClone.text()
 }
@@ -19,8 +24,27 @@ function isEventStream(response: Response): boolean {
   return response.headers.get('content-type')?.toLowerCase().includes('text/event-stream') ?? false
 }
 
+// expo/fetch's FetchResponse.clone() throws 'Not implemented', so capture can't
+// assume a second readable copy exists. Probing beats a platform flag: the answer
+// is a property of the response we were handed, not of the bundle we're in.
+function cloneOrNull(response: Response): Response | null {
+  try {
+    return response.clone()
+  } catch {
+    return null
+  }
+}
+
+function rebuildResponse(body: string, from: Response): Response {
+  return new Response(BODYLESS_STATUSES.has(from.status) ? null : body, {
+    status: from.status,
+    statusText: from.statusText,
+    headers: from.headers,
+  })
+}
+
 export function createFetchWithCapture(options: FetchWithCaptureOptions): typeof fetch {
-  const fetchImpl = options.fetchImpl ?? fetch
+  const { fetchImpl } = options
 
   return async (input, init) => {
     const request = new Request(input, init)
@@ -36,11 +60,33 @@ export function createFetchWithCapture(options: FetchWithCaptureOptions): typeof
     })
 
     try {
-      const response = await fetchImpl(request)
+      // The raw init body, not the captured text: a transport that re-sends the
+      // body itself must not round-trip a non-text one through `.text()`. Falls
+      // back to the captured text only when the caller passed a Request.
+      const outgoingBody = init?.body !== undefined ? init.body : requestBody
+      const response =
+        fetchImpl !== undefined
+          ? await fetchImpl(request)
+          : await platformFetch(request, outgoingBody)
       const responseHeaders = headersToRecord(response.headers)
 
-      if (isEventStream(response) && response.body !== null) {
-        const captureResponse = response.clone()
+      // `!= null`, not `!== null`: whatwg-fetch leaves body undefined rather than
+      // null, and treating that as a live stream sends an unreadable response
+      // down the streaming branch.
+      if (isEventStream(response) && response.body != null) {
+        const captureResponse = cloneOrNull(response)
+        if (captureResponse === null) {
+          // Native streaming transport: the body is the SDK's to consume, and
+          // teeing it would put a shim in every provider call. Headers and status
+          // are still captured; the body is not.
+          httpCallSink.completeCall(id, {
+            status: response.status,
+            responseHeaders,
+            streamed: true,
+          })
+          return response
+        }
+
         void (async () => {
           try {
             const responseBody = await captureResponse.text()
@@ -58,7 +104,21 @@ export function createFetchWithCapture(options: FetchWithCaptureOptions): typeof
         return response
       }
 
-      const responseBody = await response.clone().text()
+      const captureResponse = cloneOrNull(response)
+      if (captureResponse === null) {
+        // No second copy available, so consume the original and hand the caller a
+        // rebuilt one — non-streaming handlers only ever read text/json.
+        const responseBody = await response.text()
+        httpCallSink.completeCall(id, {
+          status: response.status,
+          responseHeaders,
+          responseBody,
+          streamed: false,
+        })
+        return rebuildResponse(responseBody, response)
+      }
+
+      const responseBody = await captureResponse.text()
       httpCallSink.completeCall(id, {
         status: response.status,
         responseHeaders,

--- a/lib/ai/transport/native-stream-body.test.ts
+++ b/lib/ai/transport/native-stream-body.test.ts
@@ -1,0 +1,89 @@
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
+import { streamText } from 'ai'
+import { describe, expect, it } from 'vitest'
+
+import { describeProviderError } from './classify-provider-error'
+import { createFetchWithCapture } from './fetch'
+
+// React Native's global fetch is `require('whatwg-fetch')` — an XHR-based
+// polyfill whose Response exposes no `body` getter at all. Every SSE streaming
+// call therefore reaches the SDK's event-source handler with `response.body ==
+// null`, which is issue #394's `Failed to process successful response`.
+function bodylessEventStreamFetch(): typeof fetch {
+  return () =>
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers({ 'content-type': 'text/event-stream' }),
+      // Absent, not null: whatwg-fetch declares no `body` getter whatsoever, so
+      // the capture wrapper's `!== null` guard passes while the SDK's `== null`
+      // check trips. Both branches must end in the same error.
+      url: 'https://inference.test/v1/chat/completions',
+      clone() {
+        return this
+      },
+      text: () => Promise.resolve(''),
+    } as unknown as Response)
+}
+
+function streamErrorOf(fetchImpl: typeof fetch): Promise<unknown> {
+  const model = createOpenAICompatible({
+    name: 'local',
+    baseURL: 'https://inference.test/v1',
+    fetch: createFetchWithCapture({ source: 'test', fetchImpl }),
+  })('local-model')
+
+  return new Promise((resolve) => {
+    const result = streamText({
+      model,
+      prompt: 'P',
+      maxRetries: 0,
+      onError: ({ error }) => resolve(error),
+    })
+    // fullStream terminates silently on a stream failure — onError is the only
+    // signal, exactly as per-turn's narrative phase relies on.
+    void (async () => {
+      for await (const _ of result.fullStream) void _
+      resolve(undefined)
+    })()
+  })
+}
+
+describe('a response with no body stream (React Native fetch shape)', () => {
+  it('fails the stream with an empty-body cause under the SDK envelope', async () => {
+    const error = await streamErrorOf(bodylessEventStreamFetch())
+
+    // The envelope alone is what issue #394 surfaced; the cause names the fault.
+    expect(describeProviderError(error)).toBe(
+      'APICallError: Failed to process successful response ← EmptyResponseBodyError: Empty response body',
+    )
+  })
+
+  it('streams normally when the response carries a body', async () => {
+    const sse = (obj: unknown) => `data: ${JSON.stringify(obj)}\n\n`
+    const chunks = [
+      sse({
+        id: 'c',
+        choices: [{ index: 0, delta: { role: 'assistant', content: 'Hi' }, finish_reason: null }],
+      }),
+      sse({ id: 'c', choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] }),
+      'data: [DONE]\n\n',
+    ]
+
+    const withBody: typeof fetch = () =>
+      Promise.resolve(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              for (const c of chunks) controller.enqueue(new TextEncoder().encode(c))
+              controller.close()
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'text/event-stream' } },
+        ),
+      )
+
+    expect(await streamErrorOf(withBody)).toBeUndefined()
+  })
+})

--- a/lib/ai/transport/platform-fetch.native.ts
+++ b/lib/ai/transport/platform-fetch.native.ts
@@ -1,0 +1,24 @@
+import { fetch as expoFetch } from 'expo/fetch'
+
+/**
+ * React Native's global `fetch` is `require('whatwg-fetch')` — an XHR transport
+ * whose Response declares no `body` getter, so the AI SDK's event-source handler
+ * hits `response.body == null` and rejects every streaming call as
+ * `EmptyResponseBodyError`. `expo/fetch` is the native streaming transport.
+ *
+ * It takes `(url, init)`, not a Request: `FetchRequestLike` requires a real
+ * `body` property, and a whatwg Request has none — handing it one silently sends
+ * an empty body. The body is therefore passed explicitly, unserialized, so a
+ * non-text body survives.
+ */
+export function platformFetch(
+  request: Request,
+  body: BodyInit | null | undefined,
+): Promise<Response> {
+  return expoFetch(request.url, {
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    signal: request.signal,
+    ...(body !== undefined ? { body } : {}),
+  }) as unknown as Promise<Response>
+}

--- a/lib/ai/transport/platform-fetch.ts
+++ b/lib/ai/transport/platform-fetch.ts
@@ -1,0 +1,10 @@
+// Web and Electron already have a streaming-capable fetch; the Request built by
+// the capture wrapper carries method, headers, body and signal, so it goes
+// straight through. The native counterpart cannot use a Request — see
+// platform-fetch.native.ts.
+export function platformFetch(
+  request: Request,
+  _body: BodyInit | null | undefined,
+): Promise<Response> {
+  return fetch(request)
+}

--- a/lib/pipeline/definitions/per-turn.ts
+++ b/lib/pipeline/definitions/per-turn.ts
@@ -3,6 +3,7 @@ import { eq, sql } from 'drizzle-orm'
 
 import { describeProviderError, resolveModel, resolveModelCapabilities, streamText } from '@/lib/ai'
 import { inheritedEntryMetadata, storyEntries, type EntryMetadata } from '@/lib/db'
+import { redactUrl } from '@/lib/diagnostics'
 import { generateId, IdBiMap } from '@/lib/ids'
 import {
   buildPiggybackActions,
@@ -173,15 +174,13 @@ async function* narrativePhase(ctx: PhaseContext): AsyncGenerator<PhaseEmittedEv
   if (streamError !== undefined) {
     // The envelope message alone ("Failed to process successful response") names
     // nothing actionable, and this is the only surface the failure reaches — the
-    // orchestrator does not log phase failures.
+    // orchestrator does not log phase failures. No body: httpCallSink already
+    // stores it, capped. The URL is redacted — an OpenAI-compatible endpoint can
+    // pass its key as a query param.
     ctx.log.error('provider.narrative_stream_failed', {
       detail: describeProviderError(streamError),
       ...(APICallError.isInstance(streamError)
-        ? {
-            statusCode: streamError.statusCode,
-            url: streamError.url,
-            responseBody: streamError.responseBody,
-          }
+        ? { statusCode: streamError.statusCode, url: redactUrl(streamError.url) }
         : {}),
     })
     return {

--- a/lib/pipeline/definitions/per-turn.ts
+++ b/lib/pipeline/definitions/per-turn.ts
@@ -1,6 +1,7 @@
+import { APICallError } from 'ai'
 import { eq, sql } from 'drizzle-orm'
 
-import { resolveModel, resolveModelCapabilities, streamText } from '@/lib/ai'
+import { describeProviderError, resolveModel, resolveModelCapabilities, streamText } from '@/lib/ai'
 import { inheritedEntryMetadata, storyEntries, type EntryMetadata } from '@/lib/db'
 import { generateId, IdBiMap } from '@/lib/ids'
 import {
@@ -170,12 +171,25 @@ async function* narrativePhase(ctx: PhaseContext): AsyncGenerator<PhaseEmittedEv
   // supposed to discard.
   if (ctx.abortSignal.aborted) return { status: 'aborted' }
   if (streamError !== undefined) {
+    // The envelope message alone ("Failed to process successful response") names
+    // nothing actionable, and this is the only surface the failure reaches — the
+    // orchestrator does not log phase failures.
+    ctx.log.error('provider.narrative_stream_failed', {
+      detail: describeProviderError(streamError),
+      ...(APICallError.isInstance(streamError)
+        ? {
+            statusCode: streamError.statusCode,
+            url: streamError.url,
+            responseBody: streamError.responseBody,
+          }
+        : {}),
+    })
     return {
       status: 'failed',
       error: {
         kind: 'provider',
         reason: 'network',
-        detail: streamError instanceof Error ? streamError.message : String(streamError),
+        detail: describeProviderError(streamError),
       },
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved narrative content wrapping to prevent horizontal scrolling, including long text, indented code blocks, and preformatted content.
  * Reader content and the composer now remain visible above the on-screen keyboard.
  * Sending a draft dismisses the keyboard and clears the composer; empty drafts cannot be sent.
  * Spellcheck overlays no longer appear for clean drafts.
  * Provider and streaming errors now offer clearer diagnostics and more reliable response handling across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->