### PR TITLE
Mock provider wizard

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -322,10 +322,18 @@ on the request:
 - **otherwise (structured)** → a JSON chat completion whose body is
   chosen by matching the exact TypeScript block the app injects into
   the prompt — `schemaToTypeScriptBlock` over each agent's Zod schema
-  (`lib/ai/prompt-schema.ts`). Each structured agent is one
-  `STRUCTURED_AGENTS` entry `{ name, block, example }`; the match
-  can't drift because it reuses the app's own renderer, and tests
-  override a specific agent's reply via `setStructured(name, value)`.
+  (`lib/ai/prompt-schema.ts`). Each structured **call site** is one
+  `STRUCTURED_SHAPES` entry (`scripts/mock-llm/shapes.ts`, shared with
+  the dev mock server) with an `EXAMPLES` reply beside it here; the
+  match can't drift because it reuses the app's own renderer, and
+  tests override a specific reply via `setStructured(name, value)`.
+
+Call sites that answer with the same schema render the same block, so
+the block alone cannot separate them — the wizard's thirteen assist
+calls share seven schemas. Those entries carry a `marker` as well: the
+literal text their template opens with, sliced out of the prompt pack
+the app itself renders, so a template edit moves the marker in the same
+edit. The marker is consulted only when the block is ambiguous.
 
 Two one-shot narrative controls model the boundary states a running turn
 can hit: `failNextNarrative()` makes the next streaming call return HTTP

--- a/e2e/harness/mock-llm.ts
+++ b/e2e/harness/mock-llm.ts
@@ -9,11 +9,13 @@ import { matchShape } from '../../scripts/mock-llm/routing'
 //   - stream: true          → an SSE prose stream (the narrative call).
 //   - otherwise (structured) → a JSON chat completion, whose body is chosen by
 //     matching the exact TypeScript block the app injects into the prompt
-//     (schemaToTypeScriptBlock over the agent's zod schema). Each reply shape
-//     is one STRUCTURED_SHAPES entry — an agent with more than one possible
-//     schema (e.g. the classifier with/without suggestions) gets one entry per
-//     shape; adding one is mechanical and the match can't drift because it
-//     reuses the app's own renderer.
+//     (schemaToTypeScriptBlock over the agent's zod schema). Each CALL SITE is
+//     one STRUCTURED_SHAPES entry — an agent with more than one possible schema
+//     (e.g. the classifier with/without suggestions) gets one entry per shape,
+//     and call sites that share a schema (the wizard's generate/refine pairs)
+//     are separated by a marker sliced out of their own template. Adding one is
+//     mechanical and the match can't drift because both halves are derived from
+//     the app's own renderer and its own prompt pack.
 // Exercises the real transport (lib/ai/transport), unlike the __DEV__-gated
 // stub provider. See docs/testing.md → Mock LLM.
 //
@@ -54,6 +56,41 @@ export const EXAMPLES: Record<string, unknown> = {
   // run failure, so an empty default would fail any spec that reaches ⟳
   // without calling setStructured. cat1 is the first enabled category.
   'suggestion-refresh': { suggestions: [{ categoryRef: 'cat1', text: 'You press on.' }] },
+
+  // Wizard assist. Nothing here is written until the user imports it, so the
+  // inertness rule the classifier defaults follow does not apply — and could
+  // not be met anyway: the list schemas require at least one row. What these
+  // are instead is minimal and unmistakably mock-shaped, so a spec asserting on
+  // wizard content is obviously reading a default it forgot to override.
+  // sceneEntities / currentLocationId stay empty: a fixture's placeholders are
+  // allocated per call, so no shared default can name one.
+  'wizard-genre': { label: 'Mock genre', promptBody: 'Mock genre body.' },
+  'wizard-genre-refine': { label: 'Mock genre', promptBody: 'Mock genre body, revised.' },
+  'wizard-tone': { label: 'Mock tone', promptBody: 'Mock tone body.' },
+  'wizard-tone-refine': { label: 'Mock tone', promptBody: 'Mock tone body, revised.' },
+  'wizard-setting': { setting: 'Mock setting.' },
+  'wizard-setting-refine': { setting: 'Mock setting, revised.' },
+  'wizard-lore': { lore: [{ title: 'Mock lore', body: 'Mock lore body.', category: '' }] },
+  'wizard-cast': {
+    entities: [
+      { kind: 'character', name: 'Mock Character', description: 'Mock.', status: 'active' },
+    ],
+  },
+  'wizard-opening': {
+    prose: 'Mock opening.',
+    sceneEntities: [],
+    currentLocationId: null,
+    worldTime: 0,
+  },
+  'wizard-opening-refine': {
+    prose: 'Mock opening, revised.',
+    sceneEntities: [],
+    currentLocationId: null,
+    worldTime: 0,
+  },
+  'wizard-title-chips': { titles: ['Mock Title'] },
+  'wizard-description': { description: 'Mock description.' },
+  'wizard-description-refine': { description: 'Mock description, revised.' },
 }
 
 export type MockLlm = {

--- a/lib/db/devtools/seed-dataset.test.ts
+++ b/lib/db/devtools/seed-dataset.test.ts
@@ -79,6 +79,36 @@ describe('buildSeedSteps', () => {
 // (prefix_<uuid>); a mnemonic id like char_kael passes through untouched and
 // the turn fails on the placeholder return trip. The fixture must therefore
 // carry real prefixed UUIDs — see docs/testing.md → Fixture + seed contract.
+// A target with no assignment resolves to 'no-profile-assigned', which
+// short-circuits generateStructured before the request is built — so the
+// feature reads as "the mock isn't running" rather than "the seed is
+// incomplete". Named explicitly rather than swept from AGENT_IDS: the registry
+// carries targets nothing calls yet, and seeding those would assert nothing.
+describe('seeded agent assignments', () => {
+  const CALLED_TARGETS = ['classifier', 'suggestion', 'wizard-assist'] as const
+
+  function seededSettings(): { assignments: Record<string, string>; profiles: { id: string }[] } {
+    const [row] = rowsOf('app_settings') as unknown as {
+      assignments: Record<string, string>
+      profiles: { id: string }[]
+    }[]
+    expect(row).toBeDefined()
+    return row!
+  }
+
+  it.each(CALLED_TARGETS)('resolves %s to a profile the seed actually defines', (target) => {
+    const { assignments, profiles } = seededSettings()
+    const profileId = assignments[target]
+    expect(profileId, `${target} has no assignment`).toBeDefined()
+    expect(profiles.map((p) => p.id)).toContain(profileId)
+  })
+
+  it('seeds a narrative-kind profile, which resolveModel finds by kind not assignment', () => {
+    const [row] = rowsOf('app_settings') as unknown as { profiles: { kind: string }[] }[]
+    expect(row!.profiles.some((p) => p.kind === 'narrative')).toBe(true)
+  })
+})
+
 describe('seed id substitution contract', () => {
   // Canonical id prefix per LLM-facing kind (docs/data-model.md → ID shape).
   const ENTITY_PREFIX: Record<string, string> = {

--- a/lib/db/devtools/seed-dataset.ts
+++ b/lib/db/devtools/seed-dataset.ts
@@ -1553,14 +1553,17 @@ const appSettingsRow: NewAppSettings = {
       modelRef: { providerId: 'prov_local', modelId: 'seed/narrative' },
     }),
   ],
-  // 'suggestion' reuses the classifier profile rather than seeding a dedicated
-  // one: resolveModel keys purely on assignments[target] -> profile id (no
-  // kind/target coupling), and no fixture scenario needs a suggestion-specific
-  // model/temperature distinct from the classifier's.
+  // 'suggestion' and 'wizard-assist' reuse the classifier profile rather than
+  // seeding dedicated ones: resolveModel keys purely on assignments[target] ->
+  // profile id (no kind/target coupling), and no fixture scenario needs a
+  // model/temperature for either distinct from the classifier's. Every agent
+  // target the app actually calls is listed — an unassigned one resolves to
+  // 'no-profile-assigned' and never reaches the provider at all.
   assignments: {
     narrative: 'prof_narrative',
     classifier: 'prof_classifier',
     suggestion: 'prof_classifier',
+    'wizard-assist': 'prof_classifier',
   },
   defaultProviderId: 'prov_local',
   embeddingModelId: 'Xenova/all-MiniLM-L6-v2',

--- a/scripts/mock-llm/README.md
+++ b/scripts/mock-llm/README.md
@@ -1,8 +1,8 @@
 # Mock LLM
 
 A local OpenAI-compatible provider with a browser control panel, so a
-pipeline turn costs milliseconds instead of minutes while you drive the
-app by hand.
+pipeline turn — or a walk through the story-creation wizard — costs
+milliseconds instead of minutes while you drive the app by hand.
 
 ```sh
 pnpm db:seed   # seeds prov_local at http://localhost:4319/v1
@@ -39,15 +39,45 @@ separates them by inspecting the request:
   the app injects into the prompt (or, on the `force-on` path, by the JSON
   Schema in `response_format`).
 
-Shapes listed in [`shapes.ts`](./shapes.ts) get a named lane with live
-schema validation. A shape that is _not_ listed still gets a lane, keyed by
-a hash of its block and flagged `unregistered` in the UI — a new agent is
-addressable straight away, and adding it to `shapes.ts` only upgrades it to
-a friendly name and validation.
+Entries in [`shapes.ts`](./shapes.ts) get a named lane with live schema
+validation; the panel files them under **Story** or **Wizard**. A shape that
+is _not_ listed still gets a lane, keyed by a hash of its block and flagged
+`unregistered` in the UI — a new agent is addressable straight away, and
+adding it to `shapes.ts` only upgrades it to a friendly name and validation.
 
 Per lane you get: a library of named responses, sequence cycling, a
 mock/passthrough switch, response delay and jitter, failure injection, and
 (narrative only) streaming speed.
+
+### One entry per call site
+
+A block identifies a _schema_, and several call sites can answer with the
+same one — the wizard's thirteen assist calls share seven schemas, so genre,
+tone and both their refines are indistinguishable on the wire. Where that
+happens, the entry also carries a `marker`: the literal text its template
+opens with, before the first Liquid tag, sliced out of the pack the app
+itself renders. Editing a template therefore moves its marker in the same
+edit, and `routing.test.ts` renders every wizard template through the real
+engine to prove the marker still survives.
+
+The marker only breaks ties. Where a block already names one call site it is
+never consulted, so a user-authored pack that rewrites wizard templates
+costs only the calls that genuinely cannot be told apart without it — those
+fall through to an `unregistered` lane rather than being served a sibling's
+reply.
+
+## Wizard assist
+
+`pnpm db:seed` assigns the `wizard-assist` agent, so **Suggest** and
+**Refine** on every wizard step reach the mock. Without that assignment
+`resolveModel` returns `no-profile-assigned` and the call never leaves the
+app, which looks identical to a mock that isn't running.
+
+Each wizard button gets its own lane and its own shipped default, so a walk
+through all five steps produces a coherent (if fictional) story rather than
+the same paragraph thirteen times. Refine lanes ship a visibly different
+reply from their generate counterpart, so a refine that did nothing is
+obvious.
 
 ## Failure injection
 
@@ -96,7 +126,9 @@ therefore name none of them.
 
 To write a reply that moves a specific entity: run the turn, open the
 request in the log, and use **Open this lane with its placeholders** — the
-roster the prompt actually sent is pinned above the editor.
+roster the prompt actually sent is pinned above the editor. The wizard's
+opening lanes are read the same way, though their prompt spells a roster row
+`- Kael (character, cast id: c1)` rather than `[c1] Kael`.
 
 ## Piggyback
 

--- a/scripts/mock-llm/context.ts
+++ b/scripts/mock-llm/context.ts
@@ -27,22 +27,30 @@ export function createContext(opts: { persist?: boolean } = {}): MockContext {
   }
 }
 
+export type LaneMeta = {
+  key: string
+  title: string
+  kind: 'narrative' | 'registered' | 'unknown'
+  /** Nav section the panel files this lane under. */
+  group: 'narrative' | 'story' | 'wizard' | 'unknown'
+}
+
 /** Lane keys the UI lists: narrative, every registered shape, then discoveries. */
-export function laneCatalog(
-  ctx: MockContext,
-): { key: string; title: string; kind: 'narrative' | 'registered' | 'unknown' }[] {
+export function laneCatalog(ctx: MockContext): LaneMeta[] {
   const registered = STRUCTURED_SHAPES.map((s) => ({
     key: s.name,
     title: s.name,
     kind: 'registered' as const,
+    group: s.group,
   }))
   const unknown = [...ctx.discovered.values()].map((d) => ({
     key: d.key,
     title: d.key,
     kind: 'unknown' as const,
+    group: 'unknown' as const,
   }))
   return [
-    { key: NARRATIVE_LANE, title: 'narrative', kind: 'narrative' as const },
+    { key: NARRATIVE_LANE, title: 'narrative', kind: 'narrative' as const, group: 'narrative' },
     ...registered,
     ...unknown,
   ]

--- a/scripts/mock-llm/log.ts
+++ b/scripts/mock-llm/log.ts
@@ -9,16 +9,25 @@ const PLACEHOLDER_ALTERNATION = Object.values(PLACEHOLDER_PREFIX_BY_KIND)
   .sort((a, b) => b.length - a.length)
   .join('|')
 
-// Prompts list entities as "[c1] Kael" (lib/prompts/bundled/state-emission.ts),
-// which is the only place a canned reply can learn what this run's positional
-// placeholders actually point at — IdBiMap allocates them per run in
-// encounter order, so they mean something different every turn.
-// The label stops at the next `[` as well as at the line end: rosters are
-// normally one entity per line, but a prompt that lists several inline would
-// otherwise fold every later entry into the first one's label.
-const ROSTER_PATTERN = new RegExp(
+// A prompt's roster is the only place a canned reply can learn what this run's
+// positional placeholders actually point at — IdBiMap allocates them per run in
+// encounter order, so they mean something different every turn. The two prompt
+// families spell a roster row differently, so both are scanned.
+
+// "[c1] Kael" (lib/prompts/bundled/state-emission.ts). The label stops at the
+// next `[` as well as at the line end: rosters are normally one entity per
+// line, but a prompt that lists several inline would otherwise fold every later
+// entry into the first one's label.
+const STORY_ROSTER_PATTERN = new RegExp(
   `\\[((?:${PLACEHOLDER_ALTERNATION})\\d+)\\]\\s*([^\\n\\r[]*)`,
   'g',
+)
+
+// "- Kael (character, cast id: c1)" (macro_wizard_opening_context). Anchored to
+// the line, since the description that may follow runs to the end of it.
+const WIZARD_ROSTER_PATTERN = new RegExp(
+  `^-\\s*([^\\n\\r]+?)\\s*\\([a-z]+, cast id: ((?:${PLACEHOLDER_ALTERNATION})\\d+)\\)`,
+  'gm',
 )
 
 export type Placeholder = { ref: string; label: string }
@@ -46,11 +55,12 @@ export type LogEntry = {
 
 export function extractPlaceholders(prompt: string): Placeholder[] {
   const seen = new Map<string, string>()
-  for (const match of prompt.matchAll(ROSTER_PATTERN)) {
-    const [, ref, label] = match
-    if (ref === undefined) continue
-    if (!seen.has(ref)) seen.set(ref, (label ?? '').trim())
+  const take = (ref: string | undefined, label: string | undefined): void => {
+    if (ref === undefined || seen.has(ref)) return
+    seen.set(ref, (label ?? '').trim())
   }
+  for (const [, ref, label] of prompt.matchAll(STORY_ROSTER_PATTERN)) take(ref, label)
+  for (const [, label, ref] of prompt.matchAll(WIZARD_ROSTER_PATTERN)) take(ref, label)
   return [...seen].map(([ref, label]) => ({ ref, label }))
 }
 

--- a/scripts/mock-llm/routing.test.ts
+++ b/scripts/mock-llm/routing.test.ts
@@ -6,9 +6,10 @@ import { schemaToTypeScriptBlock, type JsonSchema } from '@/lib/ai'
 // real one to prove the extractor tracks the template it renders.
 import { promptSchemaMiddleware } from '@/lib/ai/prompt-schema'
 import { fallbackClassifierSchema } from '@/lib/pipeline'
+import { renderTemplate, TEMPLATE_IDS, type TemplateId } from '@/lib/prompts'
 
 import { classifyRequest, extractBlockFromPrompt, matchShape, unknownKey } from './routing'
-import { STRUCTURED_SHAPES } from './shapes'
+import { findShapeByName, STRUCTURED_SHAPES, type StructuredShape } from './shapes'
 
 type MiddlewareParams = {
   prompt: { role: string; content: { type: string; text: string }[] }[]
@@ -20,11 +21,11 @@ type MiddlewareParams = {
  * so a change to SCHEMA_INSTRUCTION_TEMPLATE fails here instead of silently
  * degrading every match at runtime.
  */
-async function promptAsSent(schema: z.ZodType): Promise<string> {
+async function promptAsSent(schema: z.ZodType, text = 'Classify the turn.'): Promise<string> {
   const transform = promptSchemaMiddleware().transformParams
   if (transform === undefined) throw new Error('promptSchemaMiddleware lost transformParams')
   const params: MiddlewareParams = {
-    prompt: [{ role: 'user', content: [{ type: 'text', text: 'Classify the turn.' }] }],
+    prompt: [{ role: 'user', content: [{ type: 'text', text }] }],
     responseFormat: { type: 'json', schema: z.toJSONSchema(schema) as JsonSchema },
   }
   const out = (await transform({
@@ -99,6 +100,85 @@ describe('classifyRequest', () => {
   })
 })
 
+// Every wizard call site, rendered through the app's own prompt pack and its
+// own schema middleware, then routed. This is what holds the derived markers
+// honest: a template whose opening literal moves — or vanishes behind a Liquid
+// tag — stops routing to its own lane here rather than silently serving some
+// sibling's canned reply at runtime.
+describe('wizard call sites', () => {
+  const TEMPLATE_BY_SHAPE: Record<string, TemplateId> = {
+    'wizard-genre': TEMPLATE_IDS.wizardGenre,
+    'wizard-genre-refine': TEMPLATE_IDS.wizardGenreRefine,
+    'wizard-tone': TEMPLATE_IDS.wizardTone,
+    'wizard-tone-refine': TEMPLATE_IDS.wizardToneRefine,
+    'wizard-setting': TEMPLATE_IDS.wizardSetting,
+    'wizard-setting-refine': TEMPLATE_IDS.wizardSettingRefine,
+    'wizard-lore': TEMPLATE_IDS.wizardLore,
+    'wizard-cast': TEMPLATE_IDS.wizardCast,
+    'wizard-opening': TEMPLATE_IDS.wizardOpening,
+    'wizard-opening-refine': TEMPLATE_IDS.wizardOpeningRefine,
+    'wizard-title-chips': TEMPLATE_IDS.wizardTitleChips,
+    'wizard-description': TEMPLATE_IDS.wizardDescription,
+    'wizard-description-refine': TEMPLATE_IDS.wizardDescriptionRefine,
+  }
+
+  // The projection components/wizard/wizard-assist.ts sends, after substituteIds.
+  const WIZARD_CONTEXT = {
+    definition: {
+      mode: 'adventure',
+      setting: 'A city that flooded and stayed.',
+      genre: { label: 'Drowned-city fantasy', promptBody: 'Write drowned-city fantasy.' },
+      tone: { label: 'Wry', promptBody: 'Write wry and elegiac.' },
+    },
+    leadEntityId: 'c1',
+    opening: { content: 'The blade rasps free of its sheath.' },
+    lore: [{ title: 'The ward-work', body: 'Glyph-cut stone under the city.' }],
+    cast: [
+      {
+        id: 'c1',
+        name: 'Kael Ashwater',
+        kind: 'character',
+        status: 'active',
+        description: 'A diver.',
+      },
+      {
+        id: 'l1',
+        name: 'The Drowned Exchange',
+        kind: 'location',
+        status: 'active',
+        description: 'Flooded.',
+      },
+    ],
+    guidance: 'Keep it short.',
+    suggested: ['Bell-speech'],
+    current: {
+      content: 'An earlier draft.',
+      label: 'Wry',
+      promptBody: 'Earlier body.',
+      setting: 'Earlier setting.',
+      description: 'Earlier log line.',
+    },
+    instruction: 'Make it colder.',
+  }
+
+  it('covers every wizard shape in the registry', () => {
+    const registered = STRUCTURED_SHAPES.filter((s) => s.group === 'wizard').map((s) => s.name)
+    expect(Object.keys(TEMPLATE_BY_SHAPE).sort()).toEqual(registered.sort())
+  })
+
+  for (const [name, templateId] of Object.entries(TEMPLATE_BY_SHAPE)) {
+    it(`routes ${name} to its own lane`, async () => {
+      const shape = findShapeByName(name)
+      if (shape === undefined) throw new Error(`registry lost ${name}`)
+
+      const rendered = renderTemplate(templateId, WIZARD_CONTEXT)
+      const route = classifyRequest(requestFrom(await promptAsSent(shape.schema, rendered)))
+
+      expect(route).toMatchObject({ lane: 'structured', key: name })
+    })
+  }
+})
+
 describe('STRUCTURED_SHAPES', () => {
   it('carries the exact block the app renders for each schema', () => {
     for (const shape of STRUCTURED_SHAPES) {
@@ -106,15 +186,34 @@ describe('STRUCTURED_SHAPES', () => {
     }
   })
 
-  it('has no two shapes sharing a block, which would make a match ambiguous', () => {
-    const blocks = STRUCTURED_SHAPES.map((s) => s.block)
-    expect(new Set(blocks).size).toBe(blocks.length)
+  it('separates every shape that shares a block by a distinct, non-empty marker', () => {
+    const byBlock = new Map<string, StructuredShape[]>()
+    for (const shape of STRUCTURED_SHAPES) {
+      byBlock.set(shape.block, [...(byBlock.get(shape.block) ?? []), shape])
+    }
+    for (const [, group] of byBlock) {
+      if (group.length === 1) continue
+      const markers = group.map((s) => s.marker)
+      // An empty marker is the dangerous case, not merely a useless one:
+      // text.includes('') is true, so it would claim every sibling's calls.
+      expect(markers, group.map((s) => s.name).join(', ')).not.toContain('')
+      expect(new Set(markers).size, group.map((s) => s.name).join(', ')).toBe(markers.length)
+    }
+  })
+
+  it('has no marker contained in a sibling marker, which would make the tie-break order-dependent', () => {
+    for (const a of STRUCTURED_SHAPES) {
+      for (const b of STRUCTURED_SHAPES) {
+        if (a.name === b.name || a.block !== b.block) continue
+        expect(b.marker.includes(a.marker), `${a.name}'s marker is inside ${b.name}'s`).toBe(false)
+      }
+    }
   })
 
   it('has no block contained in another, which the substring scan relies on', () => {
     for (const a of STRUCTURED_SHAPES) {
       for (const b of STRUCTURED_SHAPES) {
-        if (a.name === b.name) continue
+        if (a.block === b.block) continue
         expect(b.block.includes(a.block), `${a.name}'s block is inside ${b.name}'s`).toBe(false)
       }
     }
@@ -122,12 +221,15 @@ describe('STRUCTURED_SHAPES', () => {
 })
 
 describe('matchShape', () => {
-  const inner = { name: 'inner', schema: z.unknown(), block: 'interface Response { a: string }' }
-  const outer = {
-    name: 'outer',
+  const shapeStub = (name: string, block: string, marker = ''): StructuredShape => ({
+    name,
+    group: 'story',
     schema: z.unknown(),
-    block: 'interface Response { a: string } & { b: number }',
-  }
+    block,
+    marker,
+  })
+  const inner = shapeStub('inner', 'interface Response { a: string }')
+  const outer = shapeStub('outer', 'interface Response { a: string } & { b: number }')
 
   it('prefers the longer block when one nests inside another', () => {
     const text = `prompt text ${outer.block} trailer`
@@ -139,6 +241,38 @@ describe('matchShape', () => {
 
   it('takes an exact block match ahead of any substring scan', () => {
     expect(matchShape(inner.block, `${outer.block}`, [inner, outer])?.name).toBe('inner')
+  })
+
+  describe('when several call sites share a block', () => {
+    const genre = shapeStub('genre', 'interface Response { label: string }', 'Suggest a genre')
+    const tone = shapeStub('tone', 'interface Response { label: string }', 'Suggest a tone')
+    const pair = [genre, tone]
+
+    it('picks the call site whose marker the prompt carries', () => {
+      expect(
+        matchShape(genre.block, `Suggest a tone for this story. ${tone.block}`, pair)?.name,
+      ).toBe('tone')
+    })
+
+    it('prefers the marker the prompt OPENS with over one quoted deeper in it', () => {
+      // A refine embeds the preview it is revising, and that preview is model
+      // output (or hand-authored, in the dev tool) — it can quote anything,
+      // including a sibling call site's directive.
+      const quoted = `Suggest a tone for this story. ${genre.marker} — that was the instruction. ${genre.block}`
+      expect(matchShape(genre.block, quoted, pair)?.name).toBe('tone')
+      // Registry order alone would have answered 'genre': it is listed first.
+      expect(pair[0]?.name).toBe('genre')
+    })
+
+    it('claims nothing when no marker matches, rather than guessing a sibling', () => {
+      // A user-authored pack can rewrite a wizard template; an unregistered
+      // lane the panel flags is honest, serving genre's reply to tone is not.
+      expect(matchShape(genre.block, `Invent a genre. ${genre.block}`, pair)).toBeNull()
+    })
+
+    it('ignores the marker when the block already identifies one call site', () => {
+      expect(matchShape(genre.block, 'nothing familiar here', [genre])?.name).toBe('genre')
+    })
   })
 
   it('names every shape uniquely — overrides and lane keys both key on the name', () => {

--- a/scripts/mock-llm/routing.ts
+++ b/scripts/mock-llm/routing.ts
@@ -69,21 +69,65 @@ function blockFromResponseFormat(body: Record<string, unknown>): string | null {
  * a schema that is a superset of another still wins — today no registered block
  * contains another (asserted in routing.test.ts), but the scan must not be the
  * thing that breaks on the day one does.
+ */
+function candidatesFor(
+  block: string | null,
+  text: string,
+  shapes: readonly StructuredShape[],
+): readonly StructuredShape[] {
+  if (block !== null) {
+    const exact = shapes.filter((s) => s.block === block)
+    if (exact.length > 0) return exact
+  }
+  const byLength = [...shapes].sort((a, b) => b.block.length - a.block.length)
+  const hit = byLength.find((s) => text.includes(s.block))
+  return hit === undefined ? [] : shapes.filter((s) => s.block === hit.block)
+}
+
+/**
+ * Earliest occurrence wins, not registry order. A marker is the literal its
+ * template OPENS with, so the real one sits at the top of the prompt, while a
+ * sibling's marker can only appear deeper — quoted back inside the `current`
+ * preview a refine embeds. Taking the first candidate that matches anywhere
+ * would let that quotation outrank the directive the call actually carries.
+ */
+function pickByMarker(
+  candidates: readonly StructuredShape[],
+  text: string,
+): StructuredShape | null {
+  let best: StructuredShape | null = null
+  let bestAt = Infinity
+  for (const shape of candidates) {
+    if (shape.marker === '') continue
+    const at = text.indexOf(shape.marker)
+    if (at === -1 || at >= bestAt) continue
+    best = shape
+    bestAt = at
+  }
+  return best
+}
+
+/**
+ * The shape this request answers with, or null when nothing claims it.
  *
- * `shapes` is a parameter so the ordering rule can be tested with a pair that
- * actually nests; production always passes the registry.
+ * A block identifies a SCHEMA, and several call sites can share one (the
+ * wizard's generate/refine pairs, and genre/tone, all answer the same shapes).
+ * Where the block is ambiguous the marker breaks the tie; where it is not, the
+ * marker is not consulted at all, so a user-authored pack that rewrites a
+ * wizard template only costs the calls that genuinely cannot be told apart
+ * without it.
+ *
+ * `shapes` is a parameter so the ordering rules can be tested with pairs that
+ * actually collide; production always passes the registry.
  */
 export function matchShape(
   block: string | null,
   text: string,
   shapes: readonly StructuredShape[] = STRUCTURED_SHAPES,
 ): StructuredShape | null {
-  if (block !== null) {
-    const exact = shapes.find((s) => s.block === block)
-    if (exact) return exact
-  }
-  const byLength = [...shapes].sort((a, b) => b.block.length - a.block.length)
-  return byLength.find((s) => text.includes(s.block)) ?? null
+  const candidates = candidatesFor(block, text, shapes)
+  if (candidates.length <= 1) return candidates[0] ?? null
+  return pickByMarker(candidates, text)
 }
 
 export function unknownKey(block: string | null): string {

--- a/scripts/mock-llm/server.test.ts
+++ b/scripts/mock-llm/server.test.ts
@@ -4,6 +4,8 @@ import { z } from 'zod'
 import { schemaToTypeScriptBlock, type JsonSchema } from '@/lib/ai'
 import { parseStateBlock, parseSuggestionsBlock, stripTrailingBlocks } from '@/lib/piggyback'
 import { fallbackClassifierSchema } from '@/lib/pipeline'
+import { renderTemplate, TEMPLATE_IDS } from '@/lib/prompts'
+import { labeledPromptOutputSchema } from '@/lib/wizard'
 
 import { collectSseContent } from './passthrough'
 import { startMockServer, type MockServer } from './server'
@@ -40,9 +42,9 @@ async function waitForEntry(): Promise<{ outcome: string }> {
 }
 
 /** The prompt the app would send for `schema` on the default (auto) path. */
-function structuredPrompt(schema: z.ZodType): string {
+function structuredPrompt(schema: z.ZodType, text = 'Classify the turn.'): string {
   const block = schemaToTypeScriptBlock(z.toJSONSchema(schema) as JsonSchema)
-  return `Classify the turn.\n\nRespond strictly with JSON. The JSON should be compatible with the TypeScript type Response from the following:\n\n${block}\n\nOutput ONLY the JSON object, no other text or markdown.`
+  return `${text}\n\nRespond strictly with JSON. The JSON should be compatible with the TypeScript type Response from the following:\n\n${block}\n\nOutput ONLY the JSON object, no other text or markdown.`
 }
 
 function structuredRequest(schema: z.ZodType): Record<string, unknown> {
@@ -66,6 +68,27 @@ describe('structured calls', () => {
 
     expect(value.worldTimeDelta).toBe(0)
     expect(value.sceneEntities).toEqual([])
+  })
+
+  it('answers a wizard call on the lane its own template names, with a reply that shape accepts', async () => {
+    const prompt = renderTemplate(TEMPLATE_IDS.wizardTone, {
+      definition: { setting: 'A city that flooded and stayed.', genre: {}, tone: {} },
+      guidance: '',
+    })
+    const response = await post({
+      model: 'seed/narrative',
+      messages: [{ role: 'user', content: structuredPrompt(labeledPromptOutputSchema, prompt) }],
+    })
+
+    const body = (await response.json()) as { choices: { message: { content: string } }[] }
+    const value = labeledPromptOutputSchema.parse(
+      JSON.parse(body.choices[0]?.message.content ?? ''),
+    )
+    expect(value.promptBody).not.toBe('')
+
+    // Genre answers the same schema, so only the marker keeps the two apart.
+    const [entry] = mock.ctx.log.list()
+    expect(entry?.lane).toBe('wizard-tone')
   })
 
   it('answers {} for a shape nobody has configured, and opens a lane for it', async () => {
@@ -238,6 +261,47 @@ describe('catalog and control surface', () => {
       { ref: 'c2', label: 'Mira' },
       { ref: 'lo1', label: 'The Drowning' },
       { ref: 'l1', label: 'The Harbour' },
+    ])
+  })
+
+  it('reads the roster out of a real wizard prompt, whose cast rows are not bracketed', async () => {
+    mock.ctx.log.clear()
+    // The macro itself, not a transcription of it: the extractor has to track
+    // whatever macro_wizard_opening_context actually renders.
+    const prompt = renderTemplate(TEMPLATE_IDS.wizardOpening, {
+      definition: { mode: 'adventure', genre: {}, tone: {} },
+      leadEntityId: 'c1',
+      lore: [],
+      cast: [
+        {
+          id: 'c1',
+          name: 'Kael Ashwater',
+          kind: 'character',
+          status: 'active',
+          description: 'A diver.',
+        },
+        {
+          id: 'l1',
+          name: 'The Drowned Exchange',
+          kind: 'location',
+          status: 'active',
+          description: '',
+        },
+        { id: 'c2', name: 'Verity Sould', kind: 'character', status: 'staged', description: '' },
+      ],
+      guidance: '',
+    })
+    await post({ model: 'seed/narrative', messages: [{ role: 'user', content: prompt }] })
+
+    const entries = (await (await fetch(`${base()}/api/log`)).json()) as {
+      placeholders: { ref: string; label: string }[]
+    }[]
+
+    // Staged rows are filtered out of the prompt by the macro, so the roster
+    // the panel pins is exactly the one the reply may legally reference.
+    expect(entries[0]?.placeholders).toEqual([
+      { ref: 'c1', label: 'Kael Ashwater' },
+      { ref: 'l1', label: 'The Drowned Exchange' },
     ])
   })
 

--- a/scripts/mock-llm/shapes.ts
+++ b/scripts/mock-llm/shapes.ts
@@ -7,6 +7,16 @@ import {
   fallbackClassifierWithSuggestionsSchema,
   suggestionRefreshSchema,
 } from '@/lib/pipeline'
+import { bundledPack, TEMPLATE_IDS, type TemplateId } from '@/lib/prompts'
+import {
+  castSuggestionsSchema,
+  descriptionOutputSchema,
+  labeledPromptOutputSchema,
+  loreSuggestionsSchema,
+  openingOutputSchema,
+  settingOutputSchema,
+  titleChipsSchema,
+} from '@/lib/wizard'
 
 // Shared by the dev mock server and e2e/harness/mock-llm.ts. Deliberately tiny
 // and side-effect free: the E2E suite imports it, so anything heavier here
@@ -14,29 +24,73 @@ import {
 //
 // `block` is the exact string the app renders into a structured prompt for this
 // schema, produced by the app's own renderer over the app's own zod schema — so
-// a match can never drift from what the app actually sends. One entry per reply
-// SHAPE, not per agent: the classifier has three schemas and therefore three
-// entries.
+// a match can never drift from what the app actually sends.
+//
+// One entry per CALL SITE. Where several call sites answer with the same schema
+// — and therefore the same block — `marker` separates them: the literal text a
+// template opens with, before its first Liquid tag, sliced out of the pack the
+// app itself renders. Derived rather than hand-written, so editing a template
+// moves its marker in the same edit. Story shapes are one call site each and
+// carry no marker.
 //
 // Default replies are NOT shared. E2E wants inert no-ops for determinism, the
 // dev mock wants defaults lively enough that a manual turn visibly does
 // something; one list serving both would serve both badly.
 
+export type ShapeGroup = 'story' | 'wizard'
+
 export type StructuredShape = {
   name: string
+  group: ShapeGroup
   schema: z.ZodType
   block: string
+  /** Prompt prefix separating call sites that share a block; '' when unneeded. */
+  marker: string
 }
 
-function shape(name: string, schema: z.ZodType): StructuredShape {
-  return { name, schema, block: schemaToTypeScriptBlock(z.toJSONSchema(schema) as JsonSchema) }
+function blockOf(schema: z.ZodType): string {
+  return schemaToTypeScriptBlock(z.toJSONSchema(schema) as JsonSchema)
+}
+
+const LIQUID_TAG = /\{[{%]/
+
+function markerOf(templateId: TemplateId): string {
+  const source = bundledPack.templates[templateId]?.source ?? ''
+  const tag = source.search(LIQUID_TAG)
+  return (tag === -1 ? source : source.slice(0, tag)).trim()
+}
+
+function storyShape(name: string, schema: z.ZodType): StructuredShape {
+  return { name, group: 'story', schema, block: blockOf(schema), marker: '' }
+}
+
+function wizardShape(name: string, schema: z.ZodType, templateId: TemplateId): StructuredShape {
+  return { name, group: 'wizard', schema, block: blockOf(schema), marker: markerOf(templateId) }
 }
 
 export const STRUCTURED_SHAPES: readonly StructuredShape[] = [
-  shape('per-turn-classifier', fallbackClassifierSchema),
-  shape('per-turn-classifier-suggestions', fallbackClassifierWithSuggestionsSchema),
-  shape('periodic-classifier', classifierExtractionSchema),
-  shape('suggestion-refresh', suggestionRefreshSchema),
+  storyShape('per-turn-classifier', fallbackClassifierSchema),
+  storyShape('per-turn-classifier-suggestions', fallbackClassifierWithSuggestionsSchema),
+  storyShape('periodic-classifier', classifierExtractionSchema),
+  storyShape('suggestion-refresh', suggestionRefreshSchema),
+
+  wizardShape('wizard-genre', labeledPromptOutputSchema, TEMPLATE_IDS.wizardGenre),
+  wizardShape('wizard-genre-refine', labeledPromptOutputSchema, TEMPLATE_IDS.wizardGenreRefine),
+  wizardShape('wizard-tone', labeledPromptOutputSchema, TEMPLATE_IDS.wizardTone),
+  wizardShape('wizard-tone-refine', labeledPromptOutputSchema, TEMPLATE_IDS.wizardToneRefine),
+  wizardShape('wizard-setting', settingOutputSchema, TEMPLATE_IDS.wizardSetting),
+  wizardShape('wizard-setting-refine', settingOutputSchema, TEMPLATE_IDS.wizardSettingRefine),
+  wizardShape('wizard-lore', loreSuggestionsSchema, TEMPLATE_IDS.wizardLore),
+  wizardShape('wizard-cast', castSuggestionsSchema, TEMPLATE_IDS.wizardCast),
+  wizardShape('wizard-opening', openingOutputSchema, TEMPLATE_IDS.wizardOpening),
+  wizardShape('wizard-opening-refine', openingOutputSchema, TEMPLATE_IDS.wizardOpeningRefine),
+  wizardShape('wizard-title-chips', titleChipsSchema, TEMPLATE_IDS.wizardTitleChips),
+  wizardShape('wizard-description', descriptionOutputSchema, TEMPLATE_IDS.wizardDescription),
+  wizardShape(
+    'wizard-description-refine',
+    descriptionOutputSchema,
+    TEMPLATE_IDS.wizardDescriptionRefine,
+  ),
 ]
 
 export function findShapeByName(name: string): StructuredShape | undefined {

--- a/scripts/mock-llm/state.test.ts
+++ b/scripts/mock-llm/state.test.ts
@@ -102,6 +102,15 @@ describe('shipped defaults', () => {
     )
   })
 
+  it('ships at least one reply per lane, since an unconfigured lane answers {}', () => {
+    // {} parses for a schema whose fields all default, and fails every schema
+    // that requires one — so a lane shipped empty is a wizard step that errors
+    // on first use rather than a lane that quietly does nothing.
+    for (const [key, lane] of Object.entries(defaultState().lanes)) {
+      expect(lane.responses.length, key).toBeGreaterThan(0)
+    }
+  })
+
   it('ships only responses their own lane schema accepts', () => {
     for (const [key, lane] of Object.entries(defaultState().lanes)) {
       for (const response of lane.responses) {

--- a/scripts/mock-llm/state.ts
+++ b/scripts/mock-llm/state.ts
@@ -165,9 +165,193 @@ function defaultLanes(): Record<string, Lane> {
     // A refresh that resolves nothing is a run failure, so the default is not
     // the empty list the other lanes use.
     'suggestion-refresh': lane([canned('Three chips', { suggestions: SAMPLE_SUGGESTIONS })]),
+
+    ...wizardLanes(),
   }
 
   return lanes
+}
+
+const DROWNED_CITY_GENRE = [
+  'Write drowned-city fantasy: a world where the water came and stayed, and people built upward rather than leaving. Magic is old infrastructure — half-understood, still running, and expensive to touch.',
+  '',
+  'Keep the fantastic domestic. A ward that keeps a doorway dry is worth more than a prophecy, and characters argue about who pays for it. Name the trades, the tolls and the tide tables; let wonder arrive through what people do for a living.',
+].join('\n')
+
+const DROWNED_CITY_TONE = [
+  'Write in a wry, elegiac register. The narration has seen worse and says so plainly; grief arrives sideways, in an inventory or a joke, rather than in a declaration.',
+  '',
+  'Favour short declaratives at the moment of action and longer, looser sentences either side of it. Cut adverbs, cut weather-as-mood unless the weather is doing something. Let a scene end one beat before the reader expects it to.',
+].join('\n')
+
+const DROWNED_CITY_SETTING =
+  'Vessel was a river port before the sea reached inland and made it an archipelago of its own rooftops. Two centuries on, the lower streets are shipping lanes, the guild halls have docks where their front steps used to be, and the tide is a municipal department.\n\nWhat kept the city alive was the ward-work in its foundations, laid by engineers nobody can now name. It still holds. Nobody knows for how long, and the people who ask loudest are the ones who have read the maintenance ledgers.'
+
+const OPENING_PROSE =
+  'The blade rasps free of its sheath. Somewhere in the drowned city a bell answers, and the rain leans closer to listen.\n\nYou come down the stair with one hand on the rail. The step gives underfoot, soft as bread, and below you something moves that is not the current.'
+
+const OPENING_PROSE_REFINED =
+  'The blade comes free without a sound — you have had practice — and the bell answers anyway, somewhere east, muffled by rain.\n\nThe stair takes your weight in the grudging way rotted wood does. Two steps from the bottom the water starts. Something in it moves against the current, unhurried, as though it has all evening.'
+
+// sceneEntities and currentLocationId stay empty for the same reason the
+// classifier defaults write nothing: IdBiMap allocates c1/l1 per run in
+// prompt-encounter order, so a shipped default cannot know what they point at.
+// The request log's "Open this lane with its placeholders" is how a reply that
+// tags a specific entity gets written.
+function opening(prose: string): Record<string, unknown> {
+  return { prose, sceneEntities: [], currentLocationId: null, worldTime: 0 }
+}
+
+function labeled(label: string, promptBody: string): Record<string, unknown> {
+  return { label, promptBody }
+}
+
+function wizardLanes(): Record<string, Lane> {
+  return {
+    'wizard-genre': lane([
+      canned('Drowned-city fantasy', labeled('Drowned-city fantasy', DROWNED_CITY_GENRE)),
+    ]),
+    'wizard-genre-refine': lane([
+      canned(
+        'Drowned-city fantasy, grimmer',
+        labeled(
+          'Drowned-city salvage fantasy',
+          `${DROWNED_CITY_GENRE}\n\nThe salvage trade is the spine of it. Everything of value was somebody's before the water, and the law about that is unsettled enough to be worth killing over.`,
+        ),
+      ),
+    ]),
+
+    'wizard-tone': lane([canned('Wry and elegiac', labeled('Wry and elegiac', DROWNED_CITY_TONE))]),
+    'wizard-tone-refine': lane([
+      canned(
+        'Wry and elegiac, drier',
+        labeled(
+          'Dry and elegiac',
+          `${DROWNED_CITY_TONE}\n\nPull the sentiment back another notch. Where a line could be either bitter or fond, write it fond and let the context supply the bitterness.`,
+        ),
+      ),
+    ]),
+
+    'wizard-setting': lane([canned('Vessel', { setting: DROWNED_CITY_SETTING })]),
+    'wizard-setting-refine': lane([
+      canned('Vessel, with the tide court', {
+        setting: `${DROWNED_CITY_SETTING}\n\nAuthority sits with the Tide Court, which meets at low water and adjourns when the stairs go under. Its writ runs exactly as far as the ward-work does, which is a matter of ongoing and occasionally violent dispute.`,
+      }),
+    ]),
+
+    'wizard-lore': lane([
+      canned('Five entries', {
+        lore: [
+          {
+            title: 'The ward-work',
+            body: 'The lattice of glyph-cut stone under Vessel that keeps the lower city dry enough to walk through at low water. Laid before the flood by engineers whose guild no longer exists. It is repaired, never extended: nobody living can cut a new line that holds.',
+            category: 'cosmology',
+          },
+          {
+            title: 'Tide Court',
+            body: 'Vessel\u2019s governing body, so named because it sits only between the tides. A session that runs long is adjourned by the water itself, which is considered a feature — long deliberations are held to be a sign of a bad question.',
+            category: 'history',
+          },
+          {
+            title: 'Salvage right',
+            body: 'The claim a diver holds over what they bring up from a drowned floor. It lapses at sunset, which is why the salvage quarter is loudest at dusk and empty by full dark.',
+            category: 'law',
+          },
+          {
+            title: 'Bell-speech',
+            body: 'The rooftop bells carry a working vocabulary of about forty phrases — tide, fire, writ, sail, plague. Children learn it before they learn to read. Two bells answering each other means something is moving that should not be.',
+            category: 'terminology',
+          },
+          {
+            title: 'The Quiet Year',
+            body: 'The twelve months after the flood when no bell was rung, by agreement, because there was nothing left to warn anyone about. Dating in Vessel still runs from its end rather than from the flood.',
+            category: 'history',
+          },
+        ],
+      }),
+    ]),
+
+    'wizard-cast': lane([
+      canned('Five entries, mixed kinds', {
+        entities: [
+          {
+            kind: 'character',
+            name: 'Kael Ashwater',
+            description:
+              'A salvage diver working the guild floors below the old exchange. Careful, underpaid, and the only person still keeping a written record of which wards have failed.',
+            status: 'active',
+            speech: 'clipped, understated',
+            traits: ['methodical', 'stubborn', 'good in cold water'],
+            drives: ['finish the survey', 'avoid owing the Tide Court a favour'],
+            faction_name: 'The Salvagers\u2019 Table',
+          },
+          {
+            kind: 'character',
+            name: 'Verity Sould',
+            description:
+              'A ward-keeper who inherited the maintenance ledgers and has read them all the way through, which is more than her predecessors managed.',
+            status: 'staged',
+            speech: 'formal, over-precise',
+            traits: ['exacting', 'privately frightened'],
+            drives: ['keep the lattice running', 'be believed'],
+          },
+          {
+            kind: 'location',
+            name: 'The Drowned Exchange',
+            description:
+              'Vessel\u2019s old trading hall, now three storeys under at high water. Its upper gallery is dry, rented out, and reachable only by rope bridge.',
+            status: 'active',
+            condition: 'flooded to the second gallery',
+          },
+          {
+            kind: 'item',
+            name: 'The survey ledger',
+            description:
+              'A wax-bound book of ward readings going back forty years, in four hands. Worth more than the building it is kept in.',
+            status: 'active',
+            condition: 'water-stained, legible',
+          },
+          {
+            kind: 'faction',
+            name: 'The Salvagers\u2019 Table',
+            description:
+              'The loose association of divers who work the drowned quarters. No charter, no dues, and an absolute rule about not diving another crew\u2019s floor.',
+            status: 'active',
+            agenda: ['keep salvage right lapsing at sunset', 'stay out of the Tide Court'],
+            standing: 'tolerated, not represented',
+          },
+        ],
+      }),
+    ]),
+
+    'wizard-opening': lane([canned('Short beat', opening(OPENING_PROSE))]),
+    'wizard-opening-refine': lane([canned('Colder, slower', opening(OPENING_PROSE_REFINED))]),
+
+    'wizard-title-chips': lane([
+      canned('Five titles', {
+        titles: [
+          'The Quiet Year',
+          'Bell-Speech',
+          'What the Water Kept',
+          'Salvage Right',
+          'The Tide Court',
+        ],
+      }),
+    ]),
+
+    'wizard-description': lane([
+      canned('Log line', {
+        description:
+          'A salvage diver in a half-drowned city finds the ward-work failing faster than anyone is willing to admit.',
+      }),
+    ]),
+    'wizard-description-refine': lane([
+      canned('Log line, sharper', {
+        description:
+          'A salvage diver discovers the wards holding her city above water are failing, and that the people who could fix them would rather not know.',
+      }),
+    ]),
+  }
 }
 
 export function defaultState(): MockState {

--- a/scripts/mock-llm/ui/index.html
+++ b/scripts/mock-llm/ui/index.html
@@ -122,6 +122,33 @@
         background: var(--panel-2);
         box-shadow: inset 3px 0 0 var(--accent);
       }
+      .group-btn {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        width: 100%;
+        border: 0;
+        border-radius: 0;
+        border-bottom: 1px solid var(--line);
+        background: var(--panel-2);
+        padding: 7px 12px;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--dim);
+      }
+      .group-btn:hover {
+        color: var(--text);
+      }
+      .group-btn .chev {
+        font-size: 9px;
+        width: 8px;
+      }
+      .group-count {
+        margin-left: auto;
+        font-family: var(--mono);
+        letter-spacing: 0;
+      }
       .lane-badges {
         display: flex;
         gap: 4px;
@@ -368,6 +395,42 @@
         structured: ['none', 'http', 'malformed', 'hang'],
       }
 
+      // Nav sections, in display order; `id` matches laneCatalog's group.
+      const GROUPS = [
+        { id: 'narrative', label: 'Narrative' },
+        { id: 'story', label: 'Story' },
+        { id: 'wizard', label: 'Wizard' },
+        { id: 'unknown', label: 'Unregistered' },
+      ]
+      const COLLAPSED_KEY = 'mock-llm.collapsed-groups'
+
+      const collapsed = new Set(
+        (() => {
+          try {
+            return JSON.parse(localStorage.getItem(COLLAPSED_KEY)) ?? []
+          } catch {
+            return []
+          }
+        })(),
+      )
+
+      function setCollapsed(id, value) {
+        if (value) collapsed.add(id)
+        else collapsed.delete(id)
+        try {
+          localStorage.setItem(COLLAPSED_KEY, JSON.stringify([...collapsed]))
+        } catch {
+          // Private-mode storage refusal costs the memory of the toggle, not the toggle.
+        }
+      }
+
+      // Selection can move without a click on the lane list (the log's "open
+      // this lane" jumps), and a highlight inside a collapsed group is invisible.
+      function revealSelected() {
+        const group = snap?.lanes.find((meta) => meta.key === selected)?.group
+        if (group !== undefined) setCollapsed(group, false)
+      }
+
       let snap = null
       let selected = 'narrative'
       let log = []
@@ -409,23 +472,40 @@
 
       // ---------- lane list ----------
 
+      function laneButton(meta) {
+        const l = meta.lane
+        const badges = [
+          l.mode === 'passthrough' ? '<span class="badge warn">passthrough</span>' : '',
+          l.failure.kind !== 'none' && l.failure.remaining !== 0
+            ? `<span class="badge bad">${esc(l.failure.kind)}</span>`
+            : '',
+          l.sequence.enabled ? '<span class="badge on">seq</span>' : '',
+          l.delay.ttfbMs > 0 ? `<span class="badge">${esc(l.delay.ttfbMs)}ms</span>` : '',
+          meta.kind === 'unknown' ? '<span class="badge bad">unregistered</span>' : '',
+        ].join('')
+        return `<button class="lane-btn" data-lane="${esc(meta.key)}" aria-current="${meta.key === selected}">
+          ${esc(meta.title)}
+          <div class="lane-badges">${badges}</div>
+        </button>`
+      }
+
       function renderLanes() {
-        $('lanes').innerHTML = snap.lanes
-          .map((meta) => {
-            const l = meta.lane
-            const badges = [
-              l.mode === 'passthrough' ? '<span class="badge warn">passthrough</span>' : '',
-              l.failure.kind !== 'none' && l.failure.remaining !== 0
-                ? `<span class="badge bad">${esc(l.failure.kind)}</span>`
-                : '',
-              l.sequence.enabled ? '<span class="badge on">seq</span>' : '',
-              l.delay.ttfbMs > 0 ? `<span class="badge">${esc(l.delay.ttfbMs)}ms</span>` : '',
-              meta.kind === 'unknown' ? '<span class="badge bad">unregistered</span>' : '',
-            ].join('')
-            return `<button class="lane-btn" data-lane="${esc(meta.key)}" aria-current="${meta.key === selected}">
-              ${esc(meta.title)}
-              <div class="lane-badges">${badges}</div>
-            </button>`
+        const sections = GROUPS.map((group) => ({
+          ...group,
+          lanes: snap.lanes.filter((meta) => meta.group === group.id),
+        })).filter((section) => section.lanes.length > 0)
+
+        $('lanes').innerHTML = sections
+          .map((section) => {
+            if (section.id === 'narrative') return section.lanes.map(laneButton).join('')
+            const open = !collapsed.has(section.id)
+            return `<div class="lane-group">
+              <button class="group-btn" data-group="${esc(section.id)}" aria-expanded="${open}">
+                <span class="chev">${open ? '▾' : '▸'}</span>${esc(section.label)}
+                <span class="group-count">${section.lanes.length}</span>
+              </button>
+              ${open ? section.lanes.map(laneButton).join('') : ''}
+            </div>`
           })
           .join('')
       }
@@ -661,11 +741,15 @@
 
       document.addEventListener('click', async (event) => {
         const t = event.target.closest(
-          '[data-lane],[data-bulk],[data-cps],[data-activate],[data-delete],[data-entry],[data-save-entry],[data-goto],[data-copy],#reset,#addResponse,#save,#rename,#seqReset',
+          '[data-lane],[data-group],[data-bulk],[data-cps],[data-activate],[data-delete],[data-entry],[data-save-entry],[data-goto],[data-copy],#reset,#addResponse,#save,#rename,#seqReset',
         )
         if (!t) return
 
         try {
+          if (t.dataset.group) {
+            setCollapsed(t.dataset.group, !collapsed.has(t.dataset.group))
+            return renderLanes()
+          }
           if (t.dataset.lane) {
             selected = t.dataset.lane
             laneError = ''
@@ -738,12 +822,14 @@
             })
             const entry = log.find((e) => e.id === t.dataset.saveEntry)
             selected = entry?.lane ?? selected
+            revealSelected()
             laneError = ''
             return render()
           }
           if (t.dataset.goto) {
             selected = t.dataset.goto
             pinned = log.find((e) => e.id === t.dataset.entryPh)?.placeholders ?? null
+            revealSelected()
             laneError = ''
             return render()
           }

--- a/scripts/mock-llm/ui/index.html
+++ b/scripts/mock-llm/ui/index.html
@@ -407,7 +407,10 @@
       const collapsed = new Set(
         (() => {
           try {
-            return JSON.parse(localStorage.getItem(COLLAPSED_KEY)) ?? []
+            // Anything but an array feeds `new Set` a non-iterable and throws at
+            // top level, which would cost the whole panel, not just the memory.
+            const stored = JSON.parse(localStorage.getItem(COLLAPSED_KEY))
+            return Array.isArray(stored) ? stored : []
           } catch {
             return []
           }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mock support for story-creation wizard flows, including genre, tone, setting, lore, cast, opening, title, and description responses.
  * Added refined response variants and placeholder roster support for wizard interactions.
  * Organized mock lanes into narrative, story, wizard, and unregistered groups with counts and collapsible navigation.
  * Collapse preferences persist between sessions, and relevant groups automatically expand when navigating or saving responses.

* **Bug Fixes**
  * Improved response matching when multiple prompts share the same structure, providing more accurate results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->