### PR TITLE
Feat/mock backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ superpowers/
 
 # Test coverage reports
 coverage/
+
+# mock LLM dev tool — local response library, not shared
+scripts/mock-llm/state.json

--- a/e2e/harness/mock-llm.ts
+++ b/e2e/harness/mock-llm.ts
@@ -1,7 +1,7 @@
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
 import type { AddressInfo } from 'node:net'
 
-import { STRUCTURED_SHAPES } from '../../scripts/mock-llm/shapes'
+import { matchShape } from '../../scripts/mock-llm/routing'
 
 // A local OpenAI-compatible endpoint. The whole pipeline talks to one URL
 // (POST …/chat/completions) but a turn fans out into calls with different
@@ -217,7 +217,7 @@ export async function startMockLlm(): Promise<MockLlm> {
       }
 
       const text = promptText(body)
-      const agent = STRUCTURED_SHAPES.find((a) => text.includes(a.block)) ?? null
+      const agent = matchShape(null, text)
       requests.push({ body, streamed, agent: agent?.name ?? null })
       const value = agent ? (overrides.get(agent.name) ?? EXAMPLES[agent.name]) : {}
       res.writeHead(200, { ...cors, 'content-type': 'application/json' })

--- a/e2e/harness/mock-llm.ts
+++ b/e2e/harness/mock-llm.ts
@@ -1,15 +1,7 @@
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
 import type { AddressInfo } from 'node:net'
 
-import { z } from 'zod'
-
-import { schemaToTypeScriptBlock, type JsonSchema } from '@/lib/ai'
-import { classifierExtractionSchema } from '@/lib/classifier'
-import {
-  fallbackClassifierSchema,
-  fallbackClassifierWithSuggestionsSchema,
-  suggestionRefreshSchema,
-} from '@/lib/pipeline'
+import { STRUCTURED_SHAPES } from '../../scripts/mock-llm/shapes'
 
 // A local OpenAI-compatible endpoint. The whole pipeline talks to one URL
 // (POST …/chat/completions) but a turn fans out into calls with different
@@ -18,12 +10,17 @@ import {
 //   - otherwise (structured) → a JSON chat completion, whose body is chosen by
 //     matching the exact TypeScript block the app injects into the prompt
 //     (schemaToTypeScriptBlock over the agent's zod schema). Each reply shape
-//     is one STRUCTURED_AGENTS entry — an agent with more than one possible
+//     is one STRUCTURED_SHAPES entry — an agent with more than one possible
 //     schema (e.g. the classifier with/without suggestions) gets one entry per
 //     shape; adding one is mechanical and the match can't drift because it
 //     reuses the app's own renderer.
 // Exercises the real transport (lib/ai/transport), unlike the __DEV__-gated
 // stub provider. See docs/testing.md → Mock LLM.
+//
+// The shape registry is shared with the dev mock server (scripts/mock-llm).
+// The default replies below are NOT: these are deliberately inert so a spec
+// that never calls setStructured writes nothing, whereas the dev tool's
+// defaults are chosen to make a hand-driven turn visibly do something.
 
 export type MockRequest = {
   body: Record<string, unknown>
@@ -32,54 +29,32 @@ export type MockRequest = {
   agent: string | null
 }
 
-// One entry per reply shape; `name` is unique per entry (`overrides` and
-// `MockRequest.agent` both key on it) even when two shapes belong to the same
-// logical agent. `block` is the exact string the app renders into the prompt
-// for this schema; `example` is a schema-valid default reply.
-type StructuredAgent = { name: string; block: string; example: unknown }
-
-const STRUCTURED_AGENTS: StructuredAgent[] = [
-  {
-    name: 'per-turn-classifier',
-    block: schemaToTypeScriptBlock(z.toJSONSchema(fallbackClassifierSchema) as JsonSchema),
-    // No-op: empty scene, no time change — parses and applies cleanly.
-    example: { sceneEntities: [], worldTimeDelta: 0 },
+// Exported so scripts/mock-llm/shapes.test.ts can assert every registered shape
+// still has one and that each is schema-valid — a shape added to the shared
+// registry without an entry here would otherwise serve `undefined` mid-suite.
+export const EXAMPLES: Record<string, unknown> = {
+  // No-op: empty scene, no time change — parses and applies cleanly.
+  'per-turn-classifier': { sceneEntities: [], worldTimeDelta: 0 },
+  // Silence is valid: the default reply must not write anything, so specs opt
+  // in to graph writes via setStructured.
+  'periodic-classifier': {
+    happenings: [],
+    relationships: [],
+    statusFlips: [],
+    newCharacters: [],
   },
-  {
-    name: 'periodic-classifier',
-    block: schemaToTypeScriptBlock(z.toJSONSchema(classifierExtractionSchema) as JsonSchema),
-    // Silence is valid: the default reply must not write anything, so specs opt
-    // in to graph writes via setStructured.
-    example: { happenings: [], relationships: [], statusFlips: [], newCharacters: [] },
-  },
-  {
-    // Same logical agent, second reply shape: the classifier's schema grows a
-    // `suggestions` field whenever the run asks for chips (suggestionsEnabled
-    // AND at least one enabled category, and no chips already in hand), which
-    // changes the injected TS block enough
-    // that it no longer matches the entry above (see per-turn-piggyback.ts).
-    // Distinct name so setStructured can target this shape without also
-    // overriding the base-schema entry's reply.
-    name: 'per-turn-classifier-suggestions',
-    block: schemaToTypeScriptBlock(
-      z.toJSONSchema(fallbackClassifierWithSuggestionsSchema) as JsonSchema,
-    ),
-    example: { sceneEntities: [], worldTimeDelta: 0, suggestions: [] },
-  },
-  {
-    // The ⟳ refresh pipeline's own agent target ('suggestion'), a distinct
-    // schema from both classifier shapes above. Its own entry because an
-    // unmatched structured request answers 200 with `{}` (not a 404 — that is
-    // only for a wrong URL or method), and `{}` fails this schema, which has no
-    // suggestions.catch([]) to absorb it (suggestion-refresh.ts).
-    name: 'suggestion-refresh',
-    block: schemaToTypeScriptBlock(z.toJSONSchema(suggestionRefreshSchema) as JsonSchema),
-    // One resolvable chip, NOT zero: a refresh that resolves nothing is now a
-    // run failure, so an empty default would fail any spec that reaches ⟳
-    // without calling setStructured. cat1 is the first enabled category.
-    example: { suggestions: [{ categoryRef: 'cat1', text: 'You press on.' }] },
-  },
-]
+  // Same logical agent as per-turn-classifier, second reply shape: the
+  // classifier's schema grows a `suggestions` field whenever the run asks for
+  // chips (suggestionsEnabled AND at least one enabled category, and no chips
+  // already in hand), which changes the injected TS block enough that it no
+  // longer matches the base entry (see per-turn-piggyback.ts). Distinct name so
+  // setStructured can target this shape without also overriding the base one.
+  'per-turn-classifier-suggestions': { sceneEntities: [], worldTimeDelta: 0, suggestions: [] },
+  // One resolvable chip, NOT zero: a refresh that resolves nothing is now a
+  // run failure, so an empty default would fail any spec that reaches ⟳
+  // without calling setStructured. cat1 is the first enabled category.
+  'suggestion-refresh': { suggestions: [{ categoryRef: 'cat1', text: 'You press on.' }] },
+}
 
 export type MockLlm = {
   /** baseURL to seed as the provider endpoint (already includes /v1). */
@@ -242,9 +217,9 @@ export async function startMockLlm(): Promise<MockLlm> {
       }
 
       const text = promptText(body)
-      const agent = STRUCTURED_AGENTS.find((a) => text.includes(a.block)) ?? null
+      const agent = STRUCTURED_SHAPES.find((a) => text.includes(a.block)) ?? null
       requests.push({ body, streamed, agent: agent?.name ?? null })
-      const value = agent ? (overrides.get(agent.name) ?? agent.example) : {}
+      const value = agent ? (overrides.get(agent.name) ?? EXAMPLES[agent.name]) : {}
       res.writeHead(200, { ...cors, 'content-type': 'application/json' })
       res.end(structuredCompletion(value))
     })()

--- a/lib/db/devtools/seed-dataset.ts
+++ b/lib/db/devtools/seed-dataset.ts
@@ -1507,7 +1507,10 @@ const appSettingsRow: NewAppSettings = {
       type: 'openai-compatible',
       displayName: 'Local (seed)',
       apiKey: '',
-      endpoint: 'http://localhost:1234/v1',
+      // scripts/mock-llm's default port, so `pnpm db:seed && pnpm mock` needs no
+      // further wiring. Deliberately not 1234, which LM Studio claims — that
+      // leaves a real local provider available as a passthrough upstream.
+      endpoint: 'http://localhost:4319/v1',
       favoriteModelIds: ['seed/narrative'],
       // taggedBlockReliable lets piggyback ride in-band on the narrative call;
       // the classifier profile below still backs the periodic classifier, the

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "db:check": "drizzle-kit check",
     "db:check:format": "tsx scripts/check-migrations-format.ts",
     "db:seed": "tsx scripts/seed/index.ts",
+    "mock": "tsx scripts/mock-llm/index.ts",
     "db:studio:desktop": "drizzle-kit studio --config drizzle.studio.config.ts"
   },
   "dependencies": {

--- a/scripts/mock-llm/README.md
+++ b/scripts/mock-llm/README.md
@@ -1,0 +1,115 @@
+# Mock LLM
+
+A local OpenAI-compatible provider with a browser control panel, so a
+pipeline turn costs milliseconds instead of minutes while you drive the
+app by hand.
+
+```sh
+pnpm db:seed   # seeds prov_local at http://localhost:4319/v1
+pnpm mock      # endpoint + control UI on :4319
+pnpm desktop
+```
+
+Then open <http://127.0.0.1:4319/>.
+
+`--port` (or `MOCK_LLM_PORT`) moves it; the app's endpoint is editable
+under Settings → Providers if you do.
+
+## What it is
+
+The same idea as [`e2e/harness/mock-llm.ts`](../../e2e/harness/mock-llm.ts)
+— a real HTTP endpoint the app reaches through its real transport — but
+external, stateful and driven from a UI instead of from a spec.
+
+It is coupled to the repo on purpose: it renders response shapes with the
+app's own [`schemaToTypeScriptBlock`](../../lib/ai/prompt-schema.ts),
+validates authored replies against the app's own zod schemas, and builds
+trailing blocks from the app's own tag constants in
+[`lib/piggyback/tags.ts`](../../lib/piggyback/tags.ts). Its tests round-trip
+everything it emits through the app's real parsers, so it cannot serve
+markup the app rejects.
+
+## Lanes
+
+The app talks to one URL, and a turn fans out into several calls. The mock
+separates them by inspecting the request:
+
+- `stream: true` → the **narrative** lane.
+- anything else → a **structured** lane, identified by the TypeScript block
+  the app injects into the prompt (or, on the `force-on` path, by the JSON
+  Schema in `response_format`).
+
+Shapes listed in [`shapes.ts`](./shapes.ts) get a named lane with live
+schema validation. A shape that is _not_ listed still gets a lane, keyed by
+a hash of its block and flagged `unregistered` in the UI — a new agent is
+addressable straight away, and adding it to `shapes.ts` only upgrades it to
+a friendly name and validation.
+
+Per lane you get: a library of named responses, sequence cycling, a
+mock/passthrough switch, response delay and jitter, failure injection, and
+(narrative only) streaming speed.
+
+## Failure injection
+
+| Kind         | What the app sees                                                                                                                                                                       |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `http`       | The chosen status. 401/403 is non-retryable, 429 and 5xx are retryable — see [`classify-provider-error.ts`](../../lib/ai/transport/classify-provider-error.ts).                         |
+| `malformed`  | A reply that cannot be repaired into a valid object, exercising the parse-retry path. On narrative it appends a truncated `<state>` block instead, exercising piggyback parse recovery. |
+| `stream-cut` | The SSE stream opens, emits, then closes with no stop frame and no `[DONE]`.                                                                                                            |
+| `hang`       | The socket opens and never finishes, until the client times out or cancels.                                                                                                             |
+
+**Structured calls retry once.** `generateStructured` wraps the call in
+`callWithRetry` with `maxProviderAttempts: 2`, so a failure budget of 1 on a
+structured lane is swallowed before the app ever sees it. Use 2 or more.
+Narrative has no such wrapper — one failure fails the run.
+
+## Passthrough and recording
+
+Set a lane to **passthrough** and pick an upstream to send just that agent
+to a real provider while everything else stays instant. Upstreams are
+configured with the _name_ of an environment variable, never a key:
+
+```jsonc
+// state.json → upstreams
+{
+  "id": "lmstudio",
+  "label": "LM Studio",
+  "baseURL": "http://localhost:1234/v1",
+  "apiKeyEnv": "",
+  "model": "qwen3-30b",
+}
+```
+
+The key is read from `process.env` at call time. It is never written to
+`state.json` and never crosses the control API.
+
+Every passthrough reply lands in the request log with **Save reply as a
+response** — the raw text is split back into prose, `<state>` and
+`<suggestions>` using the app's own parsers and stored as a canned response.
+Record once against a real model, replay forever.
+
+## Entity placeholders
+
+`IdBiMap` allocates `c1`, `c2`, `l1`… per run in prompt-encounter order, so
+the same placeholder means a different entity every turn. Shipped defaults
+therefore name none of them.
+
+To write a reply that moves a specific entity: run the turn, open the
+request in the log, and use **Open this lane with its placeholders** — the
+roster the prompt actually sent is pinned above the editor.
+
+## Piggyback
+
+Only `seed/narrative` carries `taggedBlockReliable` in the dev seed, and
+there is no capability editor in app settings, so `/v1/models` advertises
+that exact id. If the narrative model resolves to anything else,
+`resolvePiggybackFires` returns false and every turn quietly runs the
+_fallback_ classifier instead. The log flags this on any per-turn classifier
+call. `mock/no-tagged-block` is advertised for when you want that fallback
+path on purpose.
+
+## State
+
+`state.json` (gitignored) holds lanes, responses and upstreams, and is
+written back as you edit. Delete it to restore shipped defaults, or use
+**Reset to defaults** in the header.

--- a/scripts/mock-llm/completions.ts
+++ b/scripts/mock-llm/completions.ts
@@ -1,0 +1,220 @@
+import { randomUUID } from 'node:crypto'
+import type { IncomingMessage, ServerResponse } from 'node:http'
+
+import type { MockContext } from './context'
+import { extractPlaceholders, type LogEntry } from './log'
+import { passthrough } from './passthrough'
+import { streamNarrative } from './respond/narrative'
+import { hasStateContent, renderNarrative, type NarrativeValue } from './respond/tagged-block'
+import { CORS_HEADERS, SSE_HEADERS, completionBody, errorBody, roleFrame } from './respond/wire'
+import { classifyRequest, laneKeyOf, promptText, NARRATIVE_LANE } from './routing'
+import { nextResponse, takeFailure, type FailureKind, type Lane } from './state'
+
+const PER_TURN_CLASSIFIER_LANES = new Set([
+  'per-turn-classifier',
+  'per-turn-classifier-suggestions',
+])
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+function jittered(base: number, jitter: number): number {
+  if (jitter <= 0) return base
+  return Math.max(0, base + (Math.random() * 2 - 1) * jitter)
+}
+
+// Content present but nothing extractable: the app's parser reports a field
+// failure rather than "nothing to report", which is the piggyback recovery path.
+const TRUNCATED_STATE_BLOCK = '\n\n<state>\n  <transfers><item id='
+
+// Prose, not truncated JSON: generateStructured runs the reply through
+// jsonrepair before validating, and repaired truncation can land on a value a
+// schema whose fields all carry defaults accepts. A refusal fails every object
+// schema, and is what a real model actually emits when it declines.
+const MALFORMED_STRUCTURED = "I'm sorry, I can't produce that JSON."
+
+function asNarrativeValue(value: unknown): NarrativeValue {
+  if (typeof value === 'string') return { prose: value }
+  const record = (value ?? {}) as Partial<NarrativeValue>
+  return {
+    prose: typeof record.prose === 'string' ? record.prose : '',
+    ...(record.state !== undefined ? { state: record.state } : {}),
+    ...(record.suggestions !== undefined ? { suggestions: record.suggestions } : {}),
+  }
+}
+
+export function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = ''
+    req.on('data', (c) => (data += c))
+    req.on('end', () => resolve(data))
+    req.on('error', reject)
+  })
+}
+
+function sendHttpFailure(res: ServerResponse, status: number): void {
+  res.writeHead(status, { ...CORS_HEADERS, 'content-type': 'application/json' })
+  res.end(errorBody(`mock injected HTTP ${status}`))
+}
+
+function resolveUpstream(ctx: MockContext, lane: Lane) {
+  if (lane.mode !== 'passthrough') return null
+  return ctx.state.upstreams.find((u) => u.id === lane.upstreamId) ?? null
+}
+
+// Not the whole story on its own — a narrative that carried <state> and is
+// still followed by a classifier call means the piggyback fold did not take,
+// most often because the resolved narrative model has no taggedBlockReliable
+// capability. Without this the fallback path looks identical to the real one.
+function piggybackNote(ctx: MockContext, key: string): string | undefined {
+  if (!PER_TURN_CLASSIFIER_LANES.has(key)) return undefined
+  if (ctx.log.lastNarrativeHadState === true)
+    return 'fallback classifier fired even though the narrative carried <state> — check taggedBlockReliable on the resolved narrative model'
+  if (ctx.log.lastNarrativeHadState === false)
+    return 'fallback classifier fired because the narrative carried no <state> block'
+  return undefined
+}
+
+export async function handleCompletion(
+  req: IncomingMessage,
+  res: ServerResponse,
+  ctx: MockContext,
+): Promise<void> {
+  const startedAt = Date.now()
+  const raw = await readBody(req)
+  const body = (raw ? JSON.parse(raw) : {}) as Record<string, unknown>
+
+  const route = classifyRequest(body)
+  const key = laneKeyOf(route)
+  const streamed = route.lane === NARRATIVE_LANE
+
+  if (route.lane === 'structured' && route.shape === null && !ctx.discovered.has(key)) {
+    ctx.discovered.set(key, { key, block: route.block, firstSeenAt: Date.now() })
+  }
+
+  const lane = ctx.lane(key)
+  const prompt = promptText(body)
+
+  const controller = new AbortController()
+  let clientGone = false
+  req.on('close', () => {
+    clientGone = true
+    controller.abort()
+  })
+
+  const note = piggybackNote(ctx, key)
+  const entry: LogEntry = {
+    id: randomUUID(),
+    at: startedAt,
+    lane: key,
+    shapeName: route.lane === 'structured' ? (route.shape?.name ?? null) : null,
+    block: route.lane === 'structured' ? route.block : null,
+    mode: lane.mode,
+    streamed,
+    outcome: 'ok',
+    status: 200,
+    durationMs: 0,
+    prompt,
+    served: null,
+    placeholders: extractPlaceholders(prompt),
+    ...(note !== undefined ? { note } : {}),
+  }
+
+  const finish = (): void => {
+    entry.durationMs = Date.now() - startedAt
+    if (clientGone && entry.outcome === 'ok') entry.outcome = 'aborted'
+    ctx.log.push(entry)
+    ctx.save()
+  }
+
+  const failure: FailureKind = takeFailure(lane)
+  if (failure !== 'none') {
+    entry.failureKind = failure
+    entry.outcome = 'failed'
+  }
+
+  await sleep(jittered(lane.delay.ttfbMs, lane.delay.jitterMs))
+  if (clientGone) {
+    entry.outcome = 'aborted'
+    finish()
+    return
+  }
+
+  if (failure === 'http') {
+    entry.status = lane.failure.status
+    sendHttpFailure(res, lane.failure.status)
+    finish()
+    return
+  }
+
+  if (failure === 'hang') {
+    // Opened but never finished: the deterministic in-flight window a cancel or
+    // timeout test needs. The socket is released when the client gives up.
+    if (streamed) {
+      res.writeHead(200, SSE_HEADERS)
+      res.write(roleFrame())
+    } else {
+      res.writeHead(200, { ...CORS_HEADERS, 'content-type': 'application/json' })
+    }
+    req.on('close', finish)
+    return
+  }
+
+  const upstream = resolveUpstream(ctx, lane)
+  if (upstream !== null) {
+    const result = await passthrough({ upstream, body, res, signal: controller.signal })
+    entry.status = result.status
+    entry.served = result.content
+    entry.responseName = `${upstream.label} (${upstream.model})`
+    if (result.error !== undefined) entry.outcome = 'failed'
+    if (streamed) ctx.log.lastNarrativeHadState = result.content.includes('<state>')
+    finish()
+    return
+  }
+
+  if (lane.mode === 'passthrough') {
+    entry.outcome = 'failed'
+    entry.status = 503
+    entry.note = 'lane is set to passthrough but has no upstream selected'
+    res.writeHead(503, { ...CORS_HEADERS, 'content-type': 'application/json' })
+    res.end(errorBody('mock lane is set to passthrough but no upstream is selected'))
+    finish()
+    return
+  }
+
+  const canned = nextResponse(lane)
+  if (canned !== null) entry.responseName = canned.name
+
+  if (streamed) {
+    const value = asNarrativeValue(canned?.value)
+    const content =
+      failure === 'malformed'
+        ? renderNarrative(value) + TRUNCATED_STATE_BLOCK
+        : renderNarrative(value)
+
+    ctx.log.lastNarrativeHadState = failure === 'malformed' || hasStateContent(value.state)
+    entry.served = content
+
+    res.writeHead(200, SSE_HEADERS)
+    await streamNarrative(res, {
+      content,
+      charsPerSecond: lane.stream.charsPerSecond,
+      chunkSize: lane.stream.chunkSize,
+      jitterMs: lane.delay.jitterMs,
+      ...(failure === 'stream-cut' ? { cut: true } : {}),
+      aborted: () => clientGone,
+    })
+    finish()
+    return
+  }
+
+  // An unconfigured structured lane answers `{}` rather than 404 — the same
+  // contract the E2E mock uses, so a schema with defaults still parses.
+  const value = canned?.value ?? {}
+  const broken = failure === 'malformed' || failure === 'stream-cut'
+  const content = broken ? MALFORMED_STRUCTURED : JSON.stringify(value)
+
+  entry.served = broken ? content : value
+  res.writeHead(200, { ...CORS_HEADERS, 'content-type': 'application/json' })
+  res.end(completionBody(content))
+  finish()
+}

--- a/scripts/mock-llm/completions.ts
+++ b/scripts/mock-llm/completions.ts
@@ -81,7 +81,15 @@ export async function handleCompletion(
 ): Promise<void> {
   const startedAt = Date.now()
   const raw = await readBody(req)
-  const body = (raw ? JSON.parse(raw) : {}) as Record<string, unknown>
+  let body: Record<string, unknown>
+  try {
+    body = (raw ? JSON.parse(raw) : {}) as Record<string, unknown>
+  } catch {
+    // The caller's error, not the mock's — a 500 reads as the mock falling over.
+    res.writeHead(400, { ...CORS_HEADERS, 'content-type': 'application/json' })
+    res.end(errorBody('mock could not parse the request body as JSON', 'invalid_request_error'))
+    return
+  }
 
   const route = classifyRequest(body)
   const key = laneKeyOf(route)
@@ -96,7 +104,11 @@ export async function handleCompletion(
 
   const controller = new AbortController()
   let clientGone = false
-  req.on('close', () => {
+  // Not req 'close': IncomingMessage closes as soon as the body has arrived, so
+  // a listener attached after readBody never fires. writableFinished separates
+  // a reply that completed from a client that walked away mid-call.
+  res.on('close', () => {
+    if (res.writableFinished) return
     clientGone = true
     controller.abort()
   })
@@ -126,17 +138,20 @@ export async function handleCompletion(
     ctx.save()
   }
 
-  const failure: FailureKind = takeFailure(lane)
-  if (failure !== 'none') {
-    entry.failureKind = failure
-    entry.outcome = 'failed'
-  }
-
   await sleep(jittered(lane.delay.ttfbMs, lane.delay.jitterMs))
   if (clientGone) {
     entry.outcome = 'aborted'
     finish()
     return
+  }
+
+  // Spent only once the call is going to be answered: a budget claimed by a
+  // request abandoned during the delay leaves the lane looking armed while the
+  // next call sails through.
+  const failure: FailureKind = takeFailure(lane)
+  if (failure !== 'none') {
+    entry.failureKind = failure
+    entry.outcome = 'failed'
   }
 
   if (failure === 'http') {
@@ -155,7 +170,7 @@ export async function handleCompletion(
     } else {
       res.writeHead(200, { ...CORS_HEADERS, 'content-type': 'application/json' })
     }
-    req.on('close', finish)
+    res.on('close', finish)
     return
   }
 
@@ -176,7 +191,12 @@ export async function handleCompletion(
     entry.status = 503
     entry.note = 'lane is set to passthrough but has no upstream selected'
     res.writeHead(503, { ...CORS_HEADERS, 'content-type': 'application/json' })
-    res.end(errorBody('mock lane is set to passthrough but no upstream is selected'))
+    res.end(
+      errorBody(
+        'mock lane is set to passthrough but no upstream is selected',
+        'mock_lane_misconfigured',
+      ),
+    )
     finish()
     return
   }

--- a/scripts/mock-llm/context.ts
+++ b/scripts/mock-llm/context.ts
@@ -1,0 +1,49 @@
+import { RequestLog } from './log'
+import { NARRATIVE_LANE } from './routing'
+import { STRUCTURED_SHAPES } from './shapes'
+import { defaultState, emptyLane, loadState, saveState, type Lane, type MockState } from './state'
+
+/** A structured shape seen on the wire that the registry does not name. */
+export type DiscoveredShape = { key: string; block: string | null; firstSeenAt: number }
+
+export type MockContext = {
+  state: MockState
+  log: RequestLog
+  discovered: Map<string, DiscoveredShape>
+  save: () => void
+  lane: (key: string) => Lane
+}
+
+/** `persist: false` keeps a test run off the developer's state.json entirely. */
+export function createContext(opts: { persist?: boolean } = {}): MockContext {
+  const persist = opts.persist !== false
+  const state = persist ? loadState() : defaultState()
+  return {
+    state,
+    log: new RequestLog(),
+    discovered: new Map(),
+    save: persist ? () => saveState(state) : () => {},
+    lane: (key) => (state.lanes[key] ??= emptyLane()),
+  }
+}
+
+/** Lane keys the UI lists: narrative, every registered shape, then discoveries. */
+export function laneCatalog(
+  ctx: MockContext,
+): { key: string; title: string; kind: 'narrative' | 'registered' | 'unknown' }[] {
+  const registered = STRUCTURED_SHAPES.map((s) => ({
+    key: s.name,
+    title: s.name,
+    kind: 'registered' as const,
+  }))
+  const unknown = [...ctx.discovered.values()].map((d) => ({
+    key: d.key,
+    title: d.key,
+    kind: 'unknown' as const,
+  }))
+  return [
+    { key: NARRATIVE_LANE, title: 'narrative', kind: 'narrative' as const },
+    ...registered,
+    ...unknown,
+  ]
+}

--- a/scripts/mock-llm/control.ts
+++ b/scripts/mock-llm/control.ts
@@ -1,0 +1,213 @@
+import { randomUUID } from 'node:crypto'
+import type { IncomingMessage, ServerResponse } from 'node:http'
+
+import { z } from 'zod'
+
+import { parseStateBlock, parseSuggestionsBlock, stripTrailingBlocks } from '@/lib/piggyback'
+
+import { readBody } from './completions'
+import { laneCatalog, type MockContext } from './context'
+import { CORS_HEADERS } from './respond/wire'
+import { NARRATIVE_LANE } from './routing'
+import { STRUCTURED_SHAPES } from './shapes'
+import { defaultState, flushState, upstreamSchema, type CannedResponse } from './state'
+import { validateLaneValue } from './validate'
+
+function json(res: ServerResponse, status: number, value: unknown): void {
+  res.writeHead(status, { ...CORS_HEADERS, 'content-type': 'application/json' })
+  res.end(JSON.stringify(value))
+}
+
+function snapshot(ctx: MockContext) {
+  return {
+    lanes: laneCatalog(ctx).map((meta) => ({ ...meta, lane: ctx.lane(meta.key) })),
+    upstreams: ctx.state.upstreams.map((u) => ({
+      ...u,
+      // Names only — the key itself never crosses this boundary.
+      apiKeyPresent: u.apiKeyEnv !== '' && process.env[u.apiKeyEnv] !== undefined,
+    })),
+    shapes: STRUCTURED_SHAPES.map((s) => ({ name: s.name, block: s.block })),
+    discovered: [...ctx.discovered.values()],
+  }
+}
+
+/** Rebuilds an authored value from what a call actually served. */
+function recordedValue(laneKey: string, served: unknown): unknown {
+  if (laneKey !== NARRATIVE_LANE) {
+    if (typeof served !== 'string') return served
+    try {
+      return JSON.parse(served)
+    } catch {
+      return served
+    }
+  }
+
+  const raw = typeof served === 'string' ? served : ''
+  const { prose } = stripTrailingBlocks(raw)
+  const state = parseStateBlock(raw)
+  const suggestions = parseSuggestionsBlock(raw)
+  return {
+    prose,
+    ...(state.blockFound ? { state: state.block } : {}),
+    ...(suggestions.blockFound ? { suggestions: suggestions.items } : {}),
+  }
+}
+
+function sendEvents(req: IncomingMessage, res: ServerResponse, ctx: MockContext): void {
+  res.writeHead(200, {
+    ...CORS_HEADERS,
+    'content-type': 'text/event-stream',
+    'cache-control': 'no-cache',
+    connection: 'keep-alive',
+  })
+  res.write(': connected\n\n')
+  const unsubscribe = ctx.log.subscribe((entry) => {
+    res.write(`data: ${JSON.stringify(entry)}\n\n`)
+  })
+  // Proxies and browsers drop an idle event-stream; a comment frame is the
+  // cheapest thing that counts as traffic.
+  const heartbeat = setInterval(() => res.write(': ping\n\n'), 20_000)
+  req.on('close', () => {
+    clearInterval(heartbeat)
+    unsubscribe()
+  })
+}
+
+export async function handleControl(
+  req: IncomingMessage,
+  res: ServerResponse,
+  ctx: MockContext,
+  pathname: string,
+): Promise<void> {
+  const segments = pathname.split('/').filter(Boolean).slice(1)
+  const method = req.method ?? 'GET'
+  const body = async (): Promise<Record<string, unknown>> => {
+    const raw = await readBody(req)
+    return raw ? (JSON.parse(raw) as Record<string, unknown>) : {}
+  }
+  const commit = (): void => {
+    ctx.save()
+    json(res, 200, snapshot(ctx))
+  }
+
+  if (segments[0] === 'state' && method === 'GET') return json(res, 200, snapshot(ctx))
+
+  if (segments[0] === 'events' && method === 'GET') return sendEvents(req, res, ctx)
+
+  if (segments[0] === 'log') {
+    if (method === 'GET') return json(res, 200, ctx.log.list())
+    if (method === 'DELETE') {
+      ctx.log.clear()
+      return json(res, 200, { ok: true })
+    }
+    // /api/log/:id/save
+    const entry = segments[1] !== undefined ? ctx.log.find(segments[1]) : undefined
+    if (segments[2] === 'save' && method === 'POST') {
+      if (entry === undefined) return json(res, 404, { error: 'no such log entry' })
+      const payload = await body()
+      const value = recordedValue(entry.lane, entry.served)
+      const check = validateLaneValue(entry.lane, value)
+      if (!check.ok) return json(res, 400, { error: check.error })
+      const canned: CannedResponse = {
+        id: `r_${randomUUID().slice(0, 8)}`,
+        name: typeof payload.name === 'string' ? payload.name : 'Recorded',
+        value,
+      }
+      const lane = ctx.lane(entry.lane)
+      lane.responses.push(canned)
+      lane.sequence.ids.push(canned.id)
+      lane.activeId ??= canned.id
+      return commit()
+    }
+  }
+
+  if (segments[0] === 'upstreams' && method === 'PUT') {
+    const payload = await body()
+    const parsed = z.array(upstreamSchema).safeParse(payload.upstreams)
+    if (!parsed.success) return json(res, 400, { error: parsed.error.message })
+    ctx.state.upstreams = parsed.data
+    return commit()
+  }
+
+  if (segments[0] === 'lanes' && segments[1] !== undefined) {
+    const key = decodeURIComponent(segments[1])
+    const lane = ctx.lane(key)
+
+    if (segments[2] === undefined && method === 'PUT') {
+      const payload = await body()
+      for (const field of ['mode', 'upstreamId', 'activeId'] as const) {
+        if (field in payload) Object.assign(lane, { [field]: payload[field] })
+      }
+      for (const group of ['sequence', 'delay', 'failure', 'stream'] as const) {
+        if (group in payload) Object.assign(lane[group], payload[group])
+      }
+      return commit()
+    }
+
+    if (segments[2] === 'sequence' && segments[3] === 'reset' && method === 'POST') {
+      lane.sequence.cursor = 0
+      return commit()
+    }
+
+    if (segments[2] === 'responses') {
+      const payload = method === 'DELETE' ? {} : await body()
+
+      if (segments[3] === undefined && method === 'POST') {
+        const check = validateLaneValue(key, payload.value)
+        if (!check.ok) return json(res, 400, { error: check.error })
+        const canned: CannedResponse = {
+          id: `r_${randomUUID().slice(0, 8)}`,
+          name: typeof payload.name === 'string' ? payload.name : 'Untitled',
+          value: payload.value,
+        }
+        lane.responses.push(canned)
+        lane.sequence.ids.push(canned.id)
+        lane.activeId ??= canned.id
+        return commit()
+      }
+
+      const id = segments[3]
+      const index = lane.responses.findIndex((r) => r.id === id)
+      if (index === -1) return json(res, 404, { error: 'no such response' })
+
+      if (method === 'PUT') {
+        if ('value' in payload) {
+          const check = validateLaneValue(key, payload.value)
+          if (!check.ok) return json(res, 400, { error: check.error })
+        }
+        const existing = lane.responses[index] as CannedResponse
+        lane.responses[index] = {
+          ...existing,
+          ...(typeof payload.name === 'string' ? { name: payload.name } : {}),
+          ...('value' in payload ? { value: payload.value } : {}),
+        }
+        return commit()
+      }
+
+      if (method === 'DELETE') {
+        lane.responses.splice(index, 1)
+        lane.sequence.ids = lane.sequence.ids.filter((r) => r !== id)
+        if (lane.activeId === id) lane.activeId = lane.responses[0]?.id ?? null
+        return commit()
+      }
+    }
+  }
+
+  if (segments[0] === 'bulk' && method === 'POST') {
+    const payload = await body()
+    for (const lane of Object.values(ctx.state.lanes)) {
+      if (payload.mode === 'mock' || payload.mode === 'passthrough') lane.mode = payload.mode
+      if (payload.resetSequences === true) lane.sequence.cursor = 0
+      if (payload.clearFailures === true) lane.failure.kind = 'none'
+    }
+    return commit()
+  }
+
+  if (segments[0] === 'reset' && method === 'POST') {
+    Object.assign(ctx.state, defaultState())
+    flushState(ctx.state)
+    return json(res, 200, snapshot(ctx))
+  }
+
+  json(res, 404, { error: `no control route for ${method} ${pathname}` })
+}

--- a/scripts/mock-llm/control.ts
+++ b/scripts/mock-llm/control.ts
@@ -7,14 +7,16 @@ import { parseStateBlock, parseSuggestionsBlock, stripTrailingBlocks } from '@/l
 
 import { readBody } from './completions'
 import { laneCatalog, type MockContext } from './context'
-import { CORS_HEADERS } from './respond/wire'
 import { NARRATIVE_LANE } from './routing'
 import { STRUCTURED_SHAPES } from './shapes'
-import { defaultState, flushState, upstreamSchema, type CannedResponse } from './state'
+import { defaultState, flushState, laneSchema, upstreamSchema, type CannedResponse } from './state'
 import { validateLaneValue } from './validate'
 
+// No CORS headers anywhere in this file: the panel is served from this same
+// origin, and the request log carries whole prompts — a page in another tab
+// must not be able to read it or re-arm a lane.
 function json(res: ServerResponse, status: number, value: unknown): void {
-  res.writeHead(status, { ...CORS_HEADERS, 'content-type': 'application/json' })
+  res.writeHead(status, { 'content-type': 'application/json' })
   res.end(JSON.stringify(value))
 }
 
@@ -55,7 +57,6 @@ function recordedValue(laneKey: string, served: unknown): unknown {
 
 function sendEvents(req: IncomingMessage, res: ServerResponse, ctx: MockContext): void {
   res.writeHead(200, {
-    ...CORS_HEADERS,
     'content-type': 'text/event-stream',
     'cache-control': 'no-cache',
     connection: 'keep-alive',
@@ -135,12 +136,24 @@ export async function handleControl(
 
     if (segments[2] === undefined && method === 'PUT') {
       const payload = await body()
+      // Merged into a candidate and validated whole before it touches the lane:
+      // an unchecked patch persists to state.json and the next boot refuses to
+      // load it, so the panel would break the server it configures.
+      const candidate: Record<string, unknown> = { ...lane }
       for (const field of ['mode', 'upstreamId', 'activeId'] as const) {
-        if (field in payload) Object.assign(lane, { [field]: payload[field] })
+        if (field in payload) candidate[field] = payload[field]
       }
       for (const group of ['sequence', 'delay', 'failure', 'stream'] as const) {
-        if (group in payload) Object.assign(lane[group], payload[group])
+        if (!(group in payload)) continue
+        const patch = payload[group]
+        candidate[group] =
+          typeof patch === 'object' && patch !== null && !Array.isArray(patch)
+            ? { ...lane[group], ...patch }
+            : patch
       }
+      const parsed = laneSchema.safeParse(candidate)
+      if (!parsed.success) return json(res, 400, { error: parsed.error.message })
+      Object.assign(lane, parsed.data)
       return commit()
     }
 

--- a/scripts/mock-llm/index.ts
+++ b/scripts/mock-llm/index.ts
@@ -1,0 +1,41 @@
+import { startMockServer } from './server'
+import { flushState, STATE_PATH } from './state'
+
+export const DEFAULT_PORT = 4319
+
+function resolvePort(): number {
+  const flag = process.argv.indexOf('--port')
+  const raw = flag !== -1 ? process.argv[flag + 1] : process.env.MOCK_LLM_PORT
+  const port = raw !== undefined ? Number(raw) : DEFAULT_PORT
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error(`Invalid port: ${String(raw)}`)
+  }
+  return port
+}
+
+async function main(): Promise<void> {
+  const port = resolvePort()
+  const mock = await startMockServer(port)
+
+  console.log('')
+  console.log('  Aventuras mock LLM')
+  console.log(`    endpoint    ${mock.url}`)
+  console.log(`    control UI  ${mock.uiUrl}`)
+  console.log(`    state       ${STATE_PATH}`)
+  console.log('')
+  console.log('  Point the app at the endpoint above (Settings → provider endpoint),')
+  console.log('  or run `pnpm db:seed`, which seeds it already.')
+  console.log('')
+
+  const shutdown = (): void => {
+    flushState(mock.ctx.state)
+    void mock.close().then(() => process.exit(0))
+  }
+  process.on('SIGINT', shutdown)
+  process.on('SIGTERM', shutdown)
+}
+
+void main().catch((err: unknown) => {
+  console.error('[mock-llm] failed to start:', err)
+  process.exit(1)
+})

--- a/scripts/mock-llm/log.ts
+++ b/scripts/mock-llm/log.ts
@@ -1,0 +1,87 @@
+import { PLACEHOLDER_PREFIX_BY_KIND } from '@/lib/ids'
+
+import type { FailureKind } from './state'
+
+const MAX_ENTRIES = 200
+
+// Longest prefix first so `lo1` isn't matched as `l` + `o1`.
+const PLACEHOLDER_ALTERNATION = Object.values(PLACEHOLDER_PREFIX_BY_KIND)
+  .sort((a, b) => b.length - a.length)
+  .join('|')
+
+// Prompts list entities as "[c1] Kael" (lib/prompts/bundled/state-emission.ts),
+// which is the only place a canned reply can learn what this run's positional
+// placeholders actually point at — IdBiMap allocates them per run in
+// encounter order, so they mean something different every turn.
+// The label stops at the next `[` as well as at the line end: rosters are
+// normally one entity per line, but a prompt that lists several inline would
+// otherwise fold every later entry into the first one's label.
+const ROSTER_PATTERN = new RegExp(
+  `\\[((?:${PLACEHOLDER_ALTERNATION})\\d+)\\]\\s*([^\\n\\r[]*)`,
+  'g',
+)
+
+export type Placeholder = { ref: string; label: string }
+
+export type LogEntry = {
+  id: string
+  at: number
+  lane: string
+  shapeName: string | null
+  /** The TypeScript block this request declared, when one was recoverable. */
+  block: string | null
+  mode: 'mock' | 'passthrough'
+  streamed: boolean
+  outcome: 'ok' | 'failed' | 'aborted'
+  failureKind?: FailureKind
+  status: number
+  durationMs: number
+  responseName?: string
+  note?: string
+  prompt: string
+  /** Assistant text served (streaming) or the structured value (non-streaming). */
+  served: unknown
+  placeholders: Placeholder[]
+}
+
+export function extractPlaceholders(prompt: string): Placeholder[] {
+  const seen = new Map<string, string>()
+  for (const match of prompt.matchAll(ROSTER_PATTERN)) {
+    const [, ref, label] = match
+    if (ref === undefined) continue
+    if (!seen.has(ref)) seen.set(ref, (label ?? '').trim())
+  }
+  return [...seen].map(([ref, label]) => ({ ref, label }))
+}
+
+export class RequestLog {
+  private entries: LogEntry[] = []
+  private listeners = new Set<(entry: LogEntry) => void>()
+
+  /** Whether the last narrative reply carried a <state> block. */
+  lastNarrativeHadState: boolean | null = null
+
+  push(entry: LogEntry): void {
+    this.entries.unshift(entry)
+    if (this.entries.length > MAX_ENTRIES) this.entries.length = MAX_ENTRIES
+    for (const listener of this.listeners) listener(entry)
+  }
+
+  list(): LogEntry[] {
+    return this.entries
+  }
+
+  find(id: string): LogEntry | undefined {
+    return this.entries.find((e) => e.id === id)
+  }
+
+  clear(): void {
+    this.entries = []
+    this.lastNarrativeHadState = null
+  }
+
+  subscribe(listener: (entry: LogEntry) => void): () => void {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+}

--- a/scripts/mock-llm/passthrough.ts
+++ b/scripts/mock-llm/passthrough.ts
@@ -1,0 +1,118 @@
+import type { ServerResponse } from 'node:http'
+
+import { CORS_HEADERS, SSE_HEADERS, errorBody } from './respond/wire'
+import type { Upstream } from './state'
+
+export type PassthroughResult = {
+  status: number
+  /** Assembled assistant text — what record mode saves as a canned response. */
+  content: string
+  error?: string
+}
+
+function completionsUrl(baseURL: string): string {
+  return `${baseURL.replace(/\/+$/, '')}/chat/completions`
+}
+
+/** Accumulates the assistant text carried by an OpenAI-compatible SSE buffer. */
+export function collectSseContent(buffer: string): string {
+  let content = ''
+  for (const block of buffer.split('\n\n')) {
+    const line = block.split('\n').find((l) => l.startsWith('data:'))
+    if (line === undefined) continue
+    const payload = line.slice(5).trim()
+    if (payload === '' || payload === '[DONE]') continue
+    try {
+      const parsed = JSON.parse(payload) as {
+        choices?: { delta?: { content?: string } }[]
+      }
+      content += parsed.choices?.[0]?.delta?.content ?? ''
+    } catch {
+      // A partial frame at a chunk boundary is normal; the next pass sees it whole.
+    }
+  }
+  return content
+}
+
+function messageContent(raw: string): string {
+  try {
+    const parsed = JSON.parse(raw) as { choices?: { message?: { content?: string } }[] }
+    return parsed.choices?.[0]?.message?.content ?? ''
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * Forwards one call to a real provider and pipes the reply straight back, while
+ * assembling the assistant text so the request log can offer it as a canned
+ * response. The upstream's key is read from the environment at call time — it
+ * is never held in mock state and never crosses the control API.
+ */
+export async function passthrough(opts: {
+  upstream: Upstream
+  body: Record<string, unknown>
+  res: ServerResponse
+  signal: AbortSignal
+}): Promise<PassthroughResult> {
+  const { upstream, body, res, signal } = opts
+  const apiKey = upstream.apiKeyEnv ? process.env[upstream.apiKeyEnv] : undefined
+  const streamed = body.stream === true
+
+  let upstreamResponse: Response
+  try {
+    upstreamResponse = await fetch(completionsUrl(upstream.baseURL), {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {}),
+      },
+      body: JSON.stringify({ ...body, model: upstream.model }),
+      signal,
+    })
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err)
+    if (!res.headersSent) {
+      res.writeHead(502, { ...CORS_HEADERS, 'content-type': 'application/json' })
+      res.end(errorBody(`mock passthrough to ${upstream.label} failed: ${detail}`))
+    } else {
+      res.end()
+    }
+    return { status: 502, content: '', error: detail }
+  }
+
+  if (!upstreamResponse.ok || upstreamResponse.body === null) {
+    const raw = await upstreamResponse.text()
+    res.writeHead(upstreamResponse.status, {
+      ...CORS_HEADERS,
+      'content-type': upstreamResponse.headers.get('content-type') ?? 'application/json',
+    })
+    res.end(raw)
+    return { status: upstreamResponse.status, content: '', error: raw.slice(0, 500) }
+  }
+
+  res.writeHead(
+    upstreamResponse.status,
+    streamed
+      ? SSE_HEADERS
+      : {
+          ...CORS_HEADERS,
+          'content-type': upstreamResponse.headers.get('content-type') ?? 'application/json',
+        },
+  )
+
+  const decoder = new TextDecoder()
+  let raw = ''
+  for await (const chunk of upstreamResponse.body as unknown as AsyncIterable<Uint8Array>) {
+    if (signal.aborted) break
+    const text = decoder.decode(chunk, { stream: true })
+    raw += text
+    res.write(text)
+  }
+  res.end()
+
+  return {
+    status: upstreamResponse.status,
+    content: streamed ? collectSseContent(raw) : messageContent(raw),
+  }
+}

--- a/scripts/mock-llm/passthrough.ts
+++ b/scripts/mock-llm/passthrough.ts
@@ -1,6 +1,6 @@
 import type { ServerResponse } from 'node:http'
 
-import { CORS_HEADERS, SSE_HEADERS, errorBody } from './respond/wire'
+import { CORS_HEADERS, SSE_HEADERS, errorBody, write } from './respond/wire'
 import type { Upstream } from './state'
 
 export type PassthroughResult = {
@@ -28,7 +28,8 @@ export function collectSseContent(buffer: string): string {
       }
       content += parsed.choices?.[0]?.delta?.content ?? ''
     } catch {
-      // A partial frame at a chunk boundary is normal; the next pass sees it whole.
+      // The whole buffer is parsed at once, so this is a final frame the
+      // upstream truncated; its text is simply not part of what was served.
     }
   }
   return content
@@ -74,7 +75,9 @@ export async function passthrough(opts: {
     const detail = err instanceof Error ? err.message : String(err)
     if (!res.headersSent) {
       res.writeHead(502, { ...CORS_HEADERS, 'content-type': 'application/json' })
-      res.end(errorBody(`mock passthrough to ${upstream.label} failed: ${detail}`))
+      res.end(
+        errorBody(`mock passthrough to ${upstream.label} failed: ${detail}`, 'upstream_error'),
+      )
     } else {
       res.end()
     }
@@ -107,7 +110,7 @@ export async function passthrough(opts: {
     if (signal.aborted) break
     const text = decoder.decode(chunk, { stream: true })
     raw += text
-    res.write(text)
+    await write(res, text)
   }
   res.end()
 

--- a/scripts/mock-llm/respond/narrative.ts
+++ b/scripts/mock-llm/respond/narrative.ts
@@ -1,6 +1,6 @@
 import type { ServerResponse } from 'node:http'
 
-import { contentFrame, roleFrame, stopFrames } from './wire'
+import { contentFrame, roleFrame, stopFrames, write } from './wire'
 
 export type StreamPacing = {
   /** 0 delivers the whole reply in a single frame. */
@@ -42,15 +42,6 @@ export function chunkContent(content: string, chunkSize: number): string[] {
 function jittered(ms: number, jitterMs: number): number {
   if (jitterMs <= 0) return ms
   return Math.max(0, ms + (Math.random() * 2 - 1) * jitterMs)
-}
-
-// res.write returns false once the socket buffer is full; ignoring it lets a
-// slow client build an unbounded backlog instead of pacing to its own speed.
-function write(res: ServerResponse, frame: string): Promise<void> {
-  return new Promise((resolve) => {
-    if (res.write(frame)) resolve()
-    else res.once('drain', resolve)
-  })
 }
 
 /** Emits the SSE body. Headers must already be written by the caller. */

--- a/scripts/mock-llm/respond/narrative.ts
+++ b/scripts/mock-llm/respond/narrative.ts
@@ -1,0 +1,85 @@
+import type { ServerResponse } from 'node:http'
+
+import { contentFrame, roleFrame, stopFrames } from './wire'
+
+export type StreamPacing = {
+  /** 0 delivers the whole reply in a single frame. */
+  charsPerSecond: number
+  chunkSize: number
+  jitterMs: number
+}
+
+export type StreamOptions = StreamPacing & {
+  content: string
+  /** Stop partway and close the socket without a stop frame or [DONE]. */
+  cut?: boolean
+  aborted: () => boolean
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+/**
+ * Splits on word boundaries rather than at a fixed character offset: a stream
+ * chopped mid-word renders visibly differently in the reader than a real
+ * provider's token stream, which is the thing being eyeballed.
+ */
+export function chunkContent(content: string, chunkSize: number): string[] {
+  if (content.length === 0) return []
+  const pieces = content.match(/\s*\S+|\s+/g) ?? [content]
+  const chunks: string[] = []
+  let current = ''
+  for (const piece of pieces) {
+    current += piece
+    if (current.length >= chunkSize) {
+      chunks.push(current)
+      current = ''
+    }
+  }
+  if (current.length > 0) chunks.push(current)
+  return chunks
+}
+
+function jittered(ms: number, jitterMs: number): number {
+  if (jitterMs <= 0) return ms
+  return Math.max(0, ms + (Math.random() * 2 - 1) * jitterMs)
+}
+
+// res.write returns false once the socket buffer is full; ignoring it lets a
+// slow client build an unbounded backlog instead of pacing to its own speed.
+function write(res: ServerResponse, frame: string): Promise<void> {
+  return new Promise((resolve) => {
+    if (res.write(frame)) resolve()
+    else res.once('drain', resolve)
+  })
+}
+
+/** Emits the SSE body. Headers must already be written by the caller. */
+export async function streamNarrative(res: ServerResponse, opts: StreamOptions): Promise<void> {
+  await write(res, roleFrame())
+  if (opts.aborted()) return
+
+  if (opts.charsPerSecond <= 0 && opts.cut !== true) {
+    await write(res, contentFrame(opts.content))
+    if (!opts.aborted()) res.end(stopFrames())
+    return
+  }
+
+  const chunks = chunkContent(opts.content, opts.chunkSize)
+  const emit =
+    opts.cut === true ? chunks.slice(0, Math.max(1, Math.floor(chunks.length / 2))) : chunks
+
+  for (const chunk of emit) {
+    if (opts.aborted()) return
+    if (opts.charsPerSecond > 0) {
+      await sleep(jittered((chunk.length / opts.charsPerSecond) * 1000, opts.jitterMs))
+      if (opts.aborted()) return
+    }
+    await write(res, contentFrame(chunk))
+  }
+
+  if (opts.aborted()) return
+  // The cut path closes without a stop frame or [DONE] on purpose: that is the
+  // truncated-stream failure the app has to survive.
+  if (opts.cut === true) res.end()
+  else res.end(stopFrames())
+}

--- a/scripts/mock-llm/respond/tagged-block.test.ts
+++ b/scripts/mock-llm/respond/tagged-block.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseStateBlock, parseSuggestionsBlock, stripTrailingBlocks } from '@/lib/piggyback'
+
+import { hasStateContent, renderNarrative, renderStateBlock } from './tagged-block'
+
+describe('renderStateBlock', () => {
+  it('round-trips every field through the app parser', () => {
+    const raw = renderStateBlock({
+      sceneEntities: ['c1', 'c2'],
+      currentLocation: 'l1',
+      worldTimeDelta: 300,
+      visualChanges: [{ id: 'c1', type: 'attire', text: 'a rain-dark cloak' }],
+      transfers: {
+        items: [{ id: 'i1', slot: 'inventory', to: 'c1', from: 'c2' }],
+        stackables: [{ key: 'gold', amount: 5, from: 'c1' }],
+      },
+      summary: 'Kael takes the cloak and pays for passage.',
+    })
+
+    const { block, failures, blockFound } = parseStateBlock(raw)
+
+    expect(blockFound).toBe(true)
+    expect(failures).toEqual([])
+    expect(block.sceneEntities).toEqual(['c1', 'c2'])
+    expect(block.currentLocation).toBe('l1')
+    expect(block.worldTimeDelta).toBe(300)
+    expect(block.visualChanges).toEqual([{ id: 'c1', type: 'attire', text: 'a rain-dark cloak' }])
+    expect(block.transfers).toEqual({
+      items: [{ id: 'i1', slot: 'inventory', to: 'c1', from: 'c2' }],
+      stackables: [{ key: 'gold', amount: 5, from: 'c1' }],
+    })
+    expect(block.summary).toBe('Kael takes the cloak and pays for passage.')
+  })
+
+  it('omits empty collections rather than emitting a tag the parser reads as truncated', () => {
+    const raw = renderStateBlock({
+      worldTimeDelta: 0,
+      sceneEntities: [],
+      visualChanges: [],
+      transfers: { items: [], stackables: [] },
+    })
+
+    expect(raw).not.toContain('<visual_changes>')
+    expect(raw).not.toContain('<transfers>')
+    expect(raw).not.toContain('<scene_entities>')
+
+    const { block, failures } = parseStateBlock(raw)
+    expect(failures).toEqual([])
+    expect(block.worldTimeDelta).toBe(0)
+    expect(block.visualChanges).toBeUndefined()
+  })
+
+  it('drops quotes and angle brackets from an attribute value so the tag still parses', () => {
+    const raw = renderStateBlock({
+      visualChanges: [{ id: 'c1"><script>', type: 'hair', text: 'shorn short' }],
+    })
+
+    const { block, failures } = parseStateBlock(raw)
+    expect(failures).toEqual([])
+    expect(block.visualChanges).toEqual([{ id: 'c1script', type: 'hair', text: 'shorn short' }])
+  })
+
+  it('keeps a close tag typed into free text from truncating the entry', () => {
+    const raw = renderStateBlock({
+      summary: 'She wrote </summary> across the page, then kept going.',
+    })
+
+    expect(parseStateBlock(raw).block.summary).toBe('She wrote  across the page, then kept going.')
+  })
+
+  it('reports content with no extractable entries only when the mock did not build it', () => {
+    // Guards the reason empty tags are omitted: the app treats a populated but
+    // unextractable segment as a failure, not as "nothing to report".
+    const { failures } = parseStateBlock('<state>\n  <transfers>garbage</transfers>\n</state>')
+    expect(failures).toEqual([
+      {
+        field: 'transfers',
+        detail: 'transfers: content present but no well-formed entries extracted',
+      },
+    ])
+  })
+})
+
+describe('hasStateContent', () => {
+  it('is false for an all-empty block and true once any field carries content', () => {
+    expect(hasStateContent(undefined)).toBe(false)
+    expect(hasStateContent({ sceneEntities: [], transfers: { items: [], stackables: [] } })).toBe(
+      false,
+    )
+    expect(hasStateContent({ worldTimeDelta: 0 })).toBe(true)
+    expect(hasStateContent({ summary: 'something happened' })).toBe(true)
+  })
+})
+
+describe('renderNarrative', () => {
+  it('separates prose from both trailing blocks the way the reader does', () => {
+    const raw = renderNarrative({
+      prose: 'The blade rasps free of its sheath.',
+      state: { worldTimeDelta: 120, summary: 'Kael draws.' },
+      suggestions: [
+        { categoryRef: 'cat1', text: 'You press on toward the bell.' },
+        { categoryRef: 'cat2', text: 'You sheathe the blade and listen.' },
+      ],
+    })
+
+    expect(stripTrailingBlocks(raw).prose).toBe('The blade rasps free of its sheath.')
+
+    const state = parseStateBlock(raw)
+    expect(state.failures).toEqual([])
+    expect(state.block.worldTimeDelta).toBe(120)
+    expect(state.block.summary).toBe('Kael draws.')
+
+    const suggestions = parseSuggestionsBlock(raw)
+    expect(suggestions.failed).toBe(false)
+    expect(suggestions.malformedCount).toBe(0)
+    expect(suggestions.items).toEqual([
+      { categoryRef: 'cat1', text: 'You press on toward the bell.' },
+      { categoryRef: 'cat2', text: 'You sheathe the blade and listen.' },
+    ])
+  })
+
+  it('omits both blocks when there is nothing to report', () => {
+    const raw = renderNarrative({ prose: 'Rain.', state: { sceneEntities: [] }, suggestions: [] })
+
+    expect(raw).toBe('Rain.')
+    expect(parseStateBlock(raw).blockFound).toBe(false)
+    expect(parseSuggestionsBlock(raw).blockFound).toBe(false)
+  })
+
+  it('escapes a root tag typed into the prose so it cannot truncate the reply', () => {
+    const raw = renderNarrative({
+      prose: 'He scrawled <state> on the wall.',
+      state: { worldTimeDelta: 60 },
+    })
+
+    expect(stripTrailingBlocks(raw).prose).toBe('He scrawled &lt;state&gt; on the wall.')
+    expect(parseStateBlock(raw).block.worldTimeDelta).toBe(60)
+  })
+})

--- a/scripts/mock-llm/respond/tagged-block.ts
+++ b/scripts/mock-llm/respond/tagged-block.ts
@@ -79,10 +79,12 @@ function stateLines(block: ParsedStateBlock): string[] {
   const lines: string[] = []
 
   const scene = block.sceneEntities ?? []
-  if (scene.length > 0) lines.push(tag(STATE_TAGS.sceneEntities, scene.join(', ')))
+  if (scene.length > 0)
+    lines.push(tag(STATE_TAGS.sceneEntities, text(scene.join(', '), STATE_TAGS.sceneEntities)))
 
   const location = block.currentLocation?.trim()
-  if (location) lines.push(tag(STATE_TAGS.currentLocation, location))
+  if (location)
+    lines.push(tag(STATE_TAGS.currentLocation, text(location, STATE_TAGS.currentLocation)))
 
   if (block.worldTimeDelta !== undefined)
     lines.push(tag(STATE_TAGS.worldTimeDelta, String(block.worldTimeDelta)))
@@ -104,7 +106,11 @@ export function hasStateContent(block: ParsedStateBlock | undefined): boolean {
 }
 
 export function renderStateBlock(block: ParsedStateBlock): string {
-  return `<${STATE_ROOT_TAG}>\n${stateLines(block).join('\n')}\n</${STATE_ROOT_TAG}>`
+  const lines = stateLines(block)
+  // An empty root reads to the app's parser as a truncated block, not as
+  // "nothing to report" — the same reason stateLines omits empty inner tags.
+  if (lines.length === 0) return ''
+  return `<${STATE_ROOT_TAG}>\n${lines.join('\n')}\n</${STATE_ROOT_TAG}>`
 }
 
 export function renderSuggestionsBlock(items: SuggestionRef[]): string {

--- a/scripts/mock-llm/respond/tagged-block.ts
+++ b/scripts/mock-llm/respond/tagged-block.ts
@@ -1,0 +1,133 @@
+import {
+  STATE_ROOT_TAG,
+  STATE_TAGS,
+  SUGGESTION_ITEM_TAG,
+  SUGGESTIONS_ROOT_TAG,
+  TRAILING_ROOT_TAGS,
+  type ParsedStateBlock,
+  type SuggestionRef,
+} from '@/lib/piggyback'
+
+// Renders a narrative reply the way a taggedBlockReliable model would: prose,
+// then the trailing blocks the piggyback path folds in-band. Tag names come
+// from the app's own constants and the output is round-tripped through the
+// app's real parsers in tagged-block.test.ts, so the mock cannot serve markup
+// the app rejects.
+
+export type NarrativeValue = {
+  prose: string
+  state?: ParsedStateBlock
+  suggestions?: SuggestionRef[]
+}
+
+// Attribute values are ids, enum members and keys — none legitimately contain
+// these. A quote ends the value early (parseAttributes matches
+// /(\w+)="([^"]*)"/) and an angle bracket ends the whole tag (the surrounding
+// entry regexes scan `[^>]*`), so both are dropped rather than escaped: the
+// parser has no unescaping step to undo an entity reference.
+function attr(value: string | number): string {
+  return String(value).replace(/["<>]/g, '')
+}
+
+// Segment extraction is non-greedy to the first matching close tag, so a
+// literal close tag in free text truncates the entry.
+function text(value: string, closing: string): string {
+  return value.split(`</${closing}>`).join('')
+}
+
+function tag(name: string, value: string, indent = '  '): string {
+  return `${indent}<${name}>${value}</${name}>`
+}
+
+function renderVisualChanges(block: ParsedStateBlock): string | null {
+  const changes = block.visualChanges ?? []
+  if (changes.length === 0) return null
+  const rows = changes.map(
+    (c) =>
+      `    <entity id="${attr(c.id)}" type="${attr(c.type)}">${text(c.text, 'entity')}</entity>`,
+  )
+  return `  <${STATE_TAGS.visualChanges}>\n${rows.join('\n')}\n  </${STATE_TAGS.visualChanges}>`
+}
+
+function renderTransfers(block: ParsedStateBlock): string | null {
+  const items = block.transfers?.items ?? []
+  const stackables = block.transfers?.stackables ?? []
+  if (items.length === 0 && stackables.length === 0) return null
+
+  const rows = [
+    ...items.map((i) => {
+      const to = i.to !== undefined ? ` to="${attr(i.to)}"` : ''
+      const from = i.from !== undefined ? ` from="${attr(i.from)}"` : ''
+      return `    <item id="${attr(i.id)}" slot="${attr(i.slot)}"${to}${from} />`
+    }),
+    ...stackables.map((s) => {
+      const to = s.to !== undefined ? ` to="${attr(s.to)}"` : ''
+      const from = s.from !== undefined ? ` from="${attr(s.from)}"` : ''
+      return `    <stackable key="${attr(s.key)}" amount="${attr(s.amount)}"${to}${from} />`
+    }),
+  ]
+  return `  <${STATE_TAGS.transfers}>\n${rows.join('\n')}\n  </${STATE_TAGS.transfers}>`
+}
+
+/**
+ * An inner tag is emitted only when it carries content: the app's parser treats
+ * "content present but nothing extractable" as a truncation failure, so an
+ * empty `<visual_changes></visual_changes>` would report a parse failure rather
+ * than "nothing to report".
+ */
+function stateLines(block: ParsedStateBlock): string[] {
+  const lines: string[] = []
+
+  const scene = block.sceneEntities ?? []
+  if (scene.length > 0) lines.push(tag(STATE_TAGS.sceneEntities, scene.join(', ')))
+
+  const location = block.currentLocation?.trim()
+  if (location) lines.push(tag(STATE_TAGS.currentLocation, location))
+
+  if (block.worldTimeDelta !== undefined)
+    lines.push(tag(STATE_TAGS.worldTimeDelta, String(block.worldTimeDelta)))
+
+  const visual = renderVisualChanges(block)
+  if (visual) lines.push(visual)
+
+  const transfers = renderTransfers(block)
+  if (transfers) lines.push(transfers)
+
+  const summary = block.summary?.trim()
+  if (summary) lines.push(tag(STATE_TAGS.summary, text(summary, STATE_TAGS.summary)))
+
+  return lines
+}
+
+export function hasStateContent(block: ParsedStateBlock | undefined): boolean {
+  return block !== undefined && stateLines(block).length > 0
+}
+
+export function renderStateBlock(block: ParsedStateBlock): string {
+  return `<${STATE_ROOT_TAG}>\n${stateLines(block).join('\n')}\n</${STATE_ROOT_TAG}>`
+}
+
+export function renderSuggestionsBlock(items: SuggestionRef[]): string {
+  const rows = items.map(
+    (i) =>
+      `  <${SUGGESTION_ITEM_TAG} category="${attr(i.categoryRef)}">${text(i.text, SUGGESTION_ITEM_TAG)}</${SUGGESTION_ITEM_TAG}>`,
+  )
+  return `<${SUGGESTIONS_ROOT_TAG}>\n${rows.join('\n')}\n</${SUGGESTIONS_ROOT_TAG}>`
+}
+
+// stripTrailingBlocks cuts prose at the EARLIEST trailing root tag, so a root
+// tag inside the prose would silently truncate the rendered reply.
+function safeProse(prose: string): string {
+  return TRAILING_ROOT_TAGS.reduce((acc, t) => acc.split(`<${t}>`).join(`&lt;${t}&gt;`), prose)
+}
+
+export function renderNarrative(value: NarrativeValue): string {
+  const parts = [safeProse(value.prose)]
+
+  if (value.state && hasStateContent(value.state)) parts.push(renderStateBlock(value.state))
+
+  if (value.suggestions && value.suggestions.length > 0)
+    parts.push(renderSuggestionsBlock(value.suggestions))
+
+  return parts.join('\n\n')
+}

--- a/scripts/mock-llm/respond/wire.ts
+++ b/scripts/mock-llm/respond/wire.ts
@@ -1,5 +1,8 @@
-// OpenAI-compatible wire frames. Mirrors the shapes e2e/harness/mock-llm.ts
-// emits, which the real transport (lib/ai/transport) already consumes.
+// OpenAI-compatible wire frames, and the socket write every sender pushes them
+// through. Mirrors the shapes e2e/harness/mock-llm.ts emits, which the real
+// transport (lib/ai/transport) already consumes.
+
+import type { ServerResponse } from 'node:http'
 
 const CHUNK_BASE = {
   id: 'chatcmpl-mock',
@@ -19,6 +22,26 @@ export const SSE_HEADERS = {
   'content-type': 'text/event-stream',
   'cache-control': 'no-cache',
   connection: 'keep-alive',
+}
+
+// res.write returns false once the socket buffer is full; ignoring it lets a
+// slow client build an unbounded backlog instead of pacing to its own speed.
+// 'drain' never arrives on a socket the client dropped, so close and error
+// settle the wait too — otherwise the send loop never returns.
+export function write(res: ServerResponse, chunk: string): Promise<void> {
+  return new Promise((resolve) => {
+    if (res.destroyed || res.writableEnded) return resolve()
+    if (res.write(chunk)) return resolve()
+    const settle = (): void => {
+      res.off('drain', settle)
+      res.off('close', settle)
+      res.off('error', settle)
+      resolve()
+    }
+    res.once('drain', settle)
+    res.once('close', settle)
+    res.once('error', settle)
+  })
 }
 
 export function sse(obj: unknown): string {
@@ -53,6 +76,8 @@ export function completionBody(content: string): string {
   })
 }
 
-export function errorBody(message: string): string {
-  return JSON.stringify({ error: { message, type: 'mock_injected_failure' } })
+// Non-injected callers pass their own type: a provider outage must not read as
+// something the panel asked for.
+export function errorBody(message: string, type = 'mock_injected_failure'): string {
+  return JSON.stringify({ error: { message, type } })
 }

--- a/scripts/mock-llm/respond/wire.ts
+++ b/scripts/mock-llm/respond/wire.ts
@@ -1,0 +1,58 @@
+// OpenAI-compatible wire frames. Mirrors the shapes e2e/harness/mock-llm.ts
+// emits, which the real transport (lib/ai/transport) already consumes.
+
+const CHUNK_BASE = {
+  id: 'chatcmpl-mock',
+  object: 'chat.completion.chunk',
+  created: 0,
+  model: 'mock',
+}
+
+export const CORS_HEADERS = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'GET, POST, PUT, DELETE, OPTIONS',
+  'access-control-allow-headers': '*',
+}
+
+export const SSE_HEADERS = {
+  ...CORS_HEADERS,
+  'content-type': 'text/event-stream',
+  'cache-control': 'no-cache',
+  connection: 'keep-alive',
+}
+
+export function sse(obj: unknown): string {
+  return `data: ${JSON.stringify(obj)}\n\n`
+}
+
+export function roleFrame(): string {
+  return sse({
+    ...CHUNK_BASE,
+    choices: [{ index: 0, delta: { role: 'assistant', content: '' }, finish_reason: null }],
+  })
+}
+
+export function contentFrame(content: string): string {
+  return sse({ ...CHUNK_BASE, choices: [{ index: 0, delta: { content }, finish_reason: null }] })
+}
+
+export function stopFrames(): string {
+  return (
+    sse({ ...CHUNK_BASE, choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] }) +
+    'data: [DONE]\n\n'
+  )
+}
+
+export function completionBody(content: string): string {
+  return JSON.stringify({
+    id: 'chatcmpl-mock',
+    object: 'chat.completion',
+    created: 0,
+    model: 'mock',
+    choices: [{ index: 0, message: { role: 'assistant', content }, finish_reason: 'stop' }],
+  })
+}
+
+export function errorBody(message: string): string {
+  return JSON.stringify({ error: { message, type: 'mock_injected_failure' } })
+}

--- a/scripts/mock-llm/routing.test.ts
+++ b/scripts/mock-llm/routing.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+import { schemaToTypeScriptBlock, type JsonSchema } from '@/lib/ai'
+// Deep import: the middleware is internal to lib/ai and this test needs the
+// real one to prove the extractor tracks the template it renders.
+import { promptSchemaMiddleware } from '@/lib/ai/prompt-schema'
+import { fallbackClassifierSchema } from '@/lib/pipeline'
+
+import { classifyRequest, extractBlockFromPrompt, matchShape, unknownKey } from './routing'
+import { STRUCTURED_SHAPES } from './shapes'
+
+type MiddlewareParams = {
+  prompt: { role: string; content: { type: string; text: string }[] }[]
+  responseFormat?: { type: 'json'; schema?: JsonSchema }
+}
+
+/**
+ * Runs the app's own middleware to produce the prompt it would actually send,
+ * so a change to SCHEMA_INSTRUCTION_TEMPLATE fails here instead of silently
+ * degrading every match at runtime.
+ */
+async function promptAsSent(schema: z.ZodType): Promise<string> {
+  const transform = promptSchemaMiddleware().transformParams
+  if (transform === undefined) throw new Error('promptSchemaMiddleware lost transformParams')
+  const params: MiddlewareParams = {
+    prompt: [{ role: 'user', content: [{ type: 'text', text: 'Classify the turn.' }] }],
+    responseFormat: { type: 'json', schema: z.toJSONSchema(schema) as JsonSchema },
+  }
+  const out = (await transform({
+    params,
+  } as unknown as Parameters<typeof transform>[0])) as unknown as MiddlewareParams
+  return out.prompt[0]?.content.map((p) => p.text).join('\n') ?? ''
+}
+
+function requestFrom(text: string, extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return { model: 'seed/narrative', messages: [{ role: 'user', content: text }], ...extra }
+}
+
+describe('classifyRequest', () => {
+  it('routes a streaming call to the narrative lane', () => {
+    expect(classifyRequest(requestFrom('anything', { stream: true }))).toEqual({
+      lane: 'narrative',
+    })
+  })
+
+  it('recovers the block the app injects and names the shape', async () => {
+    const text = await promptAsSent(fallbackClassifierSchema)
+
+    expect(extractBlockFromPrompt(text)).toBe(
+      schemaToTypeScriptBlock(z.toJSONSchema(fallbackClassifierSchema) as JsonSchema),
+    )
+
+    const route = classifyRequest(requestFrom(text))
+    expect(route).toMatchObject({ lane: 'structured', key: 'per-turn-classifier' })
+  })
+
+  it('distinguishes the classifier shape that also asks for suggestions', async () => {
+    const withSuggestions = STRUCTURED_SHAPES.find(
+      (s) => s.name === 'per-turn-classifier-suggestions',
+    )
+    if (withSuggestions === undefined) throw new Error('registry lost the suggestions shape')
+
+    const route = classifyRequest(requestFrom(await promptAsSent(withSuggestions.schema)))
+    expect(route).toMatchObject({ lane: 'structured', key: 'per-turn-classifier-suggestions' })
+  })
+
+  it('matches the force-on path, which sends a JSON Schema instead of a prompt block', () => {
+    const route = classifyRequest(
+      requestFrom('Classify the turn.', {
+        response_format: {
+          type: 'json_schema',
+          json_schema: { name: 'Response', schema: z.toJSONSchema(fallbackClassifierSchema) },
+        },
+      }),
+    )
+    expect(route).toMatchObject({ lane: 'structured', key: 'per-turn-classifier' })
+  })
+
+  it('gives an unregistered schema a stable lane key instead of failing', async () => {
+    const novel = z.object({ mood: z.string(), intensity: z.number() })
+    const text = await promptAsSent(novel)
+
+    const route = classifyRequest(requestFrom(text))
+    expect(route.lane).toBe('structured')
+    if (route.lane !== 'structured') throw new Error('unreachable')
+    expect(route.shape).toBeNull()
+    expect(route.key).toMatch(/^unknown:[0-9a-f]{8}$/)
+    expect(route.block).toContain('mood: string;')
+
+    // Stable across calls: the UI keys a lane on it.
+    expect(classifyRequest(requestFrom(text))).toMatchObject({ key: route.key })
+  })
+
+  it('falls back to a no-schema key when nothing declares a shape', () => {
+    const route = classifyRequest(requestFrom('just some prose, no schema'))
+    expect(route).toMatchObject({ key: 'unknown:no-schema', shape: null, block: null })
+    expect(unknownKey(null)).toBe('unknown:no-schema')
+  })
+})
+
+describe('STRUCTURED_SHAPES', () => {
+  it('carries the exact block the app renders for each schema', () => {
+    for (const shape of STRUCTURED_SHAPES) {
+      expect(shape.block).toBe(schemaToTypeScriptBlock(z.toJSONSchema(shape.schema) as JsonSchema))
+    }
+  })
+
+  it('has no two shapes sharing a block, which would make a match ambiguous', () => {
+    const blocks = STRUCTURED_SHAPES.map((s) => s.block)
+    expect(new Set(blocks).size).toBe(blocks.length)
+  })
+
+  it('has no block contained in another, which the substring scan relies on', () => {
+    for (const a of STRUCTURED_SHAPES) {
+      for (const b of STRUCTURED_SHAPES) {
+        if (a.name === b.name) continue
+        expect(b.block.includes(a.block), `${a.name}'s block is inside ${b.name}'s`).toBe(false)
+      }
+    }
+  })
+})
+
+describe('matchShape', () => {
+  const inner = { name: 'inner', schema: z.unknown(), block: 'interface Response { a: string }' }
+  const outer = {
+    name: 'outer',
+    schema: z.unknown(),
+    block: 'interface Response { a: string } & { b: number }',
+  }
+
+  it('prefers the longer block when one nests inside another', () => {
+    const text = `prompt text ${outer.block} trailer`
+    // Registry order deliberately puts the shorter one first: without the
+    // longest-first scan the loose entry would claim a request meant for the
+    // more specific schema.
+    expect(matchShape(null, text, [inner, outer])?.name).toBe('outer')
+  })
+
+  it('takes an exact block match ahead of any substring scan', () => {
+    expect(matchShape(inner.block, `${outer.block}`, [inner, outer])?.name).toBe('inner')
+  })
+
+  it('names every shape uniquely — overrides and lane keys both key on the name', () => {
+    const names = STRUCTURED_SHAPES.map((s) => s.name)
+    expect(new Set(names).size).toBe(names.length)
+    expect(names).toContain('per-turn-classifier')
+    expect(names).toContain('periodic-classifier')
+    expect(names).toContain('suggestion-refresh')
+  })
+})

--- a/scripts/mock-llm/routing.ts
+++ b/scripts/mock-llm/routing.ts
@@ -1,0 +1,111 @@
+import { createHash } from 'node:crypto'
+
+import { schemaToTypeScriptBlock, type JsonSchema } from '@/lib/ai'
+
+import { STRUCTURED_SHAPES, type StructuredShape } from './shapes'
+
+export const NARRATIVE_LANE = 'narrative'
+
+// The bracketing text of SCHEMA_INSTRUCTION_TEMPLATE (lib/ai/prompt-schema.ts).
+// Not exported by the app, so routing.test.ts drives the real
+// promptSchemaMiddleware and asserts the extractor still recovers the block —
+// a template edit fails that test rather than silently degrading every match.
+const BLOCK_OPEN = 'from the following:\n\n'
+const BLOCK_CLOSE = '\n\nOutput ONLY the JSON object'
+
+export type Route =
+  | { lane: typeof NARRATIVE_LANE }
+  | {
+      lane: 'structured'
+      /** Stable lane key: the registry name, or `unknown:<hash>`. */
+      key: string
+      shape: StructuredShape | null
+      /** The TypeScript block this request declared, when one could be recovered. */
+      block: string | null
+    }
+
+export function promptText(body: Record<string, unknown>): string {
+  const messages = Array.isArray(body.messages) ? body.messages : []
+  return messages
+    .map((m) => {
+      const content = (m as { content?: unknown }).content
+      if (typeof content === 'string') return content
+      if (Array.isArray(content))
+        return content.map((p) => (p as { text?: string }).text ?? '').join('\n')
+      return ''
+    })
+    .join('\n')
+}
+
+/** The TS block the prompt-injection path writes into the last user message. */
+export function extractBlockFromPrompt(text: string): string | null {
+  const open = text.indexOf(BLOCK_OPEN)
+  if (open === -1) return null
+  const start = open + BLOCK_OPEN.length
+  const close = text.indexOf(BLOCK_CLOSE, start)
+  if (close === -1) return null
+  return text.slice(start, close)
+}
+
+// The 'force-on' path keeps responseFormat instead of injecting the block, so
+// the wire carries a JSON Schema. Rendering it through the app's own renderer
+// puts both paths on one comparable key.
+function blockFromResponseFormat(body: Record<string, unknown>): string | null {
+  const format = body.response_format as
+    | { type?: string; json_schema?: { schema?: unknown } }
+    | undefined
+  const schema = format?.json_schema?.schema
+  if (schema === undefined || schema === null || typeof schema !== 'object') return null
+  try {
+    return schemaToTypeScriptBlock(schema as JsonSchema)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Exact block equality first; the substring scan is the fallback for a prompt
+ * the extractor could not bracket. That scan takes the longest block first, so
+ * a schema that is a superset of another still wins — today no registered block
+ * contains another (asserted in routing.test.ts), but the scan must not be the
+ * thing that breaks on the day one does.
+ *
+ * `shapes` is a parameter so the ordering rule can be tested with a pair that
+ * actually nests; production always passes the registry.
+ */
+export function matchShape(
+  block: string | null,
+  text: string,
+  shapes: readonly StructuredShape[] = STRUCTURED_SHAPES,
+): StructuredShape | null {
+  if (block !== null) {
+    const exact = shapes.find((s) => s.block === block)
+    if (exact) return exact
+  }
+  const byLength = [...shapes].sort((a, b) => b.block.length - a.block.length)
+  return byLength.find((s) => text.includes(s.block)) ?? null
+}
+
+export function unknownKey(block: string | null): string {
+  if (block === null) return 'unknown:no-schema'
+  return `unknown:${createHash('sha1').update(block).digest('hex').slice(0, 8)}`
+}
+
+export function classifyRequest(body: Record<string, unknown>): Route {
+  if (body.stream === true) return { lane: NARRATIVE_LANE }
+
+  const text = promptText(body)
+  const block = extractBlockFromPrompt(text) ?? blockFromResponseFormat(body)
+  const shape = matchShape(block, text)
+
+  return {
+    lane: 'structured',
+    key: shape?.name ?? unknownKey(block),
+    shape,
+    block: block ?? shape?.block ?? null,
+  }
+}
+
+export function laneKeyOf(route: Route): string {
+  return route.lane === NARRATIVE_LANE ? NARRATIVE_LANE : route.key
+}

--- a/scripts/mock-llm/server.test.ts
+++ b/scripts/mock-llm/server.test.ts
@@ -20,12 +20,23 @@ afterAll(async () => {
 
 const base = (): string => mock.url.replace(/\/v1$/, '')
 
-async function post(body: unknown): Promise<Response> {
+async function post(body: unknown, signal?: AbortSignal): Promise<Response> {
   return fetch(`${mock.url}/chat/completions`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify(body),
+    ...(signal ? { signal } : {}),
   })
+}
+
+/** The first log entry to land, however long the handler's own delay runs. */
+async function waitForEntry(): Promise<{ outcome: string }> {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    const [entry] = mock.ctx.log.list()
+    if (entry) return entry
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+  throw new Error('no log entry arrived')
 }
 
 /** The prompt the app would send for `schema` on the default (auto) path. */
@@ -65,9 +76,11 @@ describe('structured calls', () => {
     expect(body.choices[0]?.message.content).toBe('{}')
 
     const discovered = [...mock.ctx.discovered.values()]
-    expect(discovered).toHaveLength(1)
-    expect(discovered[0]?.block).toContain('mood: string;')
-    expect(mock.ctx.state.lanes[discovered[0]?.key ?? '']).toBeDefined()
+    const entry = discovered.find((d) => d.block?.includes('mood: string;'))
+    expect(entry).toBeDefined()
+    expect(mock.ctx.state.lanes[entry?.key ?? '']).toBeDefined()
+    // A registered shape routes to its own lane and must never be discovered.
+    expect(discovered.some((d) => d.key === 'per-turn-classifier')).toBe(false)
   })
 })
 
@@ -165,6 +178,32 @@ describe('failure injection', () => {
     expect(lane.sequence.cursor).toBe(1)
 
     lane.sequence.enabled = false
+  })
+})
+
+describe('client abort', () => {
+  it('leaves the failure budget intact for a call nobody waited for', async () => {
+    mock.ctx.log.clear()
+    const lane = mock.ctx.lane('narrative')
+    lane.delay = { ttfbMs: 300, jitterMs: 0 }
+    lane.failure = { kind: 'http', status: 503, remaining: 1 }
+
+    const abort = new AbortController()
+    const inflight = post({ model: 'seed/narrative', stream: true, messages: [] }, abort.signal)
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    abort.abort()
+    await inflight.catch(() => null)
+
+    // The handler is still sleeping out its TTFB; it logs when that finishes.
+    const entry = await waitForEntry()
+    expect(entry.outcome).toBe('aborted')
+    // The whole point of the one-shot budget: it belongs to the next call that
+    // is actually served, not to one that was abandoned before it was answered.
+    expect(lane.failure.remaining).toBe(1)
+
+    lane.delay = { ttfbMs: 0, jitterMs: 0 }
+    expect((await post({ model: 'seed/narrative', stream: true, messages: [] })).status).toBe(503)
+    lane.failure = { kind: 'none', status: 500, remaining: 0 }
   })
 })
 

--- a/scripts/mock-llm/server.test.ts
+++ b/scripts/mock-llm/server.test.ts
@@ -1,0 +1,221 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+import { schemaToTypeScriptBlock, type JsonSchema } from '@/lib/ai'
+import { parseStateBlock, parseSuggestionsBlock, stripTrailingBlocks } from '@/lib/piggyback'
+import { fallbackClassifierSchema } from '@/lib/pipeline'
+
+import { collectSseContent } from './passthrough'
+import { startMockServer, type MockServer } from './server'
+
+let mock: MockServer
+
+beforeAll(async () => {
+  mock = await startMockServer(0, { persist: false })
+})
+
+afterAll(async () => {
+  await mock.close()
+})
+
+const base = (): string => mock.url.replace(/\/v1$/, '')
+
+async function post(body: unknown): Promise<Response> {
+  return fetch(`${mock.url}/chat/completions`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+/** The prompt the app would send for `schema` on the default (auto) path. */
+function structuredPrompt(schema: z.ZodType): string {
+  const block = schemaToTypeScriptBlock(z.toJSONSchema(schema) as JsonSchema)
+  return `Classify the turn.\n\nRespond strictly with JSON. The JSON should be compatible with the TypeScript type Response from the following:\n\n${block}\n\nOutput ONLY the JSON object, no other text or markdown.`
+}
+
+function structuredRequest(schema: z.ZodType): Record<string, unknown> {
+  return {
+    model: 'seed/narrative',
+    messages: [{ role: 'user', content: structuredPrompt(schema) }],
+  }
+}
+
+async function narrativeText(response: Response): Promise<string> {
+  return collectSseContent(await response.text())
+}
+
+describe('structured calls', () => {
+  it("answers with the lane's active response, parseable by the app's schema", async () => {
+    const response = await post(structuredRequest(fallbackClassifierSchema))
+    expect(response.status).toBe(200)
+
+    const body = (await response.json()) as { choices: { message: { content: string } }[] }
+    const value = fallbackClassifierSchema.parse(JSON.parse(body.choices[0]?.message.content ?? ''))
+
+    expect(value.worldTimeDelta).toBe(0)
+    expect(value.sceneEntities).toEqual([])
+  })
+
+  it('answers {} for a shape nobody has configured, and opens a lane for it', async () => {
+    const novel = z.object({ mood: z.string() })
+    const response = await post(structuredRequest(novel))
+
+    const body = (await response.json()) as { choices: { message: { content: string } }[] }
+    expect(body.choices[0]?.message.content).toBe('{}')
+
+    const discovered = [...mock.ctx.discovered.values()]
+    expect(discovered).toHaveLength(1)
+    expect(discovered[0]?.block).toContain('mood: string;')
+    expect(mock.ctx.state.lanes[discovered[0]?.key ?? '']).toBeDefined()
+  })
+})
+
+describe('narrative streaming', () => {
+  it('streams prose the reader can split from the trailing state block', async () => {
+    mock.ctx.lane('narrative').stream = { charsPerSecond: 0, chunkSize: 6 }
+    const response = await post({ model: 'seed/narrative', stream: true, messages: [] })
+
+    expect(response.headers.get('content-type')).toContain('text/event-stream')
+
+    const content = await narrativeText(response)
+    expect(stripTrailingBlocks(content).prose).toBe(
+      'The blade rasps free of its sheath. Somewhere in the drowned city, a bell answers, and the rain leans closer to listen.',
+    )
+
+    const state = parseStateBlock(content)
+    expect(state.failures).toEqual([])
+    expect(state.block.worldTimeDelta).toBe(60)
+  })
+
+  it('delivers the same content in many frames when paced', async () => {
+    mock.ctx.lane('narrative').stream = { charsPerSecond: 100_000, chunkSize: 6 }
+    const raw = await (await post({ model: 'seed/narrative', stream: true, messages: [] })).text()
+
+    const frames = raw.split('\n\n').filter((f) => f.startsWith('data:') && !f.includes('[DONE]'))
+    expect(frames.length).toBeGreaterThan(5)
+    expect(collectSseContent(raw)).toContain('The blade rasps free of its sheath.')
+  })
+
+  it('serves the suggestions block when the chosen response carries one', async () => {
+    const lane = mock.ctx.lane('narrative')
+    lane.stream = { charsPerSecond: 0, chunkSize: 6 }
+    lane.activeId = lane.responses.find((r) => r.name === 'With suggestions')?.id ?? lane.activeId
+
+    const content = await narrativeText(
+      await post({ model: 'seed/narrative', stream: true, messages: [] }),
+    )
+    const suggestions = parseSuggestionsBlock(content)
+
+    expect(suggestions.failed).toBe(false)
+    expect(suggestions.items.map((i) => i.categoryRef)).toEqual(['cat1', 'cat2', 'cat3'])
+
+    lane.activeId = lane.responses[0]?.id ?? null
+  })
+})
+
+describe('failure injection', () => {
+  it('returns the configured status and stops after the countdown', async () => {
+    const lane = mock.ctx.lane('per-turn-classifier')
+    lane.failure = { kind: 'http', status: 429, remaining: 1 }
+
+    expect((await post(structuredRequest(fallbackClassifierSchema))).status).toBe(429)
+    expect((await post(structuredRequest(fallbackClassifierSchema))).status).toBe(200)
+  })
+
+  it('serves a reply the app cannot repair into a valid object', async () => {
+    const lane = mock.ctx.lane('per-turn-classifier')
+    lane.failure = { kind: 'malformed', status: 500, remaining: 1 }
+
+    const body = (await (await post(structuredRequest(fallbackClassifierSchema))).json()) as {
+      choices: { message: { content: string } }[]
+    }
+    const raw = body.choices[0]?.message.content ?? ''
+
+    expect(() => fallbackClassifierSchema.parse(JSON.parse(raw))).toThrow()
+  })
+
+  it('cuts a narrative stream short with no stop frame', async () => {
+    const lane = mock.ctx.lane('narrative')
+    lane.stream = { charsPerSecond: 100_000, chunkSize: 6 }
+    lane.failure = { kind: 'stream-cut', status: 500, remaining: 1 }
+
+    const raw = await (await post({ model: 'seed/narrative', stream: true, messages: [] })).text()
+
+    expect(raw).not.toContain('[DONE]')
+    expect(raw).not.toContain('"finish_reason":"stop"')
+    expect(collectSseContent(raw).length).toBeGreaterThan(0)
+
+    lane.failure = { kind: 'none', status: 500, remaining: 0 }
+  })
+
+  it('does not spend a sequence entry on a call it failed', async () => {
+    const lane = mock.ctx.lane('narrative')
+    lane.stream = { charsPerSecond: 0, chunkSize: 6 }
+    lane.sequence = { enabled: true, ids: lane.responses.map((r) => r.id), cursor: 0, loop: true }
+    lane.failure = { kind: 'http', status: 500, remaining: 1 }
+
+    await post({ model: 'seed/narrative', stream: true, messages: [] })
+    expect(lane.sequence.cursor).toBe(0)
+
+    const content = await narrativeText(
+      await post({ model: 'seed/narrative', stream: true, messages: [] }),
+    )
+    expect(content).toContain('The blade rasps free of its sheath.')
+    expect(lane.sequence.cursor).toBe(1)
+
+    lane.sequence.enabled = false
+  })
+})
+
+describe('catalog and control surface', () => {
+  it('advertises the model id the seed pins taggedBlockReliable to', async () => {
+    const body = (await (await fetch(`${mock.url}/models`)).json()) as { data: { id: string }[] }
+    expect(body.data.map((m) => m.id)).toContain('seed/narrative')
+  })
+
+  it('logs each call with its lane and the placeholders its prompt offered', async () => {
+    mock.ctx.log.clear()
+    await post({
+      model: 'seed/narrative',
+      messages: [
+        {
+          role: 'user',
+          content:
+            'Cast:\n[c1] Kael, sellsword\n[c2] Mira\n[lo1] The Drowning\nLocation: [l1] The Harbour',
+        },
+      ],
+    })
+
+    const entries = (await (await fetch(`${base()}/api/log`)).json()) as {
+      lane: string
+      placeholders: { ref: string; label: string }[]
+    }[]
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.lane).toBe('unknown:no-schema')
+    expect(entries[0]?.placeholders).toEqual([
+      { ref: 'c1', label: 'Kael, sellsword' },
+      { ref: 'c2', label: 'Mira' },
+      { ref: 'lo1', label: 'The Drowning' },
+      { ref: 'l1', label: 'The Harbour' },
+    ])
+  })
+
+  it('keeps inline placeholders separate instead of folding them into one label', async () => {
+    mock.ctx.log.clear()
+    await post({
+      model: 'seed/narrative',
+      messages: [{ role: 'user', content: 'Present: [c1] Kael and [c2] Mira.' }],
+    })
+
+    const entries = (await (await fetch(`${base()}/api/log`)).json()) as {
+      placeholders: { ref: string; label: string }[]
+    }[]
+
+    expect(entries[0]?.placeholders).toEqual([
+      { ref: 'c1', label: 'Kael and' },
+      { ref: 'c2', label: 'Mira.' },
+    ])
+  })
+})

--- a/scripts/mock-llm/server.ts
+++ b/scripts/mock-llm/server.ts
@@ -1,0 +1,102 @@
+import { readFileSync } from 'node:fs'
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { handleCompletion } from './completions'
+import { createContext, type MockContext } from './context'
+import { handleControl } from './control'
+import { CORS_HEADERS } from './respond/wire'
+
+const UI_PATH = join(dirname(fileURLToPath(import.meta.url)), 'ui', 'index.html')
+
+// Only `seed/narrative` carries taggedBlockReliable in the dev seed
+// (lib/db/devtools/seed-dataset.ts) and there is no capability editor in app
+// settings, so it must be offered under that exact id or the piggyback fold
+// silently stops firing. The second id is deliberately named for what it does:
+// selecting it is how you exercise the fallback-classifier path on purpose.
+const MODEL_IDS = ['seed/narrative', 'mock/no-tagged-block']
+
+export type MockServer = {
+  url: string
+  uiUrl: string
+  ctx: MockContext
+  close: () => Promise<void>
+}
+
+export async function startMockServer(
+  port: number,
+  opts: { persist?: boolean } = {},
+): Promise<MockServer> {
+  const ctx = createContext(opts)
+
+  const server: Server = createServer((req, res) => {
+    void (async () => {
+      const pathname = new URL(req.url ?? '/', 'http://localhost').pathname
+
+      if (req.method === 'OPTIONS') {
+        res.writeHead(204, CORS_HEADERS).end()
+        return
+      }
+
+      try {
+        if (pathname.endsWith('/chat/completions') && req.method === 'POST') {
+          await handleCompletion(req, res, ctx)
+          return
+        }
+
+        if (pathname.endsWith('/models') && req.method === 'GET') {
+          res.writeHead(200, { ...CORS_HEADERS, 'content-type': 'application/json' })
+          res.end(
+            JSON.stringify({
+              object: 'list',
+              data: MODEL_IDS.map((id) => ({ id, object: 'model', owned_by: 'aventuras-mock' })),
+            }),
+          )
+          return
+        }
+
+        if (pathname.startsWith('/api/')) {
+          await handleControl(req, res, ctx, pathname)
+          return
+        }
+
+        if (pathname === '/' || pathname === '/index.html') {
+          // Read per request so editing the panel only needs a browser reload.
+          res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
+          res.end(readFileSync(UI_PATH, 'utf8'))
+          return
+        }
+
+        res.writeHead(404, CORS_HEADERS).end()
+      } catch (err) {
+        const detail = err instanceof Error ? (err.stack ?? err.message) : String(err)
+        console.error('[mock-llm] request failed:', detail)
+        if (!res.headersSent) {
+          res.writeHead(500, { ...CORS_HEADERS, 'content-type': 'application/json' })
+          res.end(JSON.stringify({ error: { message: detail } }))
+        } else {
+          res.end()
+        }
+      }
+    })()
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(port, '127.0.0.1', resolve)
+  })
+  const address = server.address() as AddressInfo
+
+  return {
+    url: `http://127.0.0.1:${address.port}/v1`,
+    uiUrl: `http://127.0.0.1:${address.port}/`,
+    ctx,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.closeAllConnections()
+        server.close(() => resolve())
+      }),
+  }
+}

--- a/scripts/mock-llm/server.ts
+++ b/scripts/mock-llm/server.ts
@@ -35,8 +35,12 @@ export async function startMockServer(
     void (async () => {
       const pathname = new URL(req.url ?? '/', 'http://localhost').pathname
 
+      // The control API is same-origin only (see control.ts); preflight is
+      // answered for the OpenAI-compatible surface the app calls cross-origin.
+      const isControl = pathname.startsWith('/api/')
+
       if (req.method === 'OPTIONS') {
-        res.writeHead(204, CORS_HEADERS).end()
+        res.writeHead(204, isControl ? {} : CORS_HEADERS).end()
         return
       }
 
@@ -57,7 +61,7 @@ export async function startMockServer(
           return
         }
 
-        if (pathname.startsWith('/api/')) {
+        if (isControl) {
           await handleControl(req, res, ctx, pathname)
           return
         }
@@ -74,7 +78,10 @@ export async function startMockServer(
         const detail = err instanceof Error ? (err.stack ?? err.message) : String(err)
         console.error('[mock-llm] request failed:', detail)
         if (!res.headersSent) {
-          res.writeHead(500, { ...CORS_HEADERS, 'content-type': 'application/json' })
+          res.writeHead(500, {
+            ...(isControl ? {} : CORS_HEADERS),
+            'content-type': 'application/json',
+          })
           res.end(JSON.stringify({ error: { message: detail } }))
         } else {
           res.end()

--- a/scripts/mock-llm/shapes.test.ts
+++ b/scripts/mock-llm/shapes.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import { STRUCTURED_SHAPES } from './shapes'
+import { EXAMPLES } from '../../e2e/harness/mock-llm'
+
+// The registry is shared with the E2E harness but the default replies are not.
+// These assertions are the seam: they fail when a shape is added to the shared
+// list without giving the suite something valid to answer with, which would
+// otherwise surface as `undefined` in a completion body mid-run.
+describe('E2E harness examples', () => {
+  it('covers every registered shape', () => {
+    expect(Object.keys(EXAMPLES).sort()).toEqual(STRUCTURED_SHAPES.map((s) => s.name).sort())
+  })
+
+  it('answers each shape with a value that shape accepts', () => {
+    for (const shape of STRUCTURED_SHAPES) {
+      const result = shape.schema.safeParse(EXAMPLES[shape.name])
+      expect(result.success, `${shape.name}: ${result.error?.message ?? ''}`).toBe(true)
+    }
+  })
+
+  it('keeps the suggestion-refresh default resolvable, since an empty one fails the run', () => {
+    const value = EXAMPLES['suggestion-refresh'] as { suggestions: unknown[] }
+    expect(value.suggestions).toHaveLength(1)
+  })
+
+  it('keeps the classifier defaults inert so a spec that sets nothing writes nothing', () => {
+    expect(EXAMPLES['per-turn-classifier']).toEqual({ sceneEntities: [], worldTimeDelta: 0 })
+    expect(EXAMPLES['periodic-classifier']).toEqual({
+      happenings: [],
+      relationships: [],
+      statusFlips: [],
+      newCharacters: [],
+    })
+  })
+})

--- a/scripts/mock-llm/shapes.ts
+++ b/scripts/mock-llm/shapes.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod'
+
+import { schemaToTypeScriptBlock, type JsonSchema } from '@/lib/ai'
+import { classifierExtractionSchema } from '@/lib/classifier'
+import {
+  fallbackClassifierSchema,
+  fallbackClassifierWithSuggestionsSchema,
+  suggestionRefreshSchema,
+} from '@/lib/pipeline'
+
+// Shared by the dev mock server and e2e/harness/mock-llm.ts. Deliberately tiny
+// and side-effect free: the E2E suite imports it, so anything heavier here
+// becomes a way for a dev-tool edit to break the test run.
+//
+// `block` is the exact string the app renders into a structured prompt for this
+// schema, produced by the app's own renderer over the app's own zod schema — so
+// a match can never drift from what the app actually sends. One entry per reply
+// SHAPE, not per agent: the classifier has three schemas and therefore three
+// entries.
+//
+// Default replies are NOT shared. E2E wants inert no-ops for determinism, the
+// dev mock wants defaults lively enough that a manual turn visibly does
+// something; one list serving both would serve both badly.
+
+export type StructuredShape = {
+  name: string
+  schema: z.ZodType
+  block: string
+}
+
+function shape(name: string, schema: z.ZodType): StructuredShape {
+  return { name, schema, block: schemaToTypeScriptBlock(z.toJSONSchema(schema) as JsonSchema) }
+}
+
+export const STRUCTURED_SHAPES: readonly StructuredShape[] = [
+  shape('per-turn-classifier', fallbackClassifierSchema),
+  shape('per-turn-classifier-suggestions', fallbackClassifierWithSuggestionsSchema),
+  shape('periodic-classifier', classifierExtractionSchema),
+  shape('suggestion-refresh', suggestionRefreshSchema),
+]
+
+export function findShapeByName(name: string): StructuredShape | undefined {
+  return STRUCTURED_SHAPES.find((s) => s.name === name)
+}

--- a/scripts/mock-llm/state.test.ts
+++ b/scripts/mock-llm/state.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+
+import { NARRATIVE_LANE } from './routing'
+import { STRUCTURED_SHAPES } from './shapes'
+import { defaultState, emptyLane, nextResponse, takeFailure, type Lane } from './state'
+import { validateLaneValue } from './validate'
+
+function laneWith(names: string[], overrides: Partial<Lane> = {}): Lane {
+  const lane = emptyLane()
+  lane.responses = names.map((name) => ({ id: name, name, value: { marker: name } }))
+  lane.activeId = names[0] ?? null
+  lane.sequence.ids = [...names]
+  Object.assign(lane, overrides)
+  return lane
+}
+
+function serve(lane: Lane, times: number): (string | null)[] {
+  return Array.from({ length: times }, () => nextResponse(lane)?.name ?? null)
+}
+
+describe('nextResponse', () => {
+  it('serves the active response repeatedly when sequencing is off', () => {
+    const lane = laneWith(['a', 'b', 'c'])
+    lane.activeId = 'b'
+    expect(serve(lane, 3)).toEqual(['b', 'b', 'b'])
+  })
+
+  it('falls back to the first response when activeId points at nothing', () => {
+    const lane = laneWith(['a', 'b'])
+    lane.activeId = 'deleted'
+    expect(serve(lane, 2)).toEqual(['a', 'a'])
+  })
+
+  it('cycles and wraps when sequencing loops', () => {
+    const lane = laneWith(['a', 'b', 'c'])
+    lane.sequence.enabled = true
+    expect(serve(lane, 5)).toEqual(['a', 'b', 'c', 'a', 'b'])
+  })
+
+  it('holds on the last entry when sequencing does not loop', () => {
+    const lane = laneWith(['a', 'b'])
+    lane.sequence.enabled = true
+    lane.sequence.loop = false
+    expect(serve(lane, 4)).toEqual(['a', 'b', 'b', 'b'])
+  })
+
+  it('resolves a cursor left out of range by an edit instead of serving nothing', () => {
+    const lane = laneWith(['a', 'b'])
+    lane.sequence.enabled = true
+    lane.sequence.loop = false
+    lane.sequence.cursor = 9
+    expect(serve(lane, 2)).toEqual(['b', 'b'])
+  })
+
+  it('skips sequence ids whose response was deleted', () => {
+    const lane = laneWith(['a', 'b', 'c'])
+    lane.sequence.enabled = true
+    lane.responses = lane.responses.filter((r) => r.id !== 'b')
+    expect(serve(lane, 4)).toEqual(['a', 'c', 'a', 'c'])
+  })
+
+  it('returns null for a lane with nothing configured', () => {
+    expect(nextResponse(emptyLane())).toBeNull()
+  })
+})
+
+describe('takeFailure', () => {
+  it('is inert while remaining is zero, whatever the kind', () => {
+    const lane = emptyLane()
+    lane.failure = { kind: 'http', status: 500, remaining: 0 }
+    expect(takeFailure(lane)).toBe('none')
+  })
+
+  it('counts a finite budget down and then stops failing', () => {
+    const lane = emptyLane()
+    lane.failure = { kind: 'http', status: 429, remaining: 2 }
+    expect([takeFailure(lane), takeFailure(lane), takeFailure(lane)]).toEqual([
+      'http',
+      'http',
+      'none',
+    ])
+    expect(lane.failure.remaining).toBe(0)
+  })
+
+  it('never exhausts a -1 budget', () => {
+    const lane = emptyLane()
+    lane.failure = { kind: 'stream-cut', status: 500, remaining: -1 }
+    expect([takeFailure(lane), takeFailure(lane), takeFailure(lane)]).toEqual([
+      'stream-cut',
+      'stream-cut',
+      'stream-cut',
+    ])
+    expect(lane.failure.remaining).toBe(-1)
+  })
+})
+
+describe('shipped defaults', () => {
+  it('gives every registered shape a lane', () => {
+    const lanes = defaultState().lanes
+    expect(Object.keys(lanes)).toEqual(
+      expect.arrayContaining([NARRATIVE_LANE, ...STRUCTURED_SHAPES.map((s) => s.name)]),
+    )
+  })
+
+  it('ships only responses their own lane schema accepts', () => {
+    for (const [key, lane] of Object.entries(defaultState().lanes)) {
+      for (const response of lane.responses) {
+        const result = validateLaneValue(key, response.value)
+        expect(
+          result.ok,
+          `${key} / ${response.name}: ${'error' in result ? result.error : ''}`,
+        ).toBe(true)
+      }
+    }
+  })
+
+  it('never names an entity placeholder, which is positional and per-run', () => {
+    const serialised = JSON.stringify(defaultState().lanes)
+    expect(serialised).not.toMatch(/"(c|l|lo|i|f|th|hp|ck)\d+"/)
+  })
+
+  it('does not ship an empty suggestion-refresh reply, which fails the run', () => {
+    const lane = defaultState().lanes['suggestion-refresh']
+    expect(lane?.responses.length).toBeGreaterThan(0)
+    for (const response of lane?.responses ?? []) {
+      expect((response.value as { suggestions: unknown[] }).suggestions.length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/scripts/mock-llm/state.ts
+++ b/scripts/mock-llm/state.ts
@@ -1,0 +1,250 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { z } from 'zod'
+
+import { NARRATIVE_LANE } from './routing'
+import { STRUCTURED_SHAPES } from './shapes'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+export const STATE_PATH = join(HERE, 'state.json')
+
+export const FAILURE_KINDS = ['none', 'http', 'stream-cut', 'malformed', 'hang'] as const
+export type FailureKind = (typeof FAILURE_KINDS)[number]
+
+const cannedResponseSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  value: z.unknown(),
+})
+
+const laneSchema = z.object({
+  mode: z.enum(['mock', 'passthrough']).default('mock'),
+  upstreamId: z.string().nullable().default(null),
+  responses: z.array(cannedResponseSchema).default([]),
+  activeId: z.string().nullable().default(null),
+  sequence: z
+    .object({
+      enabled: z.boolean().default(false),
+      ids: z.array(z.string()).default([]),
+      cursor: z.number().int().min(0).default(0),
+      loop: z.boolean().default(true),
+    })
+    .prefault({}),
+  delay: z
+    .object({
+      ttfbMs: z.number().int().min(0).max(600_000).default(0),
+      jitterMs: z.number().int().min(0).max(60_000).default(0),
+    })
+    .prefault({}),
+  failure: z
+    .object({
+      kind: z.enum(FAILURE_KINDS).default('none'),
+      status: z.number().int().min(400).max(599).default(500),
+      /** Calls still to be failed; -1 means always. */
+      remaining: z.number().int().min(-1).default(0),
+    })
+    .prefault({}),
+  stream: z
+    .object({
+      /** 0 delivers the whole reply in one frame. */
+      charsPerSecond: z.number().min(0).max(100_000).default(0),
+      chunkSize: z.number().int().min(1).max(4096).default(6),
+    })
+    .prefault({}),
+})
+
+export const upstreamSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  baseURL: z.string(),
+  /** Name of the env var holding the key — never the key itself. */
+  apiKeyEnv: z.string().default(''),
+  model: z.string(),
+})
+
+export const mockStateSchema = z.object({
+  version: z.literal(1).default(1),
+  lanes: z.record(z.string(), laneSchema).default({}),
+  upstreams: z.array(upstreamSchema).default([]),
+})
+
+export type CannedResponse = z.infer<typeof cannedResponseSchema>
+export type Lane = z.infer<typeof laneSchema>
+export type Upstream = z.infer<typeof upstreamSchema>
+export type MockState = z.infer<typeof mockStateSchema>
+
+function canned(name: string, value: unknown): CannedResponse {
+  return { id: `r_${name.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`, name, value }
+}
+
+function lane(responses: CannedResponse[], overrides: Partial<Lane> = {}): Lane {
+  return laneSchema.parse({
+    responses,
+    activeId: responses[0]?.id ?? null,
+    sequence: { ids: responses.map((r) => r.id) },
+    ...overrides,
+  })
+}
+
+const NO_STATE_CHANGE = {
+  sceneEntities: [],
+  worldTimeDelta: 0,
+  visualChanges: [],
+  transfers: { items: [], stackables: [] },
+}
+
+const SAMPLE_SUGGESTIONS = [
+  { categoryRef: 'cat1', text: 'You press on toward the sound of the bell.' },
+  { categoryRef: 'cat2', text: 'You stop, and let the rain fill the silence.' },
+  { categoryRef: 'cat3', text: 'You ask what the bell is for.' },
+]
+
+// Entity placeholders (c1, l1, …) are allocated per run in prompt-encounter
+// order by IdBiMap, so a shipped default cannot safely name one. Defaults stay
+// entity-free; the request log's "author from this request" flow is how you
+// write a reply that moves a specific entity.
+function defaultLanes(): Record<string, Lane> {
+  const lanes: Record<string, Lane> = {
+    [NARRATIVE_LANE]: lane(
+      [
+        canned('Short beat', {
+          prose:
+            'The blade rasps free of its sheath. Somewhere in the drowned city, a bell answers, and the rain leans closer to listen.',
+          state: { worldTimeDelta: 60, summary: 'A blade is drawn; a distant bell answers.' },
+        }),
+        canned('Long scene', {
+          prose: [
+            'The water had taken the lower streets weeks ago, and the city had learned to live above itself — rope bridges strung between second-storey windows, doors that opened onto nothing but a green reflection of the sky.',
+            '',
+            'You come down the stair with one hand on the rail and the other on the hilt. The step gives underfoot, soft as bread. Below, something moves that is not the current.',
+            '',
+            'The bell sounds again. Closer, this time, and answered by a second somewhere behind you.',
+          ].join('\n'),
+          state: {
+            worldTimeDelta: 900,
+            summary: 'A descent through the flooded quarter; two bells answer each other.',
+          },
+          suggestions: SAMPLE_SUGGESTIONS,
+        }),
+        canned('With suggestions', {
+          prose: 'The rain does not stop. It only changes its mind about direction.',
+          state: { worldTimeDelta: 120, summary: 'The storm shifts.' },
+          suggestions: SAMPLE_SUGGESTIONS,
+        }),
+      ],
+      { stream: { charsPerSecond: 400, chunkSize: 6 } },
+    ),
+
+    'per-turn-classifier': lane([
+      canned('No change', NO_STATE_CHANGE),
+      canned('Time passes', {
+        ...NO_STATE_CHANGE,
+        worldTimeDelta: 3600,
+        summary: 'An hour goes by.',
+      }),
+    ]),
+
+    'per-turn-classifier-suggestions': lane([
+      canned('No change, three chips', { ...NO_STATE_CHANGE, suggestions: SAMPLE_SUGGESTIONS }),
+      canned('No change, no chips', { ...NO_STATE_CHANGE, suggestions: [] }),
+    ]),
+
+    // Graph writes reference entity placeholders, which a shipped default
+    // cannot know — inert by design, authored per-run from the request log.
+    'periodic-classifier': lane([
+      canned('Nothing extracted', {
+        happenings: [],
+        relationships: [],
+        statusFlips: [],
+        newCharacters: [],
+      }),
+    ]),
+
+    // A refresh that resolves nothing is a run failure, so the default is not
+    // the empty list the other lanes use.
+    'suggestion-refresh': lane([canned('Three chips', { suggestions: SAMPLE_SUGGESTIONS })]),
+  }
+
+  return lanes
+}
+
+export function defaultState(): MockState {
+  return mockStateSchema.parse({ lanes: defaultLanes(), upstreams: [] })
+}
+
+/** A lane for a shape discovered at runtime that has no configured entry yet. */
+export function emptyLane(): Lane {
+  return laneSchema.parse({})
+}
+
+export function loadState(): MockState {
+  let raw: string
+  try {
+    raw = readFileSync(STATE_PATH, 'utf8')
+  } catch {
+    return defaultState()
+  }
+  const parsed = mockStateSchema.safeParse(JSON.parse(raw))
+  if (!parsed.success) {
+    throw new Error(
+      `${STATE_PATH} is not valid mock state — delete it to regenerate defaults.\n${parsed.error.message}`,
+    )
+  }
+  // A state file written before a shape was registered has no lane for it.
+  for (const s of STRUCTURED_SHAPES) parsed.data.lanes[s.name] ??= emptyLane()
+  parsed.data.lanes[NARRATIVE_LANE] ??= emptyLane()
+  return parsed.data
+}
+
+let pending: NodeJS.Timeout | undefined
+
+export function saveState(state: MockState): void {
+  if (pending) clearTimeout(pending)
+  pending = setTimeout(() => {
+    writeFileSync(STATE_PATH, `${JSON.stringify(state, null, 2)}\n`, 'utf8')
+    pending = undefined
+  }, 150)
+}
+
+export function flushState(state: MockState): void {
+  if (pending) clearTimeout(pending)
+  pending = undefined
+  writeFileSync(STATE_PATH, `${JSON.stringify(state, null, 2)}\n`, 'utf8')
+}
+
+/**
+ * The response this call should serve, advancing the sequence cursor when
+ * sequencing is on. Returns null when the lane has nothing configured.
+ */
+export function nextResponse(lane: Lane): CannedResponse | null {
+  const byId = new Map(lane.responses.map((r) => [r.id, r]))
+
+  if (lane.sequence.enabled) {
+    const ids = lane.sequence.ids.filter((id) => byId.has(id))
+    if (ids.length > 0) {
+      const last = ids.length - 1
+      // Clamped rather than wrapped when loop is off, so a cursor left out of
+      // range by a mid-run edit still resolves to the final entry.
+      const index = lane.sequence.loop
+        ? lane.sequence.cursor % ids.length
+        : Math.min(lane.sequence.cursor, last)
+      lane.sequence.cursor = lane.sequence.loop
+        ? (index + 1) % ids.length
+        : Math.min(index + 1, last)
+      return byId.get(ids[index] as string) ?? null
+    }
+  }
+
+  if (lane.activeId !== null && byId.has(lane.activeId)) return byId.get(lane.activeId) ?? null
+  return lane.responses[0] ?? null
+}
+
+/** Whether this call should fail, decrementing a finite countdown. */
+export function takeFailure(lane: Lane): FailureKind {
+  if (lane.failure.kind === 'none') return 'none'
+  if (lane.failure.remaining === 0) return 'none'
+  if (lane.failure.remaining > 0) lane.failure.remaining -= 1
+  return lane.failure.kind
+}

--- a/scripts/mock-llm/state.ts
+++ b/scripts/mock-llm/state.ts
@@ -19,7 +19,7 @@ const cannedResponseSchema = z.object({
   value: z.unknown(),
 })
 
-const laneSchema = z.object({
+export const laneSchema = z.object({
   mode: z.enum(['mock', 'passthrough']).default('mock'),
   upstreamId: z.string().nullable().default(null),
   responses: z.array(cannedResponseSchema).default([]),

--- a/scripts/mock-llm/transport.test.ts
+++ b/scripts/mock-llm/transport.test.ts
@@ -1,0 +1,105 @@
+import { wrapLanguageModel } from 'ai'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+import { parseStructured } from '@/lib/ai'
+import type { JsonSchema } from '@/lib/ai'
+import { jsonResponseFormatMiddleware, promptSchemaMiddleware } from '@/lib/ai/prompt-schema'
+import { createProviderModel } from '@/lib/ai/providers'
+import { runProviderCall, streamProviderCall } from '@/lib/ai/transport/provider-call'
+import { parseStateBlock, parseSuggestionsBlock, stripTrailingBlocks } from '@/lib/piggyback'
+import { fallbackClassifierSchema } from '@/lib/pipeline'
+
+import { startMockServer, type MockServer } from './server'
+
+// The seam the other suites stop short of: the app's own provider construction
+// and transport (createProviderModel -> @ai-sdk/openai-compatible ->
+// createFetchWithCapture) talking to this server, rather than a hand-built
+// fetch. A wire-format regression that the raw-HTTP tests would accept but the
+// SDK would choke on fails here.
+
+let mock: MockServer
+
+beforeAll(async () => {
+  mock = await startMockServer(0, { persist: false })
+})
+
+afterAll(async () => {
+  await mock.close()
+})
+
+const provider = (): Parameters<typeof createProviderModel>[0] => ({
+  id: 'prov_probe',
+  type: 'openai-compatible',
+  displayName: 'Mock',
+  apiKey: '',
+  favoriteModelIds: [],
+  endpoint: mock.url,
+})
+
+describe('the app transport against the mock', () => {
+  it('assembles a paced narrative stream back into prose and its trailing blocks', async () => {
+    const lane = mock.ctx.lane('narrative')
+    lane.stream = { charsPerSecond: 100_000, chunkSize: 6 }
+    lane.activeId = lane.responses.find((r) => r.name === 'With suggestions')?.id ?? lane.activeId
+
+    const stream = streamProviderCall({
+      model: createProviderModel(provider(), 'seed/narrative'),
+      prompt: 'Continue the scene.',
+    })
+
+    let assembled = ''
+    for await (const delta of stream.textStream) assembled += delta
+
+    expect(stripTrailingBlocks(assembled).prose).toBe(
+      'The rain does not stop. It only changes its mind about direction.',
+    )
+
+    const state = parseStateBlock(assembled)
+    expect(state.failures).toEqual([])
+    expect(state.block.worldTimeDelta).toBe(120)
+    expect(state.block.summary).toBe('The storm shifts.')
+
+    expect(parseSuggestionsBlock(assembled).items.map((i) => i.categoryRef)).toEqual([
+      'cat1',
+      'cat2',
+      'cat3',
+    ])
+  })
+
+  it('round-trips a structured call through the real middleware and parser', async () => {
+    const model = wrapLanguageModel({
+      model: createProviderModel(provider(), 'seed/narrative') as Parameters<
+        typeof wrapLanguageModel
+      >[0]['model'],
+      middleware: [
+        jsonResponseFormatMiddleware(z.toJSONSchema(fallbackClassifierSchema) as JsonSchema),
+        promptSchemaMiddleware(),
+      ],
+    })
+
+    const result = await runProviderCall({ model, prompt: 'Classify the turn.' })
+    const value = parseStructured(result.text, fallbackClassifierSchema)
+
+    expect(value).toMatchObject({ sceneEntities: [], worldTimeDelta: 0 })
+    // The middleware's injected block is what the mock routed on: proof the
+    // lane match works on a prompt the app built, not one the test built.
+    expect(mock.ctx.log.list().find((e) => !e.streamed)?.lane).toBe('per-turn-classifier')
+  })
+
+  it('surfaces an injected HTTP failure to the transport as an error', async () => {
+    mock.ctx.lane('per-turn-classifier').failure = { kind: 'http', status: 503, remaining: 1 }
+
+    const model = wrapLanguageModel({
+      model: createProviderModel(provider(), 'seed/narrative') as Parameters<
+        typeof wrapLanguageModel
+      >[0]['model'],
+      middleware: [
+        jsonResponseFormatMiddleware(z.toJSONSchema(fallbackClassifierSchema) as JsonSchema),
+        promptSchemaMiddleware(),
+      ],
+    })
+
+    await expect(runProviderCall({ model, prompt: 'Classify the turn.' })).rejects.toThrow()
+  })
+})

--- a/scripts/mock-llm/transport.test.ts
+++ b/scripts/mock-llm/transport.test.ts
@@ -37,6 +37,19 @@ const provider = (): Parameters<typeof createProviderModel>[0] => ({
   endpoint: mock.url,
 })
 
+/** A structured call wrapped the way lib/ai wraps it. */
+function classifierModel(): Parameters<typeof runProviderCall>[0]['model'] {
+  return wrapLanguageModel({
+    model: createProviderModel(provider(), 'seed/narrative') as Parameters<
+      typeof wrapLanguageModel
+    >[0]['model'],
+    middleware: [
+      jsonResponseFormatMiddleware(z.toJSONSchema(fallbackClassifierSchema) as JsonSchema),
+      promptSchemaMiddleware(),
+    ],
+  })
+}
+
 describe('the app transport against the mock', () => {
   it('assembles a paced narrative stream back into prose and its trailing blocks', async () => {
     const lane = mock.ctx.lane('narrative')
@@ -68,15 +81,7 @@ describe('the app transport against the mock', () => {
   })
 
   it('round-trips a structured call through the real middleware and parser', async () => {
-    const model = wrapLanguageModel({
-      model: createProviderModel(provider(), 'seed/narrative') as Parameters<
-        typeof wrapLanguageModel
-      >[0]['model'],
-      middleware: [
-        jsonResponseFormatMiddleware(z.toJSONSchema(fallbackClassifierSchema) as JsonSchema),
-        promptSchemaMiddleware(),
-      ],
-    })
+    const model = classifierModel()
 
     const result = await runProviderCall({ model, prompt: 'Classify the turn.' })
     const value = parseStructured(result.text, fallbackClassifierSchema)
@@ -90,15 +95,7 @@ describe('the app transport against the mock', () => {
   it('surfaces an injected HTTP failure to the transport as an error', async () => {
     mock.ctx.lane('per-turn-classifier').failure = { kind: 'http', status: 503, remaining: 1 }
 
-    const model = wrapLanguageModel({
-      model: createProviderModel(provider(), 'seed/narrative') as Parameters<
-        typeof wrapLanguageModel
-      >[0]['model'],
-      middleware: [
-        jsonResponseFormatMiddleware(z.toJSONSchema(fallbackClassifierSchema) as JsonSchema),
-        promptSchemaMiddleware(),
-      ],
-    })
+    const model = classifierModel()
 
     await expect(runProviderCall({ model, prompt: 'Classify the turn.' })).rejects.toThrow()
   })

--- a/scripts/mock-llm/ui/index.html
+++ b/scripts/mock-llm/ui/index.html
@@ -229,9 +229,16 @@
         cursor: pointer;
         background: var(--panel-2);
       }
-      .chip[aria-pressed='true'] {
+      .chip:has(.pick[aria-pressed='true']) {
         border-color: var(--accent);
         color: var(--accent);
+      }
+      .chip .pick {
+        border: 0;
+        background: transparent;
+        color: inherit;
+        font: inherit;
+        padding: 0;
       }
       .chip .x {
         border: 0;
@@ -412,7 +419,7 @@
                 ? `<span class="badge bad">${esc(l.failure.kind)}</span>`
                 : '',
               l.sequence.enabled ? '<span class="badge on">seq</span>' : '',
-              l.delay.ttfbMs > 0 ? `<span class="badge">${l.delay.ttfbMs}ms</span>` : '',
+              l.delay.ttfbMs > 0 ? `<span class="badge">${esc(l.delay.ttfbMs)}ms</span>` : '',
               meta.kind === 'unknown' ? '<span class="badge bad">unregistered</span>' : '',
             ].join('')
             return `<button class="lane-btn" data-lane="${esc(meta.key)}" aria-current="${meta.key === selected}">
@@ -522,21 +529,21 @@
               </div>
               <div class="field">
                 <label for="ttfb">Delay before reply (ms)</label>
-                <input type="number" id="ttfb" min="0" value="${lane.delay.ttfbMs}" />
+                <input type="number" id="ttfb" min="0" value="${esc(lane.delay.ttfbMs)}" />
               </div>
               <div class="field">
                 <label for="jitter">Jitter (± ms)</label>
-                <input type="number" id="jitter" min="0" value="${lane.delay.jitterMs}" />
+                <input type="number" id="jitter" min="0" value="${esc(lane.delay.jitterMs)}" />
               </div>
               ${
                 isNarrative
                   ? `<div class="field">
                        <label for="cps">Stream speed (chars/sec, 0 = instant)</label>
-                       <input type="number" id="cps" min="0" value="${lane.stream.charsPerSecond}" />
+                       <input type="number" id="cps" min="0" value="${esc(lane.stream.charsPerSecond)}" />
                      </div>
                      <div class="field">
                        <label for="chunk">Chunk size</label>
-                       <input type="number" id="chunk" min="1" value="${lane.stream.chunkSize}" />
+                       <input type="number" id="chunk" min="1" value="${esc(lane.stream.chunkSize)}" />
                      </div>
                      <div class="field">
                        <label>Presets</label>
@@ -550,7 +557,7 @@
               <div class="field">
                 <label for="failKind">Inject failure</label>
                 <select id="failKind">
-                  ${kinds.map((k) => `<option value="${k}" ${lane.failure.kind === k ? 'selected' : ''}>${k}</option>`).join('')}
+                  ${kinds.map((k) => `<option value="${esc(k)}" ${lane.failure.kind === k ? 'selected' : ''}>${esc(k)}</option>`).join('')}
                 </select>
               </div>
               <div class="field">
@@ -561,7 +568,7 @@
               </div>
               <div class="field">
                 <label for="failCount">For how many calls (-1 = always)</label>
-                <input type="number" id="failCount" min="-1" value="${lane.failure.remaining}" />
+                <input type="number" id="failCount" min="-1" value="${esc(lane.failure.remaining)}" />
               </div>
               <div class="field">
                 <label for="seq">Sequence</label>
@@ -572,7 +579,7 @@
                   <label style="display:inline;text-transform:none;letter-spacing:0;margin-left:8px">
                     <input type="checkbox" id="seqLoop" ${lane.sequence.loop ? 'checked' : ''} /> loop
                   </label>
-                  <button id="seqReset" style="margin-left:8px">reset (at ${lane.sequence.cursor})</button>
+                  <button id="seqReset" style="margin-left:8px">reset (at ${esc(lane.sequence.cursor)})</button>
                 </div>
               </div>
             </div>
@@ -588,8 +595,8 @@
               ${lane.responses
                 .map(
                   (r) =>
-                    `<span class="chip" aria-pressed="${r.id === lane.activeId}">
-                       <span data-activate="${esc(r.id)}">${esc(r.name)}</span>
+                    `<span class="chip">
+                       <button class="pick" data-activate="${esc(r.id)}" aria-pressed="${r.id === lane.activeId}">${esc(r.name)}</button>
                        <button class="x" data-delete="${esc(r.id)}" title="Delete">×</button>
                      </span>`,
                 )
@@ -617,13 +624,13 @@
         const rows = log
           .map((e) => {
             const time = new Date(e.at).toLocaleTimeString()
-            const row = `<tr class="entry" data-entry="${e.id}">
+            const row = `<tr class="entry" data-entry="${esc(e.id)}">
                 <td class="mono">${time}</td>
                 <td class="mono">${esc(e.lane)}${e.streamed ? ' <span class="badge">stream</span>' : ''}</td>
                 <td>${esc(e.mode)}</td>
                 <td>${esc(e.responseName ?? '—')}${e.note ? `<div class="note">${esc(e.note)}</div>` : ''}</td>
-                <td class="${e.outcome}">${esc(e.outcome)}${e.failureKind ? ` (${esc(e.failureKind)})` : ''} · ${e.status}</td>
-                <td class="mono">${e.durationMs}ms</td>
+                <td class="${e.outcome}">${esc(e.outcome)}${e.failureKind ? ` (${esc(e.failureKind)})` : ''} · ${esc(e.status)}</td>
+                <td class="mono">${esc(e.durationMs)}ms</td>
               </tr>`
             if (expanded !== e.id) return row
             const served =
@@ -632,8 +639,8 @@
               row +
               `<tr class="detail"><td colspan="6">
                  <div class="row" style="margin-bottom:8px">
-                   <button data-save-entry="${e.id}">Save reply as a response</button>
-                   <button data-goto="${esc(e.lane)}" data-entry-ph="${e.id}">Open this lane with its placeholders</button>
+                   <button data-save-entry="${esc(e.id)}">Save reply as a response</button>
+                   <button data-goto="${esc(e.lane)}" data-entry-ph="${esc(e.id)}">Open this lane with its placeholders</button>
                  </div>
                  <label>Served</label><pre>${esc(served ?? '')}</pre>
                  <label>Prompt</label><pre>${esc(e.prompt)}</pre>
@@ -754,7 +761,7 @@
         const id = event.target.id
         const value = event.target.value
         const map = {
-          mode: () => ({ mode: value, ...(value === 'mock' ? {} : {}) }),
+          mode: () => ({ mode: value }),
           upstream: () => ({ upstreamId: value || null }),
           ttfb: () => ({ delay: { ttfbMs: Number(value) } }),
           jitter: () => ({ delay: { jitterMs: Number(value) } }),
@@ -793,7 +800,11 @@
         await refresh()
       }
 
-      void boot()
+      // renderEditor needs a snapshot, so a failed boot has to report itself.
+      void boot().catch((err) => {
+        $('editor').innerHTML =
+          `<div class="empty">Could not reach the mock control API: ${esc(err.message)}</div>`
+      })
     </script>
   </body>
 </html>

--- a/scripts/mock-llm/ui/index.html
+++ b/scripts/mock-llm/ui/index.html
@@ -1,0 +1,799 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Aventuras mock LLM</title>
+    <style>
+      :root {
+        --bg: #0e1116;
+        --panel: #161b22;
+        --panel-2: #1c232c;
+        --line: #2a323d;
+        --text: #d8dee6;
+        --dim: #8b96a5;
+        --accent: #6aa6ff;
+        --ok: #56b98a;
+        --warn: #d9a441;
+        --bad: #e0616e;
+        --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+        font:
+          14px/1.5 system-ui,
+          -apple-system,
+          sans-serif;
+      }
+      header {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        flex-wrap: wrap;
+        padding: 12px 16px;
+        background: var(--panel);
+        border-bottom: 1px solid var(--line);
+        position: sticky;
+        top: 0;
+        z-index: 5;
+      }
+      header h1 {
+        font-size: 14px;
+        margin: 0;
+        letter-spacing: 0.02em;
+      }
+      header code {
+        font-family: var(--mono);
+        font-size: 12px;
+        color: var(--dim);
+      }
+      .spacer {
+        flex: 1;
+      }
+      button {
+        font: inherit;
+        font-size: 12px;
+        color: var(--text);
+        background: var(--panel-2);
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        padding: 5px 10px;
+        cursor: pointer;
+      }
+      button:hover {
+        border-color: var(--accent);
+      }
+      button.primary {
+        background: var(--accent);
+        border-color: var(--accent);
+        color: #0b1017;
+        font-weight: 600;
+      }
+      button.danger:hover {
+        border-color: var(--bad);
+        color: var(--bad);
+      }
+      main {
+        display: grid;
+        grid-template-columns: 240px minmax(0, 1fr);
+        align-items: start;
+        gap: 16px;
+        padding: 16px;
+      }
+      nav {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        overflow: hidden;
+        position: sticky;
+        top: 62px;
+      }
+      nav h2,
+      section h2 {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--dim);
+        margin: 0;
+        padding: 10px 12px;
+        border-bottom: 1px solid var(--line);
+      }
+      .lane-btn {
+        display: block;
+        width: 100%;
+        text-align: left;
+        border: 0;
+        border-radius: 0;
+        border-bottom: 1px solid var(--line);
+        background: transparent;
+        padding: 9px 12px;
+        font-family: var(--mono);
+        font-size: 12px;
+      }
+      .lane-btn:hover {
+        background: var(--panel-2);
+      }
+      .lane-btn[aria-current='true'] {
+        background: var(--panel-2);
+        box-shadow: inset 3px 0 0 var(--accent);
+      }
+      .lane-badges {
+        display: flex;
+        gap: 4px;
+        margin-top: 4px;
+        flex-wrap: wrap;
+      }
+      .badge {
+        font-family: var(--mono);
+        font-size: 10px;
+        padding: 1px 5px;
+        border-radius: 4px;
+        border: 1px solid var(--line);
+        color: var(--dim);
+      }
+      .badge.on {
+        color: var(--accent);
+        border-color: var(--accent);
+      }
+      .badge.bad {
+        color: var(--bad);
+        border-color: var(--bad);
+      }
+      .badge.warn {
+        color: var(--warn);
+        border-color: var(--warn);
+      }
+      section {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        margin-bottom: 16px;
+      }
+      .body {
+        padding: 12px;
+      }
+      .row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+        align-items: flex-end;
+      }
+      label {
+        display: block;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--dim);
+        margin-bottom: 4px;
+      }
+      input,
+      select,
+      textarea {
+        font: inherit;
+        color: var(--text);
+        background: var(--bg);
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        padding: 6px 8px;
+      }
+      input:focus,
+      select:focus,
+      textarea:focus {
+        outline: none;
+        border-color: var(--accent);
+      }
+      textarea {
+        width: 100%;
+        font-family: var(--mono);
+        font-size: 12px;
+        resize: vertical;
+      }
+      input[type='number'] {
+        width: 90px;
+      }
+      .field {
+        min-width: 0;
+      }
+      .grow {
+        flex: 1;
+        min-width: 240px;
+      }
+      .hint {
+        color: var(--dim);
+        font-size: 12px;
+        margin: 0 0 10px;
+      }
+      .hint code,
+      .mono {
+        font-family: var(--mono);
+      }
+      .responses {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        margin-bottom: 12px;
+      }
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        padding: 4px 6px 4px 10px;
+        font-size: 12px;
+        cursor: pointer;
+        background: var(--panel-2);
+      }
+      .chip[aria-pressed='true'] {
+        border-color: var(--accent);
+        color: var(--accent);
+      }
+      .chip .x {
+        border: 0;
+        background: transparent;
+        color: var(--dim);
+        padding: 0 4px;
+        border-radius: 999px;
+      }
+      .chip .x:hover {
+        color: var(--bad);
+      }
+      .error {
+        white-space: pre-wrap;
+        font-family: var(--mono);
+        font-size: 12px;
+        color: var(--bad);
+        margin: 8px 0 0;
+      }
+      .ph {
+        display: flex;
+        gap: 6px;
+        flex-wrap: wrap;
+        margin-bottom: 10px;
+      }
+      .ph button {
+        font-family: var(--mono);
+        font-size: 11px;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 12px;
+      }
+      th {
+        text-align: left;
+        font-weight: 500;
+        color: var(--dim);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        padding: 6px 10px;
+        border-bottom: 1px solid var(--line);
+      }
+      td {
+        padding: 6px 10px;
+        border-bottom: 1px solid var(--line);
+        vertical-align: top;
+      }
+      tr.entry {
+        cursor: pointer;
+      }
+      tr.entry:hover td {
+        background: var(--panel-2);
+      }
+      .detail td {
+        background: var(--bg);
+      }
+      .detail pre {
+        margin: 0 0 8px;
+        max-height: 260px;
+        overflow: auto;
+        font-family: var(--mono);
+        font-size: 11px;
+        white-space: pre-wrap;
+        word-break: break-word;
+        color: var(--dim);
+      }
+      .log-wrap {
+        overflow-x: auto;
+      }
+      .ok {
+        color: var(--ok);
+      }
+      .failed {
+        color: var(--bad);
+      }
+      .aborted {
+        color: var(--warn);
+      }
+      .note {
+        color: var(--warn);
+        font-size: 11px;
+      }
+      .empty {
+        color: var(--dim);
+        padding: 16px;
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Aventuras mock LLM</h1>
+      <code id="endpoint"></code>
+      <span class="spacer"></span>
+      <button data-bulk='{"mode":"mock"}'>All → mock</button>
+      <button data-bulk='{"mode":"passthrough"}'>All → passthrough</button>
+      <button data-bulk='{"resetSequences":true}'>Reset sequences</button>
+      <button data-bulk='{"clearFailures":true}'>Clear failures</button>
+      <button class="danger" id="reset">Reset to defaults</button>
+    </header>
+
+    <main>
+      <nav>
+        <h2>Lanes</h2>
+        <div id="lanes"></div>
+      </nav>
+
+      <div>
+        <section id="editor"></section>
+        <section>
+          <h2>Requests</h2>
+          <div class="log-wrap"><table id="log"></table></div>
+        </section>
+      </div>
+    </main>
+
+    <script>
+      const PRESETS = [
+        ['Instant', 0],
+        ['Fast', 200],
+        ['Realistic', 40],
+        ['Slow', 10],
+      ]
+      const FAILURES = {
+        narrative: ['none', 'http', 'stream-cut', 'malformed', 'hang'],
+        structured: ['none', 'http', 'malformed', 'hang'],
+      }
+
+      let snap = null
+      let selected = 'narrative'
+      let log = []
+      let expanded = null
+      let pinned = null
+      let laneError = ''
+
+      const $ = (id) => document.getElementById(id)
+      const esc = (s) =>
+        String(s).replace(
+          /[&<>"]/g,
+          (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[c],
+        )
+
+      async function api(path, options) {
+        const res = await fetch(path, {
+          headers: { 'content-type': 'application/json' },
+          ...options,
+        })
+        const body = await res.json().catch(() => ({}))
+        if (!res.ok) throw new Error(body.error || `${res.status} ${path}`)
+        return body
+      }
+
+      async function refresh() {
+        snap = await api('/api/state')
+        render()
+      }
+
+      async function patchLane(patch) {
+        snap = await api(`/api/lanes/${encodeURIComponent(selected)}`, {
+          method: 'PUT',
+          body: JSON.stringify(patch),
+        })
+        render()
+      }
+
+      const currentLane = () => snap?.lanes.find((l) => l.key === selected)
+
+      // ---------- lane list ----------
+
+      function renderLanes() {
+        $('lanes').innerHTML = snap.lanes
+          .map((meta) => {
+            const l = meta.lane
+            const badges = [
+              l.mode === 'passthrough' ? '<span class="badge warn">passthrough</span>' : '',
+              l.failure.kind !== 'none' && l.failure.remaining !== 0
+                ? `<span class="badge bad">${esc(l.failure.kind)}</span>`
+                : '',
+              l.sequence.enabled ? '<span class="badge on">seq</span>' : '',
+              l.delay.ttfbMs > 0 ? `<span class="badge">${l.delay.ttfbMs}ms</span>` : '',
+              meta.kind === 'unknown' ? '<span class="badge bad">unregistered</span>' : '',
+            ].join('')
+            return `<button class="lane-btn" data-lane="${esc(meta.key)}" aria-current="${meta.key === selected}">
+              ${esc(meta.title)}
+              <div class="lane-badges">${badges}</div>
+            </button>`
+          })
+          .join('')
+      }
+
+      // ---------- editor ----------
+
+      function responseEditor(lane) {
+        const active = lane.responses.find((r) => r.id === lane.activeId) ?? lane.responses[0]
+        if (!active) return '<p class="hint">No responses yet — add one below.</p>'
+
+        if (selected === 'narrative') {
+          const v = active.value ?? {}
+          return `
+            <label for="prose">Prose</label>
+            <textarea id="prose" rows="10">${esc(v.prose ?? '')}</textarea>
+            <div class="row" style="margin-top:10px">
+              <div class="grow">
+                <label for="stateJson">&lt;state&gt; block (JSON, omit for none)</label>
+                <textarea id="stateJson" rows="7">${esc(v.state ? JSON.stringify(v.state, null, 2) : '')}</textarea>
+              </div>
+              <div class="grow">
+                <label for="suggestionsJson">&lt;suggestions&gt; block (JSON array)</label>
+                <textarea id="suggestionsJson" rows="7">${esc(v.suggestions ? JSON.stringify(v.suggestions, null, 2) : '')}</textarea>
+              </div>
+            </div>`
+        }
+
+        return `
+          <label for="valueJson">Reply (JSON, validated against this shape's schema)</label>
+          <textarea id="valueJson" rows="16">${esc(JSON.stringify(active.value ?? {}, null, 2))}</textarea>`
+      }
+
+      function collectValue() {
+        if (selected === 'narrative') {
+          const parse = (id, fallback) => {
+            const raw = $(id).value.trim()
+            return raw === '' ? fallback : JSON.parse(raw)
+          }
+          const value = { prose: $('prose').value }
+          const state = parse('stateJson', undefined)
+          const suggestions = parse('suggestionsJson', undefined)
+          if (state !== undefined) value.state = state
+          if (suggestions !== undefined) value.suggestions = suggestions
+          return value
+        }
+        return JSON.parse($('valueJson').value)
+      }
+
+      function renderEditor() {
+        const meta = snap.lanes.find((l) => l.key === selected)
+        if (!meta) {
+          $('editor').innerHTML = '<div class="empty">Lane not found.</div>'
+          return
+        }
+        const lane = meta.lane
+        const isNarrative = selected === 'narrative'
+        const kinds = FAILURES[isNarrative ? 'narrative' : 'structured']
+        const upstreamOptions = snap.upstreams
+          .map(
+            (u) =>
+              `<option value="${esc(u.id)}" ${lane.upstreamId === u.id ? 'selected' : ''}>${esc(u.label)}${u.apiKeyEnv && !u.apiKeyPresent ? ` — ${esc(u.apiKeyEnv)} unset` : ''}</option>`,
+          )
+          .join('')
+
+        const discovered = snap.discovered.find((d) => d.key === selected)
+
+        $('editor').innerHTML = `
+          <h2>${esc(meta.title)}</h2>
+          <div class="body">
+            ${
+              meta.kind === 'unknown'
+                ? `<p class="hint">This shape is not in <code>scripts/mock-llm/shapes.ts</code>, so replies here are not schema-checked. Its TypeScript block:</p>
+                   <pre class="mono" style="max-height:180px;overflow:auto;font-size:11px;color:var(--dim)">${esc(discovered?.block ?? '(none declared)')}</pre>`
+                : ''
+            }
+            ${
+              pinned
+                ? `<label>Placeholders from the selected request — click to copy</label>
+                   <div class="ph">${pinned
+                     .map(
+                       (p) =>
+                         `<button data-copy="${esc(p.ref)}" title="${esc(p.label)}">${esc(p.ref)} · ${esc(p.label.slice(0, 28))}</button>`,
+                     )
+                     .join('')}</div>`
+                : ''
+            }
+
+            <div class="row" style="margin-bottom:12px">
+              <div class="field">
+                <label for="mode">Mode</label>
+                <select id="mode">
+                  <option value="mock" ${lane.mode === 'mock' ? 'selected' : ''}>mock</option>
+                  <option value="passthrough" ${lane.mode === 'passthrough' ? 'selected' : ''}>passthrough</option>
+                </select>
+              </div>
+              <div class="field">
+                <label for="upstream">Upstream</label>
+                <select id="upstream" ${lane.mode !== 'passthrough' ? 'disabled' : ''}>
+                  <option value="">— none —</option>${upstreamOptions}
+                </select>
+              </div>
+              <div class="field">
+                <label for="ttfb">Delay before reply (ms)</label>
+                <input type="number" id="ttfb" min="0" value="${lane.delay.ttfbMs}" />
+              </div>
+              <div class="field">
+                <label for="jitter">Jitter (± ms)</label>
+                <input type="number" id="jitter" min="0" value="${lane.delay.jitterMs}" />
+              </div>
+              ${
+                isNarrative
+                  ? `<div class="field">
+                       <label for="cps">Stream speed (chars/sec, 0 = instant)</label>
+                       <input type="number" id="cps" min="0" value="${lane.stream.charsPerSecond}" />
+                     </div>
+                     <div class="field">
+                       <label for="chunk">Chunk size</label>
+                       <input type="number" id="chunk" min="1" value="${lane.stream.chunkSize}" />
+                     </div>
+                     <div class="field">
+                       <label>Presets</label>
+                       <div>${PRESETS.map(([name, cps]) => `<button data-cps="${cps}">${name}</button>`).join(' ')}</div>
+                     </div>`
+                  : ''
+              }
+            </div>
+
+            <div class="row" style="margin-bottom:12px">
+              <div class="field">
+                <label for="failKind">Inject failure</label>
+                <select id="failKind">
+                  ${kinds.map((k) => `<option value="${k}" ${lane.failure.kind === k ? 'selected' : ''}>${k}</option>`).join('')}
+                </select>
+              </div>
+              <div class="field">
+                <label for="failStatus">HTTP status</label>
+                <select id="failStatus" ${lane.failure.kind !== 'http' ? 'disabled' : ''}>
+                  ${[401, 403, 429, 500, 502, 503].map((s) => `<option value="${s}" ${lane.failure.status === s ? 'selected' : ''}>${s}</option>`).join('')}
+                </select>
+              </div>
+              <div class="field">
+                <label for="failCount">For how many calls (-1 = always)</label>
+                <input type="number" id="failCount" min="-1" value="${lane.failure.remaining}" />
+              </div>
+              <div class="field">
+                <label for="seq">Sequence</label>
+                <div>
+                  <label style="display:inline;text-transform:none;letter-spacing:0">
+                    <input type="checkbox" id="seq" ${lane.sequence.enabled ? 'checked' : ''} /> cycle
+                  </label>
+                  <label style="display:inline;text-transform:none;letter-spacing:0;margin-left:8px">
+                    <input type="checkbox" id="seqLoop" ${lane.sequence.loop ? 'checked' : ''} /> loop
+                  </label>
+                  <button id="seqReset" style="margin-left:8px">reset (at ${lane.sequence.cursor})</button>
+                </div>
+              </div>
+            </div>
+
+            ${
+              !isNarrative && lane.failure.kind !== 'none' && lane.failure.remaining === 1
+                ? `<p class="hint" style="color:var(--warn)">Structured calls retry once (<code>maxProviderAttempts: 2</code>), so a single injected failure is swallowed before the app sees it. Use 2 or more.</p>`
+                : ''
+            }
+
+            <label>Responses</label>
+            <div class="responses">
+              ${lane.responses
+                .map(
+                  (r) =>
+                    `<span class="chip" aria-pressed="${r.id === lane.activeId}">
+                       <span data-activate="${esc(r.id)}">${esc(r.name)}</span>
+                       <button class="x" data-delete="${esc(r.id)}" title="Delete">×</button>
+                     </span>`,
+                )
+                .join('')}
+              <button id="addResponse">+ new</button>
+            </div>
+
+            ${responseEditor(lane)}
+            ${laneError ? `<p class="error">${esc(laneError)}</p>` : ''}
+            <div class="row" style="margin-top:10px">
+              <button class="primary" id="save">Save response</button>
+              <button id="rename">Rename</button>
+            </div>
+          </div>`
+      }
+
+      // ---------- log ----------
+
+      function renderLog() {
+        if (log.length === 0) {
+          $('log').innerHTML = '<tr><td class="empty">No requests yet.</td></tr>'
+          return
+        }
+        const head = `<tr><th>Time</th><th>Lane</th><th>Mode</th><th>Served</th><th>Outcome</th><th>Took</th></tr>`
+        const rows = log
+          .map((e) => {
+            const time = new Date(e.at).toLocaleTimeString()
+            const row = `<tr class="entry" data-entry="${e.id}">
+                <td class="mono">${time}</td>
+                <td class="mono">${esc(e.lane)}${e.streamed ? ' <span class="badge">stream</span>' : ''}</td>
+                <td>${esc(e.mode)}</td>
+                <td>${esc(e.responseName ?? '—')}${e.note ? `<div class="note">${esc(e.note)}</div>` : ''}</td>
+                <td class="${e.outcome}">${esc(e.outcome)}${e.failureKind ? ` (${esc(e.failureKind)})` : ''} · ${e.status}</td>
+                <td class="mono">${e.durationMs}ms</td>
+              </tr>`
+            if (expanded !== e.id) return row
+            const served =
+              typeof e.served === 'string' ? e.served : JSON.stringify(e.served, null, 2)
+            return (
+              row +
+              `<tr class="detail"><td colspan="6">
+                 <div class="row" style="margin-bottom:8px">
+                   <button data-save-entry="${e.id}">Save reply as a response</button>
+                   <button data-goto="${esc(e.lane)}" data-entry-ph="${e.id}">Open this lane with its placeholders</button>
+                 </div>
+                 <label>Served</label><pre>${esc(served ?? '')}</pre>
+                 <label>Prompt</label><pre>${esc(e.prompt)}</pre>
+               </td></tr>`
+            )
+          })
+          .join('')
+        $('log').innerHTML = head + rows
+      }
+
+      function render() {
+        renderLanes()
+        renderEditor()
+        renderLog()
+      }
+
+      // ---------- events ----------
+
+      document.addEventListener('click', async (event) => {
+        const t = event.target.closest(
+          '[data-lane],[data-bulk],[data-cps],[data-activate],[data-delete],[data-entry],[data-save-entry],[data-goto],[data-copy],#reset,#addResponse,#save,#rename,#seqReset',
+        )
+        if (!t) return
+
+        try {
+          if (t.dataset.lane) {
+            selected = t.dataset.lane
+            laneError = ''
+            pinned = null
+            return render()
+          }
+          if (t.dataset.copy) return navigator.clipboard.writeText(t.dataset.copy)
+          if (t.dataset.bulk) {
+            snap = await api('/api/bulk', { method: 'POST', body: t.dataset.bulk })
+            return render()
+          }
+          if (t.id === 'reset') {
+            if (!confirm('Discard all lanes and responses, restoring shipped defaults?')) return
+            snap = await api('/api/reset', { method: 'POST' })
+            return render()
+          }
+          if (t.dataset.cps !== undefined) {
+            return patchLane({ stream: { charsPerSecond: Number(t.dataset.cps) } })
+          }
+          if (t.dataset.activate) return patchLane({ activeId: t.dataset.activate })
+          if (t.dataset.delete) {
+            snap = await api(
+              `/api/lanes/${encodeURIComponent(selected)}/responses/${t.dataset.delete}`,
+              { method: 'DELETE' },
+            )
+            return render()
+          }
+          if (t.id === 'seqReset') {
+            snap = await api(`/api/lanes/${encodeURIComponent(selected)}/sequence/reset`, {
+              method: 'POST',
+            })
+            return render()
+          }
+          if (t.id === 'addResponse') {
+            const name = prompt('Name for the new response?')
+            if (!name) return
+            const lane = currentLane().lane
+            const template =
+              lane.responses.find((r) => r.id === lane.activeId)?.value ??
+              (selected === 'narrative' ? { prose: '' } : {})
+            snap = await api(`/api/lanes/${encodeURIComponent(selected)}/responses`, {
+              method: 'POST',
+              body: JSON.stringify({ name, value: template }),
+            })
+            laneError = ''
+            return render()
+          }
+          if (t.id === 'save' || t.id === 'rename') {
+            const lane = currentLane().lane
+            const active = lane.responses.find((r) => r.id === lane.activeId) ?? lane.responses[0]
+            if (!active) return
+            const payload =
+              t.id === 'rename'
+                ? { name: prompt('New name?', active.name) }
+                : { value: collectValue() }
+            if (t.id === 'rename' && !payload.name) return
+            snap = await api(`/api/lanes/${encodeURIComponent(selected)}/responses/${active.id}`, {
+              method: 'PUT',
+              body: JSON.stringify(payload),
+            })
+            laneError = ''
+            return render()
+          }
+          if (t.dataset.saveEntry) {
+            const name = prompt('Name for the recorded response?', 'Recorded')
+            if (!name) return
+            snap = await api(`/api/log/${t.dataset.saveEntry}/save`, {
+              method: 'POST',
+              body: JSON.stringify({ name }),
+            })
+            const entry = log.find((e) => e.id === t.dataset.saveEntry)
+            selected = entry?.lane ?? selected
+            laneError = ''
+            return render()
+          }
+          if (t.dataset.goto) {
+            selected = t.dataset.goto
+            pinned = log.find((e) => e.id === t.dataset.entryPh)?.placeholders ?? null
+            laneError = ''
+            return render()
+          }
+          if (t.dataset.entry) {
+            expanded = expanded === t.dataset.entry ? null : t.dataset.entry
+            return renderLog()
+          }
+        } catch (err) {
+          laneError = err.message
+          render()
+        }
+      })
+
+      document.addEventListener('change', (event) => {
+        const id = event.target.id
+        const value = event.target.value
+        const map = {
+          mode: () => ({ mode: value, ...(value === 'mock' ? {} : {}) }),
+          upstream: () => ({ upstreamId: value || null }),
+          ttfb: () => ({ delay: { ttfbMs: Number(value) } }),
+          jitter: () => ({ delay: { jitterMs: Number(value) } }),
+          cps: () => ({ stream: { charsPerSecond: Number(value) } }),
+          chunk: () => ({ stream: { chunkSize: Number(value) } }),
+          failKind: () => ({
+            failure: {
+              kind: value,
+              // A kind picked from the menu is meant to fire; without a budget
+              // it would sit inert and read as a broken control.
+              remaining: value === 'none' ? 0 : currentLane().lane.failure.remaining || 1,
+            },
+          }),
+          failStatus: () => ({ failure: { status: Number(value) } }),
+          failCount: () => ({ failure: { remaining: Number(value) } }),
+          seq: () => ({ sequence: { enabled: event.target.checked } }),
+          seqLoop: () => ({ sequence: { loop: event.target.checked } }),
+        }
+        if (map[id]) void patchLane(map[id]())
+      })
+
+      const events = new EventSource('/api/events')
+      events.onmessage = (event) => {
+        log.unshift(JSON.parse(event.data))
+        log = log.slice(0, 200)
+        renderLog()
+        // The served call may have advanced a sequence cursor or spent a
+        // failure budget, so the lane panel is stale until re-fetched.
+        void refresh()
+      }
+
+      async function boot() {
+        const url = new URL('/v1', location.href)
+        $('endpoint').textContent = url.href
+        log = await api('/api/log')
+        await refresh()
+      }
+
+      void boot()
+    </script>
+  </body>
+</html>

--- a/scripts/mock-llm/validate.ts
+++ b/scripts/mock-llm/validate.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod'
+
+import { suggestionRefSchema, VISUAL_CHANGE_TYPES } from '@/lib/piggyback'
+
+import { NARRATIVE_LANE } from './routing'
+import { findShapeByName } from './shapes'
+
+// ParsedStateBlock as authored in the UI. Every field optional: the renderer
+// omits what is absent, and an inner tag with nothing in it is a parse failure
+// for the app, not "nothing to report".
+const stateBlockSchema = z.object({
+  sceneEntities: z.array(z.string()).optional(),
+  currentLocation: z.string().optional(),
+  worldTimeDelta: z.number().optional(),
+  visualChanges: z
+    .array(z.object({ id: z.string(), type: z.enum(VISUAL_CHANGE_TYPES), text: z.string() }))
+    .optional(),
+  transfers: z
+    .object({
+      items: z.array(
+        z.object({
+          id: z.string(),
+          slot: z.enum(['equipped_items', 'inventory']),
+          to: z.string().optional(),
+          from: z.string().optional(),
+        }),
+      ),
+      stackables: z.array(
+        z.object({
+          key: z.string(),
+          amount: z.number(),
+          to: z.string().optional(),
+          from: z.string().optional(),
+        }),
+      ),
+    })
+    .optional(),
+  summary: z.string().optional(),
+})
+
+export const narrativeValueSchema = z.object({
+  prose: z.string(),
+  state: stateBlockSchema.optional(),
+  suggestions: z.array(suggestionRefSchema).optional(),
+})
+
+export type ValidationResult = { ok: true } | { ok: false; error: string }
+
+/**
+ * Validates an authored response against the schema its lane actually answers.
+ * A lane the registry does not name has no schema to check against, so anything
+ * JSON-shaped is accepted — the point of the unknown-shape lane is that it
+ * works before anyone updates the registry.
+ */
+export function validateLaneValue(laneKey: string, value: unknown): ValidationResult {
+  const schema =
+    laneKey === NARRATIVE_LANE ? narrativeValueSchema : findShapeByName(laneKey)?.schema
+  if (schema === undefined) return { ok: true }
+
+  const parsed = schema.safeParse(value)
+  if (parsed.success) return { ok: true }
+  return {
+    ok: false,
+    error: parsed.error.issues
+      .map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`)
+      .join('\n'),
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable mock LLM service with OpenAI-compatible endpoints.
  * Added a browser interface for managing responses, streaming, delays, failures, sequences, passthrough mode, and request logs.
  * Added support for narrative streaming and validated structured responses.
  * Added persistent or temporary mock state, response sequencing, and recorded-response management.
  * Added an npm command and configurable default port for starting the service.

* **Documentation**
  * Added setup and usage guidance for configuration, monitoring, and response management.

* **Tests**
  * Added comprehensive coverage for routing, responses, streaming, failures, persistence, and provider integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->